### PR TITLE
docs: add AGENTS.md with contributor conventions and CLAUDE.md redirect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md — agentctl contributor conventions
+
+Guidance for AI coding agents (and humans using them) working in this repository.
+
+## Workflow
+
+- **No direct commits.** All changes must go through a pull request.
+- **Test-Driven Development.** Write a failing test before writing implementation code.
+- **Report test results.** After every `go test ./...` run, include the full output in your response.
+- **Report ShellCheck results.** After any change to `agents/*.sh`, run `shellcheck agents/*.sh` and include the output.
+
+## Project shape
+
+```
+cmd/agentctl/     ← Go CLI entry point (cobra); one file: main.go
+internal/
+  cmd/            ← subcommand implementations + tests
+  git/            ← git worktree operations + tests
+  process/        ← process management + tests
+  state/          ← .agent metadata read/write + tests
+agents/
+  claude.sh       ← Claude Code adapter
+  codex.sh        ← OpenAI Codex CLI adapter
+  copilot.sh      ← GitHub Copilot adapter (stub)
+docs/
+  build.md        ← build, test, cross-compile, release instructions
+  development.md  ← full CLI reference, adapter contract, worktree layout
+```
+
+**The `agentctl` binary must live next to the `agents/` directory.** The executable's directory is used at runtime to resolve adapter paths; `go build -o agentctl ./cmd/agentctl` from the repo root satisfies this.
+
+## Build & test
+
+```bash
+go build ./...                        # verify compilation
+go build -o agentctl ./cmd/agentctl   # produce the binary
+go test ./...                         # unit tests
+go vet ./...                          # static analysis
+shellcheck agents/claude.sh agents/codex.sh agents/copilot.sh
+```
+
+CI runs all of the above on every push and pull request (`.github/workflows/go.yml`, `.github/workflows/shellcheck.yml`). Fix the root cause of any failure; do not suppress ShellCheck warnings with inline directives.
+
+## Constraints
+
+- **No direct commits.** PRs only (see Workflow above).
+- **Adapter interface is stable.** Each `agents/<name>.sh` must export exactly `agent_launch`, `agent_resume`, and `agent_pause_state`. Signatures are in `docs/development.md`. Do not rename or remove parameters.
+- **Co-location contract.** Do not move `agentctl` or `agents/` independently; adapter resolution is path-based.
+- **Spec artefact paths.** Pause-state logic depends on `specs/<issue>-*/spec.md`, `plan.md`, `tasks.md`. Changing these paths requires updating all three adapters and `internal/state` in the same PR.
+- **No new top-level commands** without a corresponding issue and discussion.
+- **No new external Go dependencies** without explicit justification; add via `go get`.
+- **No new adapter stubs** unless the agent CLI has a stable non-interactive launch mechanism (see [#16](https://github.com/arun-gupta/agentctl/issues/16)).
+- **Do not bump the Go toolchain version** incidentally while fixing something else.
+
+## PR hygiene
+
+- One logical change per PR; no unrelated cleanups.
+- `gofmt`-formatted Go, ShellCheck-clean Bash, consistent flag and variable naming.
+- Conventional commit prefixes: `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`.
+- PR titles ≤ 72 characters.
+
+## Security & secrets
+
+- Never commit tokens, API keys, or credentials.
+- Adapters must not hard-code credentials; rely on environment variables (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.).
+- Document any new required environment variable in `docs/development.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md) for all project conventions, workflow rules, and contributor guidance.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **agentctl** is a **Go** CLI for provisioning isolated [git worktrees](https://git-scm.com/docs/git-worktree) per GitHub issue and launching a coding agent inside each one. It supports multiple agent back-ends via Bash adapter scripts under `agents/` (sourced at runtime). By default it follows **spec-driven development (SDD)**: a spec is produced and reviewed before the agent carries out the full implementation plan.
 
-Migrated from [arun-gupta/repo-pulse](https://github.com/arun-gupta/repo-pulse) with full commit history preserved.
+Migrated from [arun-gupta/repo-pulse](https://github.com/arun-gupta/repo-pulse) with full commit history preserved. See [AGENTS.md](AGENTS.md) for AI agent and contributor conventions.
 
 ## Spec-driven development and SpecKit
 


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` at the repo root: project shape, build/test commands, workflow rules (no direct commits, TDD, test reporting), constraints, PR hygiene, and security guidance
- Adds `CLAUDE.md` as a one-liner redirect to `AGENTS.md` — single source of truth, no duplication
- Updates `README.md` with a link to `AGENTS.md`

## Test plan

- [x] Verify `AGENTS.md` renders correctly on GitHub
- [x] Verify `CLAUDE.md` link to `AGENTS.md` resolves
- [x] Verify `README.md` link to `AGENTS.md` resolves

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)