### PR TITLE
docs: slim README; add install and spec-driven guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,31 @@
 # agentctl
 
-**agentctl** is a **Go** CLI for provisioning isolated [git worktrees](https://git-scm.com/docs/git-worktree) per GitHub issue and launching a coding agent inside each one. It supports multiple agent back-ends via Bash adapter scripts under `agents/` (sourced at runtime). By default it follows **spec-driven development (SDD)**: a spec is produced and reviewed before the agent carries out the full implementation plan.
-
-Migrated from [arun-gupta/repo-pulse](https://github.com/arun-gupta/repo-pulse) with full commit history preserved. See [AGENTS.md](AGENTS.md) for AI agent and contributor conventions.
-
-## Spec-driven development and SpecKit
-
-Today’s default workflow is **SDD with a human checkpoint**: the agent runs **Stage 1** (write a spec), stops for your approval or revision (`approve-spec` / `revise-spec` when headless), then **Stage 2** (plan, tasks, implement) and opens a PR. That flow is **implemented in terms of [Spec Kit](https://github.com/github/spec-kit)**—the kickoff tells the agent to use `/speckit.specify`, `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement`, and `agentctl` infers pause state from files under `specs/` (for example `spec.md` vs `plan.md` / `tasks.md`).
-
-**agentctl does not install or vendor Spec Kit.** The **target repository** (and your agent setup, e.g. Claude Code slash commands) must already support that SpecKit-style lifecycle. If your repo is not set up for it, use **`--no-speckit`** on `spawn` so the agent skips that lifecycle and works straight toward a PR with no spec-review pause.
-
-## Repository layout
-
-```
-cmd/agentctl/     ← Go CLI (cobra)
-internal/         ← git, process, state, commands
-agents/
-  claude.sh       ← Claude Code adapter
-  codex.sh        ← OpenAI Codex CLI adapter
-  copilot.sh      ← GitHub Copilot adapter (stub — not yet implemented)
-```
-
-The **`agentctl` binary must live in the same directory as the `agents/` folder** (the executable’s directory is used to resolve adapter paths). A normal clone + `go build` from repo root satisfies that.
-
-## Prerequisites
-
-| Requirement | Purpose |
-|-------------|---------|
-| `git` ≥ 2.5 | worktree support |
-| `bash` | agent adapters are sourced and run via Bash |
-| `gh` CLI | PR management (`cleanup-merged`, `status`), slug-from-title |
-| `claude` CLI | required when using the `claude` adapter (default) |
-| `codex` CLI | required when using the `codex` adapter (`npm install -g @openai/codex`) |
-| SpecKit (or equivalent) in the **target repo** | Needed for the default SDD flow (see above). `agentctl` does not install or verify it. Use `--no-speckit` when the repo is not set up for that workflow. |
-| GitHub Copilot CLI (`gh copilot`) | optional; intended for the `copilot` adapter (stub until non-interactive launch/resume exists) |
-| Go | only if you build from source (see `go.mod` for the toolchain version) |
-
-## Installation
-
-### Build from clone (recommended)
-
-```bash
-git clone https://github.com/arun-gupta/agentctl
-cd agentctl
-go build -o agentctl ./cmd/agentctl
-# Run from this directory so ./agents/ sits next to ./agentctl
-./agentctl --help
-```
-
-To install elsewhere, keep **`agentctl` and `agents/` in the same directory** (for example copy both into `/opt/agentctl/` and put that directory on your `PATH`, or run from the clone as above).
-
-### Prebuilt binaries
-
-Publishing **Go** snapshot binaries per commit and documenting install from **GitHub Releases** is tracked in **[#13](https://github.com/arun-gupta/agentctl/issues/13)**. Homebrew is tracked in **[#14](https://github.com/arun-gupta/agentctl/issues/14)**.
-
-Tagged **GitHub Releases** attach archives that contain **`agentctl` plus `agents/`**; extract and add that folder to your `PATH`. Vendoring the repo (e.g. git subtree) is described in **[docs/development.md](docs/development.md)**.
+**agentctl** is a **Go** CLI that creates a [git worktree](https://git-scm.com/docs/git-worktree) per GitHub issue and launches a coding agent there, using Bash adapters in `agents/`.
 
 ## Quick start
 
-Run these from your **application** repository (the primary worktree), with `agentctl` on your `PATH` or invoked by full path.
+Build from a clone, then run commands from your **application** repository (the primary git worktree):
 
 ```bash
-# Spawn a worktree for issue #42 and open Claude interactively
+git clone https://github.com/arun-gupta/agentctl && cd agentctl
+go build -o agentctl ./cmd/agentctl
+export PATH="$(pwd):$PATH"   # keep agentctl next to ./agents/
+
+cd /path/to/your/app-repo
 agentctl spawn 42
-
-# Run headless (background) with a custom slug
-agentctl spawn --headless --agent claude 42 my-feature
-
-# Approve the spec and resume the agent
-agentctl approve-spec 42
-
-# Clean up after the PR is merged
+agentctl approve-spec 42       # headless: after you review the spec
 agentctl cleanup-merged 42
 ```
 
-Run `agentctl --help` and `agentctl <command> --help` for options.
+`agentctl --help` and `agentctl <command> --help` list all flags.
 
-For batch workflows, the adapter contract, worktree layout, and local ShellCheck, see **[docs/development.md](docs/development.md)**.
+## Documentation
+
+- **[docs/install.md](docs/install.md)** — prerequisites, layout, install paths, releases  
+- **[docs/spec-driven.md](docs/spec-driven.md)** — SDD, Spec Kit, `--no-speckit`  
+- **[docs/development.md](docs/development.md)** — CLI reference, batches, adapters, worktrees, CI  
+- **[docs/build.md](docs/build.md)** — contributor build, test, coverage  
+- **[AGENTS.md](AGENTS.md)** — conventions for AI agents working in this repo  
 
 ## License
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development
 
-Contributor-oriented notes: full CLI reference, workflows, adapters, layout, install variants, and CI. For **SDD and Spec Kit** behavior, see [spec-driven.md](spec-driven.md).
+Contributor-oriented notes: full CLI reference, workflows, adapters, layout, and CI. For **install and prerequisites**, see [install.md](install.md). For **SDD and Spec Kit**, see [spec-driven.md](spec-driven.md).
 
 ## Usage
 
@@ -139,34 +139,9 @@ agent.log       ← agent stdout/stderr (headless mode)
 specs/          ← SpecKit artefacts (spec.md, plan.md, tasks.md)
 ```
 
-## Install instructions
+## Install
 
-### Option A — Go binary from clone (recommended)
-
-```bash
-git clone https://github.com/arun-gupta/agentctl
-cd agentctl
-go build -o agentctl ./cmd/agentctl
-# Keep agentctl and agents/ in the same directory (see README).
-```
-
-### Option B — symlink the built binary (agents stay in the clone)
-
-```bash
-git clone https://github.com/arun-gupta/agentctl ~/.local/share/agentctl
-cd ~/.local/share/agentctl && go build -o agentctl ./cmd/agentctl
-ln -sf ~/.local/share/agentctl/agentctl ~/.local/bin/agentctl
-# Adapters resolve from the real path of the agentctl binary (~/.local/share/agentctl/agents/).
-```
-
-### Option C — git subtree
-
-```bash
-git subtree add --prefix agentctl \
-  https://github.com/arun-gupta/agentctl main --squash
-```
-
-Then `cd agentctl && go build -o agentctl ./cmd/agentctl` (or use a **GitHub Release** archive that already contains `agentctl` + `agents/`).
+See **[install.md](install.md)** for prerequisites, layout, clone/symlink/subtree installs, and release archives.
 
 ## Testing strategy
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,76 @@
+# Install and layout
+
+How to install **agentctl**, what you need on your machine, and how files are arranged.
+
+## Repository layout
+
+```
+cmd/agentctl/     ← Go CLI (cobra)
+internal/         ← git, process, state, commands
+agents/
+  claude.sh       ← Claude Code adapter
+  codex.sh        ← OpenAI Codex CLI adapter
+  copilot.sh      ← GitHub Copilot adapter (stub)
+```
+
+The **`agentctl` binary must live in the same directory as the `agents/` folder** (the executable’s directory is used to resolve adapter paths). Building from a clone at repo root keeps `./agentctl` next to `./agents/`.
+
+## Prerequisites
+
+| Requirement | Purpose |
+|-------------|---------|
+| `git` ≥ 2.5 | worktree support |
+| `bash` | adapters are sourced and run via Bash |
+| `gh` CLI | PR management (`cleanup-merged`, `status`), slug-from-title |
+| `claude` CLI | required for the `claude` adapter (default) |
+| `codex` CLI | required for the `codex` adapter (`npm install -g @openai/codex`) |
+| Spec Kit in the **target app repo** | default SDD flow; see [spec-driven.md](spec-driven.md). Use `spawn --no-speckit` if not set up |
+| `gh copilot` | optional; for the `copilot` adapter (stub) |
+| Go | only to build from source (see `go.mod`) |
+
+## Install from source (clone)
+
+```bash
+git clone https://github.com/arun-gupta/agentctl
+cd agentctl
+go build -o agentctl ./cmd/agentctl
+# Run ./agentctl from this directory, or add this directory to PATH
+./agentctl --help
+```
+
+To install elsewhere, copy **`agentctl` and `agents/`** into the same directory (for example `/opt/agentctl/`) and put that directory on your `PATH`.
+
+### Symlink only the binary
+
+Agents resolve from the **real path** of the executable:
+
+```bash
+git clone https://github.com/arun-gupta/agentctl ~/.local/share/agentctl
+cd ~/.local/share/agentctl && go build -o agentctl ./cmd/agentctl
+ln -sf ~/.local/share/agentctl/agentctl ~/.local/bin/agentctl
+# Adapters: ~/.local/share/agentctl/agents/
+```
+
+### Git subtree
+
+```bash
+git subtree add --prefix agentctl \
+  https://github.com/arun-gupta/agentctl main --squash
+```
+
+Then `cd agentctl && go build -o agentctl ./cmd/agentctl`, or unpack a **GitHub Release** archive that already contains `agentctl` + `agents/`.
+
+## Prebuilt binaries
+
+- Per-commit / release automation: [#13](https://github.com/arun-gupta/agentctl/issues/13)
+- Homebrew: [#14](https://github.com/arun-gupta/agentctl/issues/14)
+
+Tagged **GitHub Releases** ship archives with **`agentctl` plus `agents/`**; extract the folder and add it to your `PATH`.
+
+## Contributor builds
+
+For `go build ./...`, tests, and coverage, see **[build.md](build.md)**.
+
+## Provenance
+
+Migrated from [arun-gupta/repo-pulse](https://github.com/arun-gupta/repo-pulse) with preserved history.

--- a/docs/spec-driven.md
+++ b/docs/spec-driven.md
@@ -1,0 +1,21 @@
+# Spec-driven development and Spec Kit
+
+## Default workflow (SDD)
+
+By default, **agentctl** assumes **spec-driven development** with a **human checkpoint**:
+
+1. **Stage 1** — The agent writes a spec, then stops for your approval or revision. In headless mode use `agentctl approve-spec` and `agentctl revise-spec`.
+2. **Stage 2** — After approval, the agent runs planning and implementation tasks, then pushes and opens a PR.
+
+That flow is implemented in terms of [**Spec Kit**](https://github.com/github/spec-kit): the kickoff instructs the agent to run `/speckit.specify`, `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement`. **Pause state** is inferred from files under `specs/` in the worktree (for example `spec.md` vs `plan.md` / `tasks.md`).
+
+## What you must provide
+
+**agentctl does not install or vendor Spec Kit.** The **target application repository** (and your coding-agent setup, e.g. Claude Code slash commands) must already support that Spec Kit–style lifecycle.
+
+If the repo is not set up for it, use **`agentctl spawn --no-speckit`** so the agent skips the spec lifecycle and works straight toward a PR with no spec-review pause.
+
+## Related
+
+- [install.md](install.md) — prerequisites and installing `agentctl`
+- [development.md](development.md) — CLI usage, batch flows, adapters, worktree layout


### PR DESCRIPTION
## Summary

- **README**: short tagline, **Quick start** first (`go build` + example commands), **Documentation** index only.
- **`docs/install.md`**: prerequisites, repo layout, install options (clone, symlink, subtree), releases (#13 / #14), contributor pointer to `build.md`, provenance.
- **`docs/spec-driven.md`**: SDD + Spec Kit detail (moved out of README).
- **`docs/development.md`**: links to install/spec-driven; install section replaced with pointer to `install.md`.

## Test plan

- [x] Markdown renders sensibly on GitHub (links, tables).
- [x] No broken internal links between `README` and `docs/*.md`.

Made with [Cursor](https://cursor.com)