### PR TITLE
test: expand coverage, update docs, and add release instructions

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -102,6 +102,17 @@ go build -trimpath -ldflags="-s -w -X main.version=<tag>" -o dist/agentctl ./cmd
 | `-s -w` | Strip debug symbols and DWARF info (smaller binary) |
 | `-X main.version=<tag>` | Embed the Git tag as the version string |
 
+## Releasing
+
+To publish a new release and trigger the binary build workflow, create and push a `v*` tag:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+This triggers the [`release` workflow](../.github/workflows/release.yml), which builds archives for all supported platforms and publishes them as a GitHub Release. Use `v<major>.<minor>.0` for a new release (e.g. `v0.1.0`, `v0.2.0`).
+
 ## CI
 
 Every push and pull request runs the following via the [`go` workflow](../.github/workflows/go.yml):


### PR DESCRIPTION
## Summary

- Remove legacy `agent.sh` shell entrypoint
- Add `AGENTS.md` with contributor conventions; redirect `CLAUDE.md` to it
- Expand unit and integration test coverage across `internal/` packages
- Expand test-running instructions in `docs/build.md`
- Slim README; add `docs/install.md` and `docs/spec-driven.md`
- Add Releasing section to `docs/build.md` with `v*` tag instructions for triggering binary releases

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)