### PR TITLE
docs: add rule to never invoke gh pr merge directly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ CI runs all of the above on every push and pull request (`.github/workflows/go.y
 - **No new adapter stubs** unless the agent CLI has a stable non-interactive launch mechanism (see [#16](https://github.com/arun-gupta/agentctl/issues/16)).
 - **Do not bump the Go toolchain version** incidentally while fixing something else.
 
+## Merging
+
+- **Never invoke `gh pr merge` directly.** Open the PR and ask the user to merge it manually.
+
 ## PR hygiene
 
 - One logical change per PR; no unrelated cleanups.


### PR DESCRIPTION
## Summary

- Adds a **Merging** section to `AGENTS.md` prohibiting direct use of `gh pr merge`
- Rule: always open the PR and ask the user to merge manually

## Test plan

- [x] No code changes; docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)