### PR TITLE
docs: lead with stable release download in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,35 @@
 
 **agentctl** is a **Go** CLI that creates a [git worktree](https://git-scm.com/docs/git-worktree) per GitHub issue and launches a coding agent there, using Bash adapters in `agents/`.
 
-## Quick start
+## Install
 
-Build from a clone, then run commands from your **application** repository (the primary git worktree):
+**Stable release** (recommended) — download the archive for your platform, extract it, and add the `agentctl/` directory to your `PATH`:
+
+```bash
+# macOS (Apple Silicon)
+curl -fsSL https://github.com/arun-gupta/agentctl/releases/latest/download/agentctl-darwin-arm64.tar.gz | tar -xz
+export PATH="$(pwd)/agentctl:$PATH"
+```
+
+Replace `darwin-arm64` with `darwin-amd64`, `linux-amd64`, or `linux-arm64` as needed. Windows users: download `agentctl-windows-amd64.zip` from the [Releases page](https://github.com/arun-gupta/agentctl/releases).
+
+**Latest build** — per-commit snapshot artifacts are published on every push to `main` via [Actions → snapshot](https://github.com/arun-gupta/agentctl/actions/workflows/snapshot.yml) (14-day retention).
+
+**Build from source:**
 
 ```bash
 git clone https://github.com/arun-gupta/agentctl && cd agentctl
 go build -o agentctl ./cmd/agentctl
 export PATH="$(pwd):$PATH"   # keep agentctl next to ./agents/
+```
 
+See **[docs/install.md](docs/install.md)** for full details, symlink setup, and subtree installs.
+
+## Quick start
+
+Run commands from your **application** repository (the primary git worktree):
+
+```bash
 cd /path/to/your/app-repo
 agentctl spawn 42
 agentctl approve-spec 42       # headless: after you review the spec

--- a/docs/install.md
+++ b/docs/install.md
@@ -88,9 +88,6 @@ Expand-Archive agentctl-windows-amd64.zip -DestinationPath .
 > **Note:** The archive contains both the `agentctl` binary and the `agents/` adapter scripts.  
 > Keep both in the same directory (e.g. `/opt/agentctl/`) and add that directory to your `PATH`.
 
-- Per-commit / release automation: [#13](https://github.com/arun-gupta/agentctl/issues/13)
-- Homebrew: [#14](https://github.com/arun-gupta/agentctl/issues/14)
-
 ## Prebuilt binaries — per-commit snapshots
 
 Every push to `main` runs the [`snapshot` workflow](../.github/workflows/snapshot.yml) which publishes


### PR DESCRIPTION
## Summary

- **README**: adds an **Install** section above Quick start with three tiers: stable release (curl), latest snapshot (Actions artifacts), and build from source; Quick start now focuses only on running commands
- **docs/install.md**: removes stale issue links (#13, #14) for per-commit automation and Homebrew — both are now live

## Test plan

- [x] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)