### PR TITLE
docs: add CLI workflow guide and release-first install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@ agents/
   copilot.sh      ← GitHub Copilot adapter (stub)
 docs/
   build.md        ← build, test, cross-compile, release instructions
-  development.md  ← full CLI reference, adapter contract, worktree layout
+  cli.md          ← command reference and workflows
+  development.md  ← adapter contract, worktree layout, testing, CI
 ```
 
 **The `agentctl` binary must live next to the `agents/` directory.** The executable's directory is used at runtime to resolve adapter paths; `go build -o agentctl ./cmd/agentctl` from the repo root satisfies this.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ agentctl cleanup-merged 42
 ## Documentation
 
 - **[docs/install.md](docs/install.md)** — prerequisites, layout, install paths, releases  
+- **[docs/cli.md](docs/cli.md)** — command reference and workflows  
 - **[docs/spec-driven.md](docs/spec-driven.md)** — SDD, Spec Kit, `--no-speckit`  
-- **[docs/development.md](docs/development.md)** — CLI reference, batches, adapters, worktrees, CI  
+- **[docs/development.md](docs/development.md)** — adapters, testing, CI  
 - **[docs/build.md](docs/build.md)** — contributor build, test, coverage  
 - **[AGENTS.md](AGENTS.md)** — conventions for AI agents working in this repo  
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,35 @@
 
 **agentctl** is a **Go** CLI that creates a [git worktree](https://git-scm.com/docs/git-worktree) per GitHub issue and launches a coding agent there, using Bash adapters in `agents/`.
 
-## Quick start
+## Install
 
-Build from a clone, then run commands from your **application** repository (the primary git worktree):
+**Stable release** (recommended) — download the archive for your platform, extract it, and add the `agentctl/` directory to your `PATH`:
+
+```bash
+# macOS (Apple Silicon)
+curl -fsSL https://github.com/arun-gupta/agentctl/releases/latest/download/agentctl-darwin-arm64.tar.gz | tar -xz
+export PATH="$(pwd)/agentctl:$PATH"
+```
+
+Replace `darwin-arm64` with `darwin-amd64`, `linux-amd64`, or `linux-arm64` as needed. Windows users: download `agentctl-windows-amd64.zip` from the [Releases page](https://github.com/arun-gupta/agentctl/releases).
+
+**Latest build** — per-commit snapshot artifacts are published on every push to `main` via [Actions → snapshot](https://github.com/arun-gupta/agentctl/actions/workflows/snapshot.yml) (14-day retention).
+
+**Build from source:**
 
 ```bash
 git clone https://github.com/arun-gupta/agentctl && cd agentctl
 go build -o agentctl ./cmd/agentctl
 export PATH="$(pwd):$PATH"   # keep agentctl next to ./agents/
+```
 
+See **[docs/install.md](docs/install.md)** for full details, symlink setup, and subtree installs.
+
+## Quick start
+
+Run commands from your **application** repository (the primary git worktree):
+
+```bash
 cd /path/to/your/app-repo
 agentctl spawn 42
 agentctl approve-spec 42       # headless: after you review the spec

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,241 @@
+# CLI reference and workflows
+
+Canonical command reference and operating workflows for **agentctl**.
+
+Run `agentctl --help` or `agentctl <command> --help` for generated help from the binary.
+
+## Command reference
+
+### `agentctl spawn`
+
+```bash
+agentctl spawn [--agent <name>] [--headless] [--no-speckit] <issue-number> [slug]
+```
+
+Creates a linked worktree for a GitHub issue and launches the selected coding agent inside it.
+
+- `--agent <name>`: adapter name from `agents/<name>.sh`; default is `claude`.
+- `--headless`: run the agent in the background and write agent output to `agent.log`.
+- `--no-speckit`: skip the default Spec Kit lifecycle and work directly toward a PR.
+- `<issue-number>`: GitHub issue number.
+- `[slug]`: optional branch/worktree slug. If omitted, `agentctl` uses `gh issue view` to fetch the issue title and derive a slug.
+
+Side effects:
+
+- Creates a branch named `<issue>-<slug>`.
+- Creates a worktree at `../<repo>-<issue>-<slug>/`.
+- Reserves a dev-server port in the `3010-3100` range.
+- Writes `.agent` metadata in the worktree.
+- Seeds `.env.local` from the primary worktree when present and appends `PORT=<port>`.
+- Runs `npm install --silent` and starts `npm run dev -- -p <port>`.
+- Launches the selected adapter.
+
+### `agentctl approve-spec`
+
+```bash
+agentctl approve-spec <issue-number>
+```
+
+Resumes a paused headless run after you approve the generated spec. This sends the approval prompt (`proceed`) to the adapter's `agent_resume` function.
+
+The command requires:
+
+- A linked worktree for the issue.
+- A `.agent` metadata file with the selected agent and session ID.
+- A generated spec at `specs/*/spec.md`.
+
+### `agentctl revise-spec`
+
+```bash
+agentctl revise-spec <issue-number> <feedback>
+```
+
+Resumes a paused headless run with revision feedback instead of approval. Feedback must be non-empty.
+
+Use this when the generated spec needs changes before implementation begins.
+
+### `agentctl status`
+
+```bash
+agentctl status
+agentctl status --verbose
+agentctl list
+```
+
+Shows all linked worktrees and their current state.
+
+Default columns:
+
+```text
+ISSUE  BRANCH  AGENT  PORT  SPEC  PR
+```
+
+Verbose columns:
+
+```text
+ISSUE  BRANCH  AGENT  PATH  PORT  DEV-PID  AGENT-PID  SPEC  PR  SESSION
+```
+
+Spec states:
+
+- `no-spec`: no spec found for the issue.
+- `paused`: `spec.md` exists, but no `plan.md` or `tasks.md`.
+- `in-progress`: `plan.md` exists, but no `tasks.md`.
+- `done`: `tasks.md` exists.
+
+PR states come from `gh pr view <branch>` and are usually `none`, `OPEN`, `MERGED`, or `CLOSED`.
+
+### `agentctl cleanup-merged`
+
+```bash
+agentctl cleanup-merged [issue-number]
+```
+
+Cleans up a worktree after its PR is merged.
+
+Behavior:
+
+- Infers the issue number from the current branch when run inside a linked worktree and no issue is provided.
+- Ensures the primary worktree is on `main`.
+- Verifies the branch PR is `MERGED` via `gh`.
+- Pulls `main` with fast-forward only.
+- Stops recorded dev/agent PIDs when possible.
+- Removes the linked worktree.
+- Deletes local and remote branches.
+
+If the PR is not merged, use `agentctl discard` for abandoned work.
+
+### `agentctl cleanup-all-merged`
+
+```bash
+agentctl cleanup-all-merged
+```
+
+Scans linked worktrees and runs the merged cleanup flow for each branch whose PR state is `MERGED`.
+
+Branches without PRs, unmerged PRs, detached worktrees, or branches without a numeric issue prefix are skipped.
+
+### `agentctl discard`
+
+```bash
+agentctl discard [issue-number]
+```
+
+Permanently discards a worktree and deletes local/remote branches. This is unrecoverable and prompts for `YES`.
+
+Use this for abandoned or failed work where the PR should not be merged.
+
+Like `cleanup-merged`, the issue number can be inferred from the current branch when run inside a linked worktree.
+
+## Workflows
+
+### Interactive single-issue workflow
+
+```bash
+# From your application repo's primary worktree
+agentctl spawn 42
+```
+
+The agent runs interactively in your terminal. With the default Spec Kit workflow, review the generated spec when the agent stops, then tell the agent to continue in the interactive session.
+
+After the PR is merged:
+
+```bash
+agentctl cleanup-merged 42
+```
+
+### Headless single-issue workflow
+
+```bash
+# Start work in the background
+agentctl spawn --headless 42
+
+# Watch progress
+agentctl status --verbose
+tail -f ../<repo>-42-<slug>/agent.log
+
+# Approve the spec after review
+agentctl approve-spec 42
+
+# Or request revisions instead
+agentctl revise-spec 42 "Narrow scope to the API layer; avoid UI changes."
+
+# Clean up after merge
+agentctl cleanup-merged 42
+```
+
+### Batch headless workflow
+
+```bash
+# Spawn several issues
+for i in 210 211 212; do
+  agentctl spawn --headless "$i"
+done
+
+# Review generated specs, then approve each one
+for i in 210 211 212; do
+  agentctl approve-spec "$i"
+done
+
+# Monitor all worktrees
+agentctl status
+agentctl status --verbose
+
+# Sweep merged PRs
+agentctl cleanup-all-merged
+```
+
+### Repo without Spec Kit
+
+```bash
+agentctl spawn --no-speckit 42
+```
+
+This skips the spec-review pause. The agent works directly toward a PR.
+
+See [spec-driven.md](spec-driven.md) for default SDD behavior and target-repo expectations.
+
+### Recovery and maintenance
+
+Discard abandoned work:
+
+```bash
+agentctl discard 42
+```
+
+Run cleanup/discard from inside a linked worktree without passing the issue number:
+
+```bash
+cd ../myrepo-42-my-feature
+agentctl cleanup-merged
+# or
+agentctl discard
+```
+
+Inspect logs and state:
+
+```bash
+agentctl status --verbose
+cat ../<repo>-42-<slug>/.agent
+tail -f ../<repo>-42-<slug>/agent.log
+tail -f ../<repo>-42-<slug>/dev.log
+```
+
+## Worktree state files
+
+Each spawned worktree contains:
+
+```text
+.agent          key=value metadata (agent, session-id, dev-pid, agent-pid)
+agent.log       coding-agent output in headless mode
+dev.log         dev-server output
+specs/          Spec Kit artifacts when using the default SDD flow
+```
+
+The primary worktree is the first worktree reported by `git worktree list --porcelain`; linked worktrees are created next to it.
+
+## Related docs
+
+- [install.md](install.md) — prerequisites, binary layout, and installation.
+- [spec-driven.md](spec-driven.md) — default SDD / Spec Kit behavior.
+- [development.md](development.md) — adapter contract, testing, and CI.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,58 +1,10 @@
 # Development
 
-Contributor-oriented notes: full CLI reference, workflows, adapters, layout, and CI. For **install and prerequisites**, see [install.md](install.md). For **SDD and Spec Kit**, see [spec-driven.md](spec-driven.md).
+Contributor-oriented notes: adapter contracts, worktree layout, testing, and CI.
 
-## Spec-driven development and SpecKit
-
-The default `agentctl spawn` workflow is **SDD with a human checkpoint**: the agent runs **Stage 1** (write a spec), stops for your approval or revision (`approve-spec` / `revise-spec` when headless), then **Stage 2** (plan, tasks, implement) and opens a PR. That flow is implemented in terms of [Spec Kit](https://github.com/github/spec-kit)—the kickoff tells the agent to use `/speckit.specify`, `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement`, and `agentctl` infers pause state from files under `specs/` (for example `spec.md` vs `plan.md` / `tasks.md`).
-
-**agentctl does not install or vendor Spec Kit.** The **target repository** (and your agent setup, e.g. Claude Code slash commands) must already support that SpecKit-style lifecycle. If your repo is not set up for it, use **`--no-speckit`** on `spawn` so the agent skips that lifecycle and works straight toward a PR with no spec-review pause.
-
-## Usage
-
-```
-Provision an isolated agent worktree for an issue and launch a coding agent in it.
-
-Usage:
-  agentctl spawn [--agent <name>] [--headless] [--no-speckit] <issue-number> [slug]
-  agentctl approve-spec        <issue-number>
-  agentctl revise-spec         <issue-number> <feedback>
-  agentctl discard             [<issue-number>]
-  agentctl cleanup-merged      [<issue-number>]
-  agentctl cleanup-all-merged
-  agentctl status
-
-Flags (spawn):
-  --agent <name>         Select coding agent adapter (default: claude).
-  --headless             Run agent in background (log -> agent.log)
-  --no-speckit           Skip SpecKit lifecycle; agent opens a PR directly (no spec pause)
-
-Subcommands:
-  approve-spec           Release the spec-review pause for a paused headless spawn
-  revise-spec            Send non-empty revision feedback to a paused spawn
-  discard                Discard worktree + delete local/remote branch (unrecoverable; prompts for confirmation)
-  cleanup-merged         Post-merge: pull main, remove worktree, delete local+remote branch
-  cleanup-all-merged     Batch sweep: run cleanup-merged on every worktree whose PR is MERGED
-  status                 Compact table: issue, branch, agent, port, spec state, PR state.
-  status --verbose       Full table: adds PATH, DEV-PID, AGENT-PID, SESSION.
-  -h, --help             Show help and exit
-```
-
-### Batch workflow
-
-```bash
-# Spawn three issues in parallel (headless)
-for i in 210 211 212; do agentctl spawn --headless "$i"; done
-
-# Approve all specs once you've reviewed them
-for i in 210 211 212; do agentctl approve-spec "$i"; done
-
-# Sweep up everything that's been merged
-agentctl cleanup-all-merged
-
-# Check the status of all active worktrees
-agentctl status
-```
+For user-facing command docs and operating workflows, see **[cli.md](cli.md)**.
+For install and prerequisites, see **[install.md](install.md)**.
+For SDD and Spec Kit behavior, see **[spec-driven.md](spec-driven.md)**.
 
 ## Adapter interface
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -88,9 +88,6 @@ Expand-Archive agentctl-windows-amd64.zip -DestinationPath .
 > **Note:** The archive contains both the `agentctl` binary and the `agents/` adapter scripts.  
 > Keep both in the same directory (e.g. `/opt/agentctl/`) and add that directory to your `PATH`.
 
-- Per-commit / release automation: [#13](https://github.com/arun-gupta/agentctl/issues/13)
-- Homebrew: [#14](https://github.com/arun-gupta/agentctl/issues/14)
-
 ## Prebuilt binaries — per-commit snapshots
 
 Every push to `main` runs the [`snapshot` workflow](../.github/workflows/snapshot.yml) which publishes

--- a/docs/spec-driven.md
+++ b/docs/spec-driven.md
@@ -18,4 +18,5 @@ If the repo is not set up for it, use **`agentctl spawn --no-speckit`** so the a
 ## Related
 
 - [install.md](install.md) — prerequisites and installing `agentctl`
-- [development.md](development.md) — CLI usage, batch flows, adapters, worktree layout
+- [cli.md](cli.md) — CLI usage and workflows
+- [development.md](development.md) — adapters, testing, and CI


### PR DESCRIPTION
## Summary

- Add `docs/cli.md` as the canonical command reference and workflow guide.
- Point README, `docs/development.md`, `docs/spec-driven.md`, and `AGENTS.md` at the new CLI guide.
- Keep the README slim and release-first: stable release download, latest snapshot link, source build fallback.
- Remove stale issue-tracking language from install docs now that release/snapshot docs exist.

## Test plan

- [x] Docs-only change; no code tests run.
- [x] Verify markdown renders cleanly on GitHub and internal links resolve.


Made with [Cursor](https://cursor.com)