### PR TITLE
docs: highlight supported coding agents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agentctl
 
-**agentctl** is a **Go** CLI that creates a [git worktree](https://git-scm.com/docs/git-worktree) per GitHub issue and launches a coding agent there, using Bash adapters in `agents/`.
+**agentctl** is a **Go** CLI that creates a [git worktree](https://git-scm.com/docs/git-worktree) per GitHub issue and launches a coding agent there. Built-in agent integrations currently support **Claude Code** (default), **OpenAI Codex**, **Gemini CLI**, and **OpenCode**; **GitHub Copilot CLI** is present as a stub.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Update the README intro to list supported agent integrations: Claude Code, OpenAI Codex, Gemini CLI, and OpenCode.
- Note GitHub Copilot CLI as a stub without exposing the Bash adapter implementation detail.

## Test plan

- [x] Docs-only change; no code tests run.

Made with [Cursor](https://cursor.com)