### PR TITLE
feat: add checksums to release workflow and Homebrew install to README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,9 @@ jobs:
           path: dist/
           merge-multiple: true
 
+      - name: Generate checksums
+        run: (cd dist && sha256sum agentctl-* > checksums.txt)
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:

--- a/README.md
+++ b/README.md
@@ -8,15 +8,21 @@
 
 ## Install
 
-Download a release archive, extract it, and add the `agentctl/` directory to your `PATH`:
+**Homebrew** (macOS and Linux):
+
+```bash
+brew install arun-gupta/tap/agentctl
+```
+
+**Manual** — download a release archive, extract it, and move the binary onto your `PATH`:
 
 ```bash
 # macOS (Apple Silicon)
 curl -fsSL https://github.com/arun-gupta/agentctl/releases/latest/download/agentctl-darwin-arm64.tar.gz | tar -xz
-export PATH="$(pwd)/agentctl:$PATH"
+sudo mv agentctl /usr/local/bin/
 ```
 
-For other platforms, source builds, symlinks, and subtree installs, see **[docs/install.md](docs/install.md)**.
+For other platforms, source builds, and subtree installs, see **[docs/install.md](docs/install.md)**.
 
 ## Quick start
 

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -21,10 +21,13 @@ import (
 	"github.com/arun-gupta/agentctl/internal/cmd"
 )
 
+var version = "dev"
+
 func main() {
 	root := &cobra.Command{
-		Use:   "agentctl",
-		Short: "Provision isolated git worktrees per issue and launch coding agents",
+		Use:     "agentctl",
+		Version: version,
+		Short:   "Provision isolated git worktrees per issue and launch coding agents",
 		Long: `agentctl provisions isolated git worktrees per GitHub issue and launches
 coding agents inside each one. It supports multiple agent back-ends via
 a simple adapter registry and follows spec-driven development (SDD) by default.`,


### PR DESCRIPTION
## Summary

- Adds a `Generate checksums` step to the release workflow that produces `checksums.txt` (SHA256 per tarball) and uploads it as a release asset alongside the binaries
- Updates README `Install` section to lead with `brew install arun-gupta/tap/agentctl`

## Related

Closes #14

Part of the Homebrew tap work:
- Tap repo created: https://github.com/arun-gupta/homebrew-tap
- Formula targets v0.2.0 self-contained binary (post #45 embed work)
- Tap CI runs `brew audit --strict` and `brew install` smoke test on every push/PR

## Test plan

- [ ] Merge this PR and push a new version tag — verify `checksums.txt` appears in the GitHub release assets
- [ ] `brew tap arun-gupta/tap && brew install arun-gupta/tap/agentctl && agentctl --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)