### PR TITLE
ci: auto-bump Homebrew formula on release

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -1,0 +1,93 @@
+name: bump-homebrew
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump:
+    name: Open formula bump PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern checksums.txt \
+            --output checksums.txt
+
+      - name: Parse checksums
+        id: sums
+        run: |
+          get() { grep "$1" checksums.txt | awk '{print $1}'; }
+          echo "darwin_arm64=$(get darwin-arm64.tar.gz)"   >> "$GITHUB_OUTPUT"
+          echo "darwin_amd64=$(get darwin-amd64.tar.gz)"   >> "$GITHUB_OUTPUT"
+          echo "linux_arm64=$(get linux-arm64.tar.gz)"     >> "$GITHUB_OUTPUT"
+          echo "linux_amd64=$(get linux-amd64.tar.gz)"     >> "$GITHUB_OUTPUT"
+
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          repository: arun-gupta/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Update formula
+        env:
+          VERSION: ${{ github.ref_name }}
+          DARWIN_ARM64: ${{ steps.sums.outputs.darwin_arm64 }}
+          DARWIN_AMD64: ${{ steps.sums.outputs.darwin_amd64 }}
+          LINUX_ARM64:  ${{ steps.sums.outputs.linux_arm64 }}
+          LINUX_AMD64:  ${{ steps.sums.outputs.linux_amd64 }}
+        run: |
+          VERSION="${VERSION#v}"
+          sed -i "s/^  version \".*\"/  version \"${VERSION}\"/" Formula/agentctl.rb
+          # Update sha256 values in order: darwin-arm64, darwin-amd64, linux-arm64, linux-amd64
+          # Each sha256 line is unique in context so we replace by pairing with the preceding url line
+          python3 - <<'PYEOF'
+          import re, os
+
+          formula = open("Formula/agentctl.rb").read()
+
+          pairs = [
+              ("darwin-arm64",  os.environ["DARWIN_ARM64"]),
+              ("darwin-amd64",  os.environ["DARWIN_AMD64"]),
+              ("linux-arm64",   os.environ["LINUX_ARM64"]),
+              ("linux-amd64",   os.environ["LINUX_AMD64"]),
+          ]
+
+          for arch, sha in pairs:
+              formula = re.sub(
+                  rf'(url "[^"]*{re.escape(arch)}[^"]*"\n\s+sha256 ")[0-9a-f]+"',
+                  rf'\g<1>{sha}"',
+                  formula,
+              )
+
+          open("Formula/agentctl.rb", "w").write(formula)
+          PYEOF
+
+      - name: Commit and push branch
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="bump/agentctl-${VERSION}"
+          git checkout -b "$BRANCH"
+          git add Formula/agentctl.rb
+          git commit -m "feat: bump agentctl to ${VERSION}"
+          git push origin "$BRANCH"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          gh pr create \
+            --repo arun-gupta/homebrew-tap \
+            --head "$BRANCH" \
+            --base main \
+            --title "feat: bump agentctl to ${VERSION}" \
+            --body "Automated formula bump for [${VERSION}](https://github.com/arun-gupta/agentctl/releases/tag/${VERSION})."

--- a/docs/build.md
+++ b/docs/build.md
@@ -104,14 +104,39 @@ go build -trimpath -ldflags="-s -w -X main.version=<tag>" -o dist/agentctl ./cmd
 
 ## Releasing
 
-To publish a new release and trigger the binary build workflow, create and push a `v*` tag:
+Push a `v*` tag to publish a new release:
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
+git tag v0.2.0
+git push origin v0.2.0
 ```
 
-This triggers the [`release` workflow](../.github/workflows/release.yml), which builds archives for all supported platforms and publishes them as a GitHub Release. Use `v<major>.<minor>.0` for a new release (e.g. `v0.1.0`, `v0.2.0`).
+This triggers a chain of three automated workflows:
+
+```
+tag push
+  └─▶ release workflow        — builds archives for all platforms, publishes GitHub Release
+        └─▶ bump-homebrew      — opens a PR in homebrew-tap with updated version + SHA256s
+              └─▶ tap CI       — brew audit + brew install smoke test on the bump PR
+```
+
+**release workflow** ([`.github/workflows/release.yml`](../.github/workflows/release.yml))
+- Builds `agentctl` for Linux/macOS/Windows × amd64/arm64
+- Publishes archives (`agentctl-<os>-<arch>.tar.gz` / `.zip`) as release assets
+- Generates `checksums.txt` (SHA256 per archive) and includes it in the release
+
+**bump-homebrew workflow** ([`.github/workflows/bump-homebrew.yml`](../.github/workflows/bump-homebrew.yml))
+- Triggered automatically when the GitHub Release is published
+- Downloads `checksums.txt` from the new release
+- Patches `version` and `sha256` values in `Formula/agentctl.rb` in [homebrew-tap](https://github.com/arun-gupta/homebrew-tap)
+- Opens a PR (`bump/agentctl-vX.Y.Z`) in homebrew-tap for review
+- Requires the `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT scoped to homebrew-tap with contents + pull-requests write)
+
+**tap CI** ([homebrew-tap `.github/workflows/ci.yml`](https://github.com/arun-gupta/homebrew-tap/blob/main/.github/workflows/ci.yml))
+- Runs `brew audit --strict agentctl` on every push and PR
+- Runs `brew install arun-gupta/tap/agentctl` and `agentctl --version` smoke test
+
+Merge the bump PR in homebrew-tap once tap CI is green. Use `v<major>.<minor>.0` for a new release (e.g. `v0.2.0`, `v0.3.0`).
 
 ## CI
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,7 +9,7 @@ How to install **agentctl** and what you need on your machine.
 | Requirement | Purpose |
 |-------------|---------|
 | `git` ≥ 2.5 | worktree support |
-| `bash` | adapters are sourced and run via Bash |
+| `bash` | adapters are run via Bash |
 | `gh` CLI | PR management (`cleanup-merged`, `status`), slug-from-title |
 
 ### Required for the default workflow
@@ -29,9 +29,24 @@ How to install **agentctl** and what you need on your machine.
 | `copilot` CLI | required only when using `--agent copilot`; install from [GitHub Copilot CLI](https://github.com/features/copilot/cli) (`npm install -g @github/copilot`); auth via `GITHUB_TOKEN` or `copilot auth` |
 | Go | only to build from source (see `go.mod`) |
 
-## Prebuilt binaries — GitHub Releases (stable)
+## Homebrew (macOS and Linux) — recommended
 
-Tagged releases publish archives for all supported platforms. Download the archive for your OS/arch, extract it, and add the `agentctl/` directory to your `PATH`.
+```bash
+brew install arun-gupta/tap/agentctl
+```
+
+To add the tap once and install later:
+
+```bash
+brew tap arun-gupta/tap
+brew install agentctl
+```
+
+Tap source: [github.com/arun-gupta/homebrew-tap](https://github.com/arun-gupta/homebrew-tap)
+
+## Prebuilt binaries — GitHub Releases
+
+Tagged releases publish archives for all supported platforms. Download the archive for your OS/arch, extract it, and move the binary onto your `PATH`.
 
 **macOS / Linux**
 
@@ -40,8 +55,8 @@ Tagged releases publish archives for all supported platforms. Download the archi
 # linux-amd64 | linux-arm64 | darwin-amd64 | darwin-arm64
 curl -fsSL https://github.com/arun-gupta/agentctl/releases/latest/download/agentctl-<os>-<arch>.tar.gz \
   | tar -xz
-sudo mv agentctl /usr/local/bin/agentctl   # or any directory on your PATH
-agentctl version
+sudo mv agentctl /usr/local/bin/agentctl
+agentctl --version
 ```
 
 **Windows (PowerShell)**
@@ -49,13 +64,15 @@ agentctl version
 ```powershell
 # Download from the Releases page:
 # https://github.com/arun-gupta/agentctl/releases/latest
-# Then extract and move agentctl.exe to a directory on your PATH.
 Expand-Archive agentctl-windows-amd64.zip -DestinationPath .
-.\agentctl\agentctl.exe version
+.\agentctl.exe --version
 ```
 
-> **Note:** The archive contains both the `agentctl` binary and the `agents/` adapter scripts.  
-> Keep both in the same directory (e.g. `/opt/agentctl/`) and add that directory to your `PATH`.
+Each release also ships a `checksums.txt` with SHA256 digests for every archive. Verify before installing:
+
+```bash
+sha256sum -c checksums.txt --ignore-missing
+```
 
 ## Prebuilt binaries — per-commit snapshots
 
@@ -65,62 +82,21 @@ workflow artifacts for the full platform matrix (14-day retention). Use these to
 1. Go to **[Actions → snapshot](https://github.com/arun-gupta/agentctl/actions/workflows/snapshot.yml)**.
 2. Open the latest successful run on `main`.
 3. Download the artifact for your platform, e.g. `agentctl-<sha>-linux-amd64` (`.tar.gz`) or `agentctl-<sha>-windows-amd64` (`.zip`).
-4. Extract and place `agentctl` (or `agentctl.exe`) + the `agents/` directory in the same folder on your `PATH`.
+4. Extract and move `agentctl` (or `agentctl.exe`) onto your `PATH`.
 
 Artifact naming: `agentctl-<7-char-sha>-<goos>-<goarch>`, e.g. `agentctl-a1b2c3d-linux-amd64.tar.gz`.
 
-## Install from source (clone)
-
-Use this path for development, local patches, or when you do not want a prebuilt archive.
+## Install from source
 
 ```bash
 git clone https://github.com/arun-gupta/agentctl
 cd agentctl
 go build -o agentctl ./cmd/agentctl
-# Run ./agentctl from this directory, or add this directory to PATH
-./agentctl --help
+sudo mv agentctl /usr/local/bin/agentctl
+agentctl --version
 ```
 
-To install elsewhere, keep **`agentctl` and `agents/` in the same directory** (for example copy both into `/opt/agentctl/`) and put that directory on your `PATH`.
-
-### Symlink only the binary
-
-Agents resolve from the **real path** of the executable:
-
-```bash
-git clone https://github.com/arun-gupta/agentctl ~/.local/share/agentctl
-cd ~/.local/share/agentctl && go build -o agentctl ./cmd/agentctl
-ln -sf ~/.local/share/agentctl/agentctl ~/.local/bin/agentctl
-# Adapters: ~/.local/share/agentctl/agents/
-```
-
-### Git subtree
-
-```bash
-git subtree add --prefix agentctl \
-  https://github.com/arun-gupta/agentctl main --squash
-```
-
-Then `cd agentctl && go build -o agentctl ./cmd/agentctl`, or unpack a **GitHub Release** archive that already contains `agentctl` + `agents/`.
-
-## Binary and adapter layout
-
-The **`agentctl` binary must live in the same directory as the `agents/` folder** (the executable's directory is used to resolve adapter paths). Release archives already use this layout, and building from a clone at repo root keeps `./agentctl` next to `./agents/`.
-
-```
-cmd/agentctl/     ← Go CLI (cobra)
-internal/         ← git, process, state, commands
-agents/
-  claude.sh       ← Claude Code adapter
-  codex.sh        ← OpenAI Codex CLI adapter
-  copilot.sh      ← GitHub Copilot CLI adapter
-  gemini.sh       ← Google Gemini CLI adapter
-  opencode.sh     ← OpenCode CLI adapter
-```
-
-## Contributor builds
-
-For `go build ./...`, tests, and coverage, see **[build.md](build.md)**.
+For contributor builds, test commands, and cross-compilation see **[build.md](build.md)**.
 
 ## Provenance
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/bump-homebrew.yml` triggered on `release: published`
- On each new release, the workflow downloads `checksums.txt`, extracts the four SHA256s, patches `Formula/agentctl.rb` in `homebrew-tap`, and opens a PR there automatically

## How it works

1. Downloads `checksums.txt` from the published release using `GITHUB_TOKEN`
2. Parses SHA256 for each platform (darwin-arm64/amd64, linux-arm64/amd64)
3. Checks out `homebrew-tap` using `HOMEBREW_TAP_TOKEN` (already set as repo secret)
4. Patches version + sha256 values in the formula using `sed` + Python regex
5. Pushes a `bump/agentctl-vX.Y.Z` branch and opens a PR in homebrew-tap

## Test plan

- [ ] Merge and push a new version tag — verify a bump PR is opened in https://github.com/arun-gupta/homebrew-tap automatically

## Closes

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)