### PR TITLE
refactor: remove agent_pause_state from adapter scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ CI runs all of the above on every push and pull request (`.github/workflows/go.y
 ## Constraints
 
 - **No direct commits.** PRs only (see Workflow above).
-- **Adapter interface is stable.** Each `agents/<name>.sh` must export exactly `agent_launch`, `agent_resume`, and `agent_pause_state`. Signatures are in `docs/development.md`. Do not rename or remove parameters.
+- **Adapter interface is stable.** Each `agents/<name>.sh` must export exactly `agent_launch` and `agent_resume`. Signatures are in `docs/development.md`. Do not rename or remove parameters.
 - **Co-location contract.** Do not move `agentctl` or `agents/` independently; adapter resolution is path-based.
 - **Spec artefact paths.** Pause-state logic depends on `specs/<issue>-*/spec.md`, `plan.md`, `tasks.md`. Changing these paths requires updating all three adapters and `internal/state` in the same PR.
 - **No new top-level commands** without a corresponding issue and discussion.

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ For SDD and Spec Kit behavior, see **[spec-driven.md](spec-driven.md)**.
 
 ## Adapter interface
 
-Each adapter is a Bash file in the `agents/` directory that `agentctl` sources via Bash at runtime. An adapter **must** implement three functions:
+Each adapter is a Bash file in the `agents/` directory that `agentctl` sources via Bash at runtime. An adapter **must** implement two functions:
 
 ### `agent_launch(wt, issue, port, session_id, kickoff, headless)`
 
@@ -34,17 +34,6 @@ Resumes a paused headless agent with new instructions.
 | `wt` | Absolute path to the linked worktree |
 | `prompt` | Revision feedback string |
 
-### `agent_pause_state(wt, issue)` → stdout
-
-Returns a single-word state string based on the presence of spec artefacts in `$wt/specs/`:
-
-| Return value | Meaning |
-|-------------|---------|
-| `no-spec` | No spec directory found |
-| `paused` | `spec.md` exists but no `plan.md` or `tasks.md` |
-| `in-progress` | `plan.md` exists but no `tasks.md` |
-| `done` | `tasks.md` exists |
-
 ### Naming convention
 
 The file must be named `agents/<name>.sh`. It is selected with `agentctl spawn --agent <name>`. Use `agentctl spawn --help` to see flags; available adapters are the `*.sh` files under `agents/`.
@@ -69,21 +58,6 @@ agent_launch() {
 agent_resume() {
   local wt="$1" prompt="$2"
   ( cd "$wt" && nohup my-bot --resume --message "$prompt" >> agent.log 2>&1 & )
-}
-
-agent_pause_state() {
-  local wt="$1" issue="$2"
-  local state="no-spec"
-  if [[ -n "${issue:-}" ]] && compgen -G "$wt/specs/${issue}-*/spec.md" > /dev/null 2>&1; then
-    if compgen -G "$wt/specs/${issue}-*/tasks.md" > /dev/null 2>&1; then
-      state="done"
-    elif compgen -G "$wt/specs/${issue}-*/plan.md" > /dev/null 2>&1; then
-      state="in-progress"
-    else
-      state="paused"
-    fi
-  fi
-  echo "$state"
 }
 ```
 

--- a/internal/agents/scripts/claude.sh
+++ b/internal/agents/scripts/claude.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Claude Code adapter for agentctl
-# Implements: agent_launch, agent_resume, agent_pause_state
+# Implements: agent_launch, agent_resume
 
 agent_launch() {
   local wt="$1" issue="$2" _port="$3" session_id="$4" kickoff="$5" headless="$6"
@@ -28,19 +28,4 @@ agent_resume() {
     exit 1
   fi
   ( cd "$wt" && nohup claude -p "$prompt" --resume "$session_id" >> agent.log 2>&1 & )
-}
-
-agent_pause_state() {
-  local wt="$1" issue="$2"
-  local state="no-spec"
-  if [[ -n "${issue:-}" ]] && compgen -G "$wt/specs/${issue}-*/spec.md" > /dev/null 2>&1; then
-    if compgen -G "$wt/specs/${issue}-*/tasks.md" > /dev/null 2>&1; then
-      state="done"
-    elif compgen -G "$wt/specs/${issue}-*/plan.md" > /dev/null 2>&1; then
-      state="in-progress"
-    else
-      state="paused"
-    fi
-  fi
-  echo "$state"
 }

--- a/internal/agents/scripts/codex.sh
+++ b/internal/agents/scripts/codex.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # OpenAI Codex CLI adapter for agentctl
-# Implements: agent_launch, agent_resume, agent_pause_state
+# Implements: agent_launch, agent_resume
 #
 # Requires the Codex CLI (https://github.com/openai/codex).
 # Install: npm install -g @openai/codex
@@ -37,19 +37,4 @@ agent_resume() {
     exit 1
   fi
   ( cd "$wt" && nohup codex -q "$prompt" --resume "$session_id" >> agent.log 2>&1 & )
-}
-
-agent_pause_state() {
-  local wt="$1" issue="$2"
-  local state="no-spec"
-  if [[ -n "${issue:-}" ]] && compgen -G "$wt/specs/${issue}-*/spec.md" > /dev/null 2>&1; then
-    if compgen -G "$wt/specs/${issue}-*/tasks.md" > /dev/null 2>&1; then
-      state="done"
-    elif compgen -G "$wt/specs/${issue}-*/plan.md" > /dev/null 2>&1; then
-      state="in-progress"
-    else
-      state="paused"
-    fi
-  fi
-  echo "$state"
 }

--- a/internal/agents/scripts/copilot.sh
+++ b/internal/agents/scripts/copilot.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # GitHub Copilot CLI adapter for agentctl
-# Implements: agent_launch, agent_resume, agent_pause_state
+# Implements: agent_launch, agent_resume
 #
 # Requires the GitHub Copilot CLI (https://github.com/features/copilot/cli).
 # Install: npm install -g @github/copilot
@@ -41,19 +41,4 @@ agent_resume() {
     exit 1
   fi
   ( cd "$wt" && nohup copilot -p "$prompt" --session-id "$session_id" >> agent.log 2>&1 & )
-}
-
-agent_pause_state() {
-  local wt="$1" issue="$2"
-  local state="no-spec"
-  if [[ -n "${issue:-}" ]] && compgen -G "$wt/specs/${issue}-*/spec.md" > /dev/null 2>&1; then
-    if compgen -G "$wt/specs/${issue}-*/tasks.md" > /dev/null 2>&1; then
-      state="done"
-    elif compgen -G "$wt/specs/${issue}-*/plan.md" > /dev/null 2>&1; then
-      state="in-progress"
-    else
-      state="paused"
-    fi
-  fi
-  echo "$state"
 }

--- a/internal/agents/scripts/gemini.sh
+++ b/internal/agents/scripts/gemini.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Google Gemini CLI adapter for agentctl
-# Implements: agent_launch, agent_resume, agent_pause_state
+# Implements: agent_launch, agent_resume
 #
 # Requires the Gemini CLI (https://github.com/google-gemini/gemini-cli).
 # Install: npm install -g @google/gemini-cli
@@ -37,19 +37,4 @@ agent_resume() {
     exit 1
   fi
   ( cd "$wt" && nohup gemini -p "$prompt" >> agent.log 2>&1 & )
-}
-
-agent_pause_state() {
-  local wt="$1" issue="$2"
-  local state="no-spec"
-  if [[ -n "${issue:-}" ]] && compgen -G "$wt/specs/${issue}-*/spec.md" > /dev/null 2>&1; then
-    if compgen -G "$wt/specs/${issue}-*/tasks.md" > /dev/null 2>&1; then
-      state="done"
-    elif compgen -G "$wt/specs/${issue}-*/plan.md" > /dev/null 2>&1; then
-      state="in-progress"
-    else
-      state="paused"
-    fi
-  fi
-  echo "$state"
 }

--- a/internal/agents/scripts/opencode.sh
+++ b/internal/agents/scripts/opencode.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # OpenCode CLI adapter for agentctl
-# Implements: agent_launch, agent_resume, agent_pause_state
+# Implements: agent_launch, agent_resume
 #
 # Requires the OpenCode CLI (https://opencode.ai).
 # Install: npm install -g opencode@latest
@@ -37,19 +37,4 @@ agent_resume() {
     exit 1
   fi
   ( cd "$wt" && nohup opencode run -p "$prompt" --session "$session_id" >> agent.log 2>&1 & )
-}
-
-agent_pause_state() {
-  local wt="$1" issue="$2"
-  local state="no-spec"
-  if [[ -n "${issue:-}" ]] && compgen -G "$wt/specs/${issue}-*/spec.md" > /dev/null 2>&1; then
-    if compgen -G "$wt/specs/${issue}-*/tasks.md" > /dev/null 2>&1; then
-      state="done"
-    elif compgen -G "$wt/specs/${issue}-*/plan.md" > /dev/null 2>&1; then
-      state="in-progress"
-    else
-      state="paused"
-    fi
-  fi
-  echo "$state"
 }


### PR DESCRIPTION
## Summary

- Removes `agent_pause_state` from all five adapter scripts (claude, codex, gemini, opencode, copilot)
- Updates `AGENTS.md` and `docs/development.md` to reflect the narrowed interface: `agent_launch` + `agent_resume` only

## Why

`agent_pause_state` was never called from Go. `computeSpecState` in `internal/cmd/commands.go:706` is the authoritative implementation and has been used exclusively since the Go rewrite. The shell functions were dead code duplicating that logic across every adapter.

Removing it also means anyone adding a new adapter no longer has to implement a function that does nothing.

## Test plan

- `go test ./...` — all green
- No functional change; dead code removal only

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)