### PR TITLE
docs: clarify install field is a display hint, never executed

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -47,7 +47,8 @@ launch: <string>          # default: derived from binary + prompt + session
 # launch still falls back to structured fields if not set.
 resume_cmd: <string>      # default: derived from binary + prompt + resume_id
 
-# Install hint shown when the binary is not found on PATH.
+# Hint shown in the error message when the binary is not found on PATH.
+# agentctl never executes this string — it is displayed to the user only.
 install: <string>         # optional; e.g. "npm install -g @anthropic-ai/claude-code"
 ```
 


### PR DESCRIPTION
## Summary

Adds a second comment line to the `install` field in the YAML schema to make clear agentctl never runs this string — it is only shown to the user in the error message when the binary is not found on PATH.

Before:
```yaml
# Install hint shown when the binary is not found on PATH.
install: <string>
```

After:
```yaml
# Hint shown in the error message when the binary is not found on PATH.
# agentctl never executes this string — it is displayed to the user only.
install: <string>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)