### PR TITLE
docs: add Upgrade section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ sudo mv agentctl /usr/local/bin/
 
 For other platforms, source builds, and subtree installs, see **[docs/install.md](docs/install.md)**.
 
+## Upgrade
+
+**Homebrew:**
+
+```bash
+brew upgrade agentctl
+```
+
+**Manual** — re-run the same `curl` command from Install to replace the binary.
+
 ## Quick start
 
 Run commands from your **application** repository (the primary git worktree):


### PR DESCRIPTION
Adds a short `## Upgrade` section between Install and Quick start — the first thing users look for after they've already installed.

- Homebrew: `brew upgrade agentctl`
- Manual: re-run the same `curl` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)