### PR TITLE
docs: use brew update && brew upgrade in Upgrade section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For other platforms, source builds, and subtree installs, see **[docs/install.md
 **Homebrew:**
 
 ```bash
-brew upgrade agentctl
+brew update && brew upgrade agentctl
 ```
 
 **Manual** — re-run the same `curl` command from Install to replace the binary.


### PR DESCRIPTION
## Summary
- `brew upgrade` silently skips if the local tap cache is stale; `brew update` refreshes the formula index first

## Test plan
- [x] Read the Upgrade section in README.md and confirm the command is `brew update && brew upgrade agentctl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)