### PR TITLE
fix: correct SDD description and add getting-started examples to root help

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For other platforms, source builds, and subtree installs, see **[docs/install.md
 **Homebrew:**
 
 ```bash
-brew upgrade agentctl
+brew update && brew upgrade agentctl
 ```
 
 **Manual** — re-run the same `curl` command from Install to replace the binary.

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -32,7 +32,17 @@ func main() {
 		Short:   "Provision isolated git worktrees per issue and launch coding agents",
 		Long: `agentctl provisions isolated git worktrees per GitHub issue and launches
 coding agents inside each one. It supports multiple agent back-ends via
-a simple adapter registry and follows spec-driven development (SDD) by default.`,
+a simple adapter registry and supports optional spec-driven development (SDD) methodologies via --sdd.
+
+Examples:
+  # Start work on issue #42 (launches Claude Code in a new worktree)
+  agentctl start 42
+
+  # Check status of all active worktrees
+  agentctl status
+
+  # Merge and clean up when the PR for issue #42 is merged
+  agentctl cleanup-merged 42`,
 		SilenceUsage: true,
 	}
 


### PR DESCRIPTION
## Summary
- Fix misleading "SDD by default" wording — SDD is opt-in via `--sdd` since #70
- Add three getting-started examples to the root `agentctl` help output: start, status, cleanup-merged

## Test plan
- [x] Run `agentctl` (or `go run ./cmd/agentctl`) and verify the description and examples look correct
- [x] Confirm no mention of "by default" for SDD

🤖 Generated with [Claude Code](https://claude.com/claude-code)