### PR TITLE
feat: add --quiet flag to suppress log output and show spinner/heartbeat only

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,13 +9,14 @@ Run `agentctl --help` or `agentctl <command> --help` for generated help from the
 ### `agentctl start`
 
 ```bash
-agentctl start [--agent <name>] [--headless] [--sdd <name>] <issue-number> [slug]
+agentctl start [--agent <name>] [--headless] [--quiet] [--sdd <name>] <issue-number> [slug]
 ```
 
 Creates a linked worktree for a GitHub issue and launches the selected coding agent inside it.
 
 - `--agent <name>`: adapter name; default is `claude`. See [adapters.md](adapters.md) for available adapters.
 - `--headless`: run the agent in the background and write agent output to `agent.log`.
+- `--quiet`: suppress agent log output in the terminal; show only the spinner (TTY) or heartbeat lines (non-TTY/CI). Has no effect with `--headless`.
 - `--sdd <name>`: opt into an SDD methodology (e.g. `plain`, `speckit`, or a custom methodology). Omit to skip SDD and work directly toward a PR. See [sdd.md](sdd.md).
 - `<issue-number>`: GitHub issue number.
 - `[slug]`: optional branch/worktree slug. If omitted, `agentctl` uses `gh issue view` to fetch the issue title and derive a slug.
@@ -190,7 +191,13 @@ Error cases:
 agentctl start 42
 ```
 
-The agent runs interactively in your terminal. Without `--sdd`, the agent works directly toward a PR. Use `--sdd plain` or `--sdd speckit` to add a spec-review checkpoint.
+The agent runs in your terminal with its log streamed live so you can follow along. Without `--sdd`, the agent works directly toward a PR. Use `--sdd plain` or `--sdd speckit` to add a spec-review checkpoint.
+
+To suppress log output and show only a spinner/heartbeat:
+
+```bash
+agentctl start --quiet 42
+```
 
 After the PR is merged:
 
@@ -292,7 +299,7 @@ Each started worktree contains:
 
 ```text
 .agent          key=value metadata (agent, session-id, dev-pid, agent-pid)
-agent.log       coding-agent output in headless mode
+agent.log       coding-agent output (streamed to terminal in interactive mode; only file in headless mode)
 dev.log         dev-server output
 specs/          SDD spec artifacts (e.g. spec.md, plan.md, tasks.md) when using SDD
 ```

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -34,6 +34,7 @@ func NewStartCmd() *cobra.Command {
 	var (
 		agentName string
 		headless  bool
+		quiet     bool
 		sddName   string
 	)
 	c := &cobra.Command{
@@ -52,16 +53,17 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 			if len(args) > 1 {
 				slug = args[1]
 			}
-			return runStart(issue, slug, agentName, sddName, headless)
+			return runStart(issue, slug, agentName, sddName, headless, quiet)
 		},
 	}
 	c.Flags().StringVar(&agentName, "agent", "claude", "Coding agent adapter to use")
 	c.Flags().BoolVar(&headless, "headless", false, "Run agent in background (log -> agent.log)")
+	c.Flags().BoolVar(&quiet, "quiet", false, "Suppress agent log output; show spinner/heartbeat only")
 	c.Flags().StringVar(&sddName, "sdd", "", "SDD methodology to use (e.g. plain, speckit, or custom); omit to skip SDD")
 	return c
 }
 
-func runStart(issue, slug, agentName, sddName string, headless bool) error {
+func runStart(issue, slug, agentName, sddName string, headless, quiet bool) error {
 	// Validate the adapter exists before doing any setup work.
 	if err := validateAdapter(agentName); err != nil {
 		return err
@@ -185,7 +187,7 @@ func runStart(issue, slug, agentName, sddName string, headless bool) error {
 		kickoff = m.KickoffPrompt(issue, portStr)
 	}
 
-	return launchAgent(agentName, wtPath, issue, portStr, sessionID, kickoff, headless)
+	return launchAgent(agentName, wtPath, issue, portStr, sessionID, kickoff, headless, quiet)
 }
 
 // ─── approve-spec ─────────────────────────────────────────────────────────────
@@ -1009,8 +1011,9 @@ func findWorktreePath(issue string) (string, error) {
 
 // launchAgent starts the coding agent in the background via the named adapter,
 // then either returns immediately (headless) or streams agent.log to stdout
-// until the agent exits (non-headless).
-func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, headless bool) error {
+// until the agent exits (non-headless). quiet suppresses log lines, showing
+// only the spinner/heartbeat.
+func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, headless, quiet bool) error {
 	ad, err := adapters.Get(adapterName)
 	if err != nil {
 		return err
@@ -1064,7 +1067,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		followLog(logPath, os.Stdout, logDone)
+		followLog(logPath, os.Stdout, logDone, quiet)
 	}()
 
 	sigCh := make(chan os.Signal, 1)
@@ -1112,10 +1115,11 @@ var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "�
 // On a TTY the spinner is redrawn on the next 100 ms tick after a log line is
 // printed — there is intentionally no immediate redraw to keep the logic simple.
 //
-// After done is closed, any remaining content in the file is flushed to out.
+// When quiet is true, log lines are suppressed and only the spinner/heartbeat
+// is shown. After done is closed, any remaining content is flushed (unless quiet).
 // Note: agent-process hang-on-exit (issue #78) is a separate concern and is
 // not addressed here; that fix belongs in the process-monitoring loop.
-func followLog(logPath string, out io.Writer, done <-chan struct{}) {
+func followLog(logPath string, out io.Writer, done <-chan struct{}, quiet bool) {
 	f, err := os.Open(logPath)
 	if err != nil {
 		fmt.Fprintf(out, "warning: unable to follow log: %v\n", err)
@@ -1143,7 +1147,7 @@ func followLog(logPath string, out io.Writer, done <-chan struct{}) {
 	drainLines := func() {
 		for {
 			line, err := reader.ReadString('\n')
-			if line != "" {
+			if line != "" && !quiet {
 				clearSpinner()
 				fmt.Fprint(out, line)
 			}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -315,7 +315,7 @@ func writeLocalAdapter(t *testing.T, dir, name, content string) {
 
 func TestLaunchAgent_unknownAdapter(t *testing.T) {
 	dir := t.TempDir()
-	err := launchAgent("nonexistent-xyz-abc", dir, "42", "3010", "sess-123", "kickoff", true)
+	err := launchAgent("nonexistent-xyz-abc", dir, "42", "3010", "sess-123", "kickoff", true, false)
 	if err == nil {
 		t.Error("expected error for unknown adapter")
 	}
@@ -326,7 +326,7 @@ func TestLaunchAgent_binaryNotFound(t *testing.T) {
 	writeLocalAdapter(t, dir, "fakebinary", "binary: __nonexistent_binary_xyz__\n")
 	chdirTemp(t, dir)
 
-	err := launchAgent("fakebinary", dir, "42", "3010", "sess-123", "kickoff", true)
+	err := launchAgent("fakebinary", dir, "42", "3010", "sess-123", "kickoff", true, false)
 	if err == nil {
 		t.Fatal("expected error when binary not found")
 	}
@@ -342,7 +342,7 @@ func TestLaunchAgent_headless(t *testing.T) {
 		"binary: echo\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", true)
+	err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", true, false)
 	if err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
@@ -452,7 +452,7 @@ func TestFollowLog_drainsContentAndExits(t *testing.T) {
 	finished := make(chan struct{})
 	go func() {
 		defer close(finished)
-		followLog(logPath, &buf, done)
+		followLog(logPath, &buf, done, false)
 	}()
 
 	// Poll until followLog has picked up the initial content.
@@ -514,7 +514,7 @@ func TestFollowLog_heartbeatOnNonTTY(t *testing.T) {
 	finished := make(chan struct{})
 	go func() {
 		defer close(finished)
-		followLog(logPath, &buf, done)
+		followLog(logPath, &buf, done, false)
 	}()
 
 	// The first heartbeat is emitted immediately (lastHeartbeat starts 30s in the
@@ -530,6 +530,37 @@ func TestFollowLog_heartbeatOnNonTTY(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "agent running...") {
 		t.Errorf("expected heartbeat line in non-terminal output; got: %q", out)
+	}
+}
+
+// TestFollowLog_quietSuppressesLogLines verifies that log content is not written
+// to out when quiet is true, but the heartbeat still appears.
+func TestFollowLog_quietSuppressesLogLines(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.log")
+	if err := os.WriteFile(logPath, []byte("secret line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		followLog(logPath, &buf, done, true)
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	close(done)
+	<-finished
+
+	out := buf.String()
+	if strings.Contains(out, "secret line") {
+		t.Errorf("quiet mode should suppress log lines; got: %q", out)
+	}
+	if !strings.Contains(out, "agent running...") {
+		t.Errorf("quiet mode should still show heartbeat; got: %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Default behaviour: agent log lines are streamed to the console in real time (addresses review feedback on #79)
- `--quiet`: suppresses log output — shows only the spinner (TTY) or heartbeat lines (non-TTY)

## Changes
- `NewStartCmd`: adds `--quiet bool` flag
- `runStart` / `launchAgent` / `followLog`: thread `quiet` through; in `drainLines`, skip `fmt.Fprint` when `quiet` is true
- New test `TestFollowLog_quietSuppressesLogLines`: verifies log lines are suppressed and heartbeat still appears

## Usage
```
agentctl start 42           # streams agent log + spinner (default)
agentctl start 42 --quiet   # spinner/heartbeat only, no log output
```

## Test plan
- [x] `go test ./internal/cmd/... -run "TestFollowLog|TestLaunchAgent"` — all pass
- [ ] Run `agentctl start <issue>` and verify agent log lines appear in the terminal
- [ ] Run `agentctl start <issue> --quiet` and verify only the spinner/heartbeat is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)