### PR TITLE
feat: log agent non-zero exit code to stderr

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1054,7 +1054,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 	exitCh := make(chan struct{})
 	go func() {
 		if err := agentCmd.Wait(); err != nil {
-			fmt.Fprintf(os.Stderr, "agent exited with error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "agent exited: %v\n", err)
 		}
 		close(exitCh)
 	}()

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1043,8 +1043,21 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 	logFile.Close()
 
 	pid := agentCmd.Process.Pid
-	// Release our reference to the process handle; monitoring is done via PID.
-	_ = agentCmd.Process.Release()
+	// Do NOT call Process.Release(): we need to call Wait() below to properly
+	// reap the child. Releasing the handle prevents Wait() from working, and
+	// kill(0) polling on a zombie process always returns success — causing the
+	// monitor loop to spin forever after the agent exits.
+
+	// Reap the child in a background goroutine and signal exitCh when done.
+	// Using Wait() instead of kill-0 polling is the reliable way to detect
+	// process exit regardless of session/launchd topology.
+	// The exit error is discarded: the agent's stdout/stderr is already
+	// captured in agent.log, so the exit code adds no new information here.
+	exitCh := make(chan struct{})
+	go func() {
+		_ = agentCmd.Wait()
+		close(exitCh)
+	}()
 
 	// Record the agent PID in .agent (core fields were already written by runStart).
 	if err := state.AppendKey(wtPath, "agent-pid", strconv.Itoa(pid)); err != nil {
@@ -1072,23 +1085,21 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	pidStr := strconv.Itoa(pid)
-	for process.IsAlive(pidStr) {
+	for {
 		select {
+		case <-exitCh:
+			signal.Stop(sigCh)
+			close(logDone)
+			wg.Wait()
+			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)
 			close(logDone)
 			wg.Wait()
 			fmt.Fprintf(os.Stdout, "agent still running in background (pid %d)\n", pid)
 			return nil
-		case <-time.After(500 * time.Millisecond):
 		}
 	}
-	signal.Stop(sigCh)
-
-	close(logDone)
-	wg.Wait()
-	return nil
 }
 
 // waitForFile polls until path exists or the timeout elapses.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1055,7 +1055,9 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 	// captured in agent.log, so the exit code adds no new information here.
 	exitCh := make(chan struct{})
 	go func() {
-		_ = agentCmd.Wait()
+		if err := agentCmd.Wait(); err != nil {
+			fmt.Fprintf(os.Stderr, "agent exited with error: %v\n", err)
+		}
 		close(exitCh)
 	}()
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1051,8 +1051,6 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 	// Reap the child in a background goroutine and signal exitCh when done.
 	// Using Wait() instead of kill-0 polling is the reliable way to detect
 	// process exit regardless of session/launchd topology.
-	// The exit error is discarded: the agent's stdout/stderr is already
-	// captured in agent.log, so the exit code adds no new information here.
 	exitCh := make(chan struct{})
 	go func() {
 		if err := agentCmd.Wait(); err != nil {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -381,7 +381,22 @@ func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 			t.Fatalf("launchAgent non-headless: %v", err)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("launchAgent did not return after agent process exited — would have required Ctrl+C before the fix")
+		// Ensure the goroutine running launchAgent is told to shut down before
+		// failing the test, otherwise it can outlive this test and hang the
+		// overall `go test` run until the global timeout.
+		if p, err := os.FindProcess(os.Getpid()); err == nil {
+			_ = p.Signal(os.Interrupt)
+		}
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("launchAgent did not return after agent process exited and cleanup returned error: %v", err)
+			}
+			t.Fatal("launchAgent did not return after agent process exited — required interrupt-driven cleanup before failing")
+		case <-time.After(2 * time.Second):
+			t.Fatal("launchAgent did not return after agent process exited, and did not exit after interrupt-driven cleanup")
+		}
 	}
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -381,9 +381,11 @@ func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 			t.Fatalf("launchAgent non-headless: %v", err)
 		}
 	case <-time.After(5 * time.Second):
-		// Ensure the goroutine running launchAgent is told to shut down before
-		// failing the test, otherwise it can outlive this test and hang the
-		// overall `go test` run until the global timeout.
+		// launchAgent listens on sigCh for os.Interrupt/SIGTERM to unblock its
+		// select loop. Sending SIGINT to this process delivers it to sigCh via
+		// signal.Notify, which causes launchAgent to return — letting the goroutine
+		// above exit cleanly rather than leaking into subsequent tests or hanging
+		// the full `go test` run until the global timeout.
 		if p, err := os.FindProcess(os.Getpid()); err == nil {
 			_ = p.Signal(os.Interrupt)
 		}
@@ -401,6 +403,46 @@ func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 }
 
 // ─── agentResume ─────────────────────────────────────────────────────────────
+
+func TestLaunchAgent_nonZeroExitLogsToStderr(t *testing.T) {
+	dir := t.TempDir()
+	// Use `false` as the agent binary — always exits with code 1.
+	writeLocalAdapter(t, dir, "falseagent", "binary: false\n")
+	chdirTemp(t, dir)
+
+	// Redirect os.Stderr to a pipe so we can capture the error message.
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = oldStderr })
+
+	// Run launchAgent in non-headless mode. It returns only after exitCh is
+	// closed, which happens after fmt.Fprintf(os.Stderr, ...) in the reaper
+	// goroutine — so by the time launchAgent returns, the message is already
+	// captured in the pipe.
+	launchErr := launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", false, false)
+
+	// Close the write end and restore stderr before reading.
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("reading captured stderr: %v", err)
+	}
+	r.Close()
+
+	// launchAgent itself does not return the agent's exit code as an error.
+	if launchErr != nil {
+		t.Fatalf("launchAgent: unexpected error: %v", launchErr)
+	}
+	if !strings.Contains(buf.String(), "agent exited") {
+		t.Errorf("expected 'agent exited' on stderr for non-zero exit, got: %q", buf.String())
+	}
+}
 
 func TestAgentResume_unknownAdapter(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -360,6 +360,31 @@ func TestLaunchAgent_headless(t *testing.T) {
 	}
 }
 
+func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
+	dir := t.TempDir()
+	// Use `echo` as the agent binary — always on PATH, exits immediately.
+	writeLocalAdapter(t, dir, "echoagent",
+		"binary: echo\nsession: --session\n")
+	chdirTemp(t, dir)
+
+	// Run launchAgent in non-headless mode in a goroutine; it must return
+	// automatically once the agent process (echo) exits, without requiring
+	// Ctrl+C or any other intervention.
+	done := make(chan error, 1)
+	go func() {
+		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", false, false)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("launchAgent non-headless: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("launchAgent did not return after agent process exited — would have required Ctrl+C before the fix")
+	}
+}
+
 // ─── agentResume ─────────────────────────────────────────────────────────────
 
 func TestAgentResume_unknownAdapter(t *testing.T) {


### PR DESCRIPTION
## Summary
- Surface non-zero exit codes from the agent process to stderr so developers know when the agent failed vs succeeded
- Previously `agentCmd.Wait()` error was silently discarded (`_ = agentCmd.Wait()`)

## Change
```go
// Before
_ = agentCmd.Wait()

// After
if err := agentCmd.Wait(); err != nil {
    fmt.Fprintf(os.Stderr, "agent exited with error: %v\n", err)
}
```

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/cmd/... -run TestLaunchAgent` — all pass
- [ ] Run `agentctl start <issue>` with a successful agent run — no error line printed
- [ ] Simulate a failing agent — confirm error line appears on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Review done by Claude (claude-sonnet-4-6) via [Claude Code](https://claude.ai/code)._