### PR TITLE
docs: add GitHub URL example to Quick start; fix agent.log description

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ brew update && brew upgrade agentctl
 
 ## Quick start
 
-Run commands from your **application** repository (the primary git worktree):
-
 ```bash
+# From your application repo's primary worktree
 cd /path/to/your/app-repo
 agentctl start 42
+
+# Or from anywhere, using a full GitHub issue URL
+agentctl start https://github.com/owner/repo/issues/42
+
 agentctl cleanup-merged 42
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ agentctl start 42
 # Or from anywhere, using a full GitHub issue URL
 agentctl start https://github.com/owner/repo/issues/42
 
+# Back in your application repo's primary worktree
+cd /path/to/your/app-repo
 agentctl cleanup-merged 42
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,7 +176,7 @@ When `agentctl start <issue>` runs, it creates a linked worktree at `../<repo>-<
 
 ```
 .agent          ← key=value metadata (agent, port, session-id, agent-pid, dev-pid)
-agent.log       ← agent stdout/stderr (headless mode)
+agent.log       ← agent stdout/stderr (streamed to terminal in interactive mode; file only in headless mode)
 specs/          ← SDD artefacts (spec.md, plan.md, tasks.md)
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,7 +176,7 @@ When `agentctl start <issue>` runs, it creates a linked worktree at `../<repo>-<
 
 ```
 .agent          ← key=value metadata (agent, port, session-id, agent-pid, dev-pid)
-agent.log       ← agent stdout/stderr (streamed to terminal in interactive mode; file only in headless mode)
+agent.log       ← agent stdout/stderr (always written to this file; interactive mode also streams it to the terminal unless `--quiet` is used)
 specs/          ← SDD artefacts (spec.md, plan.md, tasks.md)
 ```
 


### PR DESCRIPTION
## Summary

- Adds GitHub issue URL example to README Quick start (the most significant DX change from this session)
- Removes the now-inaccurate "Run commands from your application repository" constraint from the Quick start intro
- Fixes `agent.log` description in `docs/development.md` worktree layout table to say it's used in both interactive and headless modes (was incorrectly labelled "headless mode" only)

## Test plan

- [ ] Read README Quick start and confirm both forms (`42` and full URL) are shown
- [ ] Read `docs/development.md` Worktree layout and confirm `agent.log` description matches `docs/cli.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)