### PR TITLE
feat: auto-merge Homebrew bump PR when tap CI passes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
           git push origin "$BRANCH"
           echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
 
-      - name: Open PR
+      - name: Open PR and enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           VERSION: ${{ github.ref_name }}
@@ -173,3 +173,8 @@ jobs:
             --base main \
             --title "feat: bump agentctl to ${VERSION}" \
             --body "Automated formula bump for [${VERSION}](https://github.com/arun-gupta/agentctl/releases/tag/${VERSION})."
+          gh pr merge \
+            --repo arun-gupta/homebrew-tap \
+            --head "$BRANCH" \
+            --auto \
+            --merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,6 @@ jobs:
             --body "Automated formula bump for [${VERSION}](https://github.com/arun-gupta/agentctl/releases/tag/${VERSION})."
           gh pr merge \
             --repo arun-gupta/homebrew-tap \
-            --head "$BRANCH" \
             --auto \
-            --merge
+            --merge \
+            "$BRANCH"

--- a/docs/development.md
+++ b/docs/development.md
@@ -108,8 +108,8 @@ tag push
   └─▶ release workflow (release.yml)
         ├─▶ build jobs          — builds archives for all platforms
         ├─▶ release job         — publishes GitHub Release with archives + checksums
-        └─▶ bump-homebrew job   — opens a PR in homebrew-tap with updated version + SHA256s
-              └─▶ tap CI        — brew audit + brew install smoke test on the bump PR
+        └─▶ bump-homebrew job   — opens a PR in homebrew-tap, enables auto-merge
+              └─▶ tap CI        — brew audit + brew install; auto-merges on green
 ```
 
 **release workflow** ([`.github/workflows/release.yml`](../.github/workflows/release.yml))
@@ -118,13 +118,13 @@ tag push
 
 *`release` job* — Downloads all build artifacts, generates `checksums.txt` (SHA256 per archive), and publishes the GitHub Release.
 
-*`bump-homebrew` job* — Runs after `release`; downloads `checksums.txt` from the new release, patches `version` and `sha256` values in `Formula/agentctl.rb` in [homebrew-tap](https://github.com/arun-gupta/homebrew-tap), and opens a PR (`bump/agentctl-vX.Y.Z`) for review.
+*`bump-homebrew` job* — Runs after `release`; downloads `checksums.txt` from the new release, patches `version` and `sha256` values in `Formula/agentctl.rb` in [homebrew-tap](https://github.com/arun-gupta/homebrew-tap), opens a PR (`bump/agentctl-vX.Y.Z`), and enables auto-merge so it merges automatically once tap CI passes.
 
 > **Note:** The `bump-homebrew` job runs in the same workflow as `release` to avoid GitHub's restriction that prevents workflows triggered by `GITHUB_TOKEN` from cascading to other workflows via repository events.
 
 Requires the `HOMEBREW_TAP_TOKEN` secret — a fine-grained PAT scoped to the homebrew-tap repository with **contents** and **pull-requests** write permission. Set it in **Settings → Secrets and variables → Actions** of this repository.
 
-Merge the bump PR in homebrew-tap once tap CI is green. Use `v<major>.<minor>.0` for a new release (e.g. `v0.2.0`, `v0.3.0`).
+Use `v<major>.<minor>.0` for a new release (e.g. `v0.2.0`, `v0.3.0`).
 
 ## CI
 


### PR DESCRIPTION
## Summary

- Adds `gh pr merge --auto --merge` after `gh pr create` in the `bump-homebrew` job so the formula bump PR in homebrew-tap merges automatically once tap CI (brew audit + brew install) passes — no manual step required
- Updates `docs/development.md` to reflect that the bump PR now auto-merges instead of requiring a manual merge

## Test plan

- [ ] Push a `v*` tag and confirm the `bump-homebrew` job opens a PR in homebrew-tap with auto-merge enabled
- [ ] Confirm the PR merges automatically once tap CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)