### PR TITLE
fix: remove hardcoded line breaks from root help description

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -30,12 +30,8 @@ func main() {
 		Use:     "agentctl",
 		Version: version,
 		Short:   "Provision isolated git worktrees per issue and launch coding agents",
-		Long: `agentctl provisions isolated git worktrees per GitHub issue and launches
-coding agents inside each one. It supports multiple agent back-ends via
-a simple adapter registry and supports optional spec-driven development (SDD) methodologies via --sdd.
-
-Examples:
-  # Start work on issue #42 (launches Claude Code in a new worktree)
+		Long: `agentctl provisions isolated git worktrees per GitHub issue and launches coding agents inside each one. It supports multiple agent back-ends via a simple adapter registry and supports optional spec-driven development (SDD) methodologies via --sdd.`,
+		Example: `  # Start work on issue #42 (launches Claude Code in a new worktree)
   agentctl start 42
 
   # Check status of all active worktrees

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -30,7 +30,7 @@ func main() {
 		Use:     "agentctl",
 		Version: version,
 		Short:   "Provision isolated git worktrees per issue and launch coding agents",
-		Long: `agentctl provisions isolated git worktrees per GitHub issue and launches coding agents inside each one. It supports multiple agent back-ends via a simple adapter registry and supports optional spec-driven development (SDD) methodologies via --sdd.`,
+		Long: `agentctl provisions isolated git worktrees per GitHub issue and launches coding agents inside each one. It supports multiple agent back-ends via a simple adapter registry and supports optional spec-driven development (SDD) methodologies through the start command (for example, agentctl start --sdd <name>).`,
 		Example: `  # Start work on issue #42 (launches Claude Code in a new worktree)
   agentctl start 42
 


### PR DESCRIPTION
## Summary

- Removes the manually inserted `\n` characters from the `Long` description in `main.go`. Cobra renders `Long` verbatim, so the fixed-width line breaks caused the text to wrap at ~70 chars regardless of terminal width, producing the ragged output visible in the screenshot.
- Moves the examples out of `Long` and into the separate `Example` field, which Cobra formats under its own "Examples:" header — keeping the output structure identical but now driven by Cobra rather than a manual header string inside `Long`.

## Before / After

**Before** — wraps at ~70 chars, last line overruns:
```
agentctl provisions isolated git worktrees per GitHub issue and launches
coding agents inside each one. It supports multiple agent back-ends via
a simple adapter registry and supports optional spec-driven development (SDD) methodologies via --sdd.
```

**After** — single paragraph, terminal wraps at its own width:
```
agentctl provisions isolated git worktrees per GitHub issue and launches coding agents inside each one. It supports multiple agent back-ends via a simple adapter registry and supports optional spec-driven development (SDD) methodologies via --sdd.
```

## Test plan

- [ ] `go build -o /tmp/agentctl ./cmd/agentctl && /tmp/agentctl --help` and confirm the description flows as one paragraph that wraps at the terminal width

🤖 Generated with [Claude Code](https://claude.com/claude-code)