### PR TITLE
feat: stream agent output progressively in interactive mode

### DIFF
--- a/internal/adapters/builtin/claude.yml
+++ b/internal/adapters/builtin/claude.yml
@@ -1,4 +1,4 @@
 binary: claude
-launch: claude --permission-mode bypassPermissions --verbose -p {kickoff} --session-id {session_id}
+launch: claude --permission-mode bypassPermissions -p {kickoff} --session-id {session_id}
 resume_cmd: claude -p {prompt} --resume {session_id}
 install: npm install -g @anthropic-ai/claude-code

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1135,16 +1136,60 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 	if err != nil {
 		return fmt.Errorf("create agent.log: %w", err)
 	}
-	agentCmd.Stdout = logFile
-	agentCmd.Stderr = logFile
+
+	// In interactive mode, capture output through a pipe so we can parse
+	// stream-json events and write human-readable text to the log file
+	// progressively. In headless mode the agent writes directly to the file.
+	var pr, pw *os.File
+	if !headless {
+		pr, pw, err = os.Pipe()
+		if err != nil {
+			logFile.Close()
+			return fmt.Errorf("os.Pipe: %w", err)
+		}
+		agentCmd.Args = append(agentCmd.Args, "--output-format", "stream-json")
+		agentCmd.Stdout = pw
+		agentCmd.Stderr = pw
+	} else {
+		agentCmd.Stdout = logFile
+		agentCmd.Stderr = logFile
+	}
+
 	detachProcess(agentCmd)
 
 	if err := agentCmd.Start(); err != nil {
+		if pw != nil {
+			pw.Close()
+			pr.Close()
+		}
 		logFile.Close()
 		return fmt.Errorf("agent failed to start: %w", err)
 	}
-	// The child process inherits the fd; close our copy.
-	logFile.Close()
+
+	// convWg tracks the converter goroutine so we can drain all remaining pipe
+	// content into the log file before signalling followLog to do its final read.
+	var convWg sync.WaitGroup
+	if headless {
+		// The child process inherits the fd; close our copy.
+		logFile.Close()
+	} else {
+		// Close the write end in the parent; the child has its own copy.
+		pw.Close()
+		// Convert JSON stream events to readable text written to logFile.
+		convWg.Add(1)
+		go func() {
+			defer convWg.Done()
+			defer pr.Close()
+			defer logFile.Close()
+			sc := bufio.NewScanner(pr)
+			sc.Buffer(make([]byte, 512*1024), 512*1024)
+			for sc.Scan() {
+				if text := extractStreamText(sc.Text()); text != "" {
+					fmt.Fprintln(logFile, text)
+				}
+			}
+		}()
+	}
 
 	pid := agentCmd.Process.Pid
 	// Do NOT call Process.Release(): we need to call Wait() below to properly
@@ -1193,6 +1238,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 		select {
 		case <-exitCh:
 			signal.Stop(sigCh)
+			convWg.Wait() // drain remaining pipe → log before the final read
 			close(logDone)
 			wg.Wait()
 			return nil
@@ -1216,6 +1262,46 @@ func waitForFile(path string, timeout time.Duration) error {
 		time.Sleep(100 * time.Millisecond)
 	}
 	return fmt.Errorf("%s did not appear within %s", path, timeout)
+}
+
+// extractStreamText converts a single claude --output-format stream-json line
+// into human-readable text. It extracts assistant text/tool-use blocks and the
+// final result. Non-JSON lines are returned as-is (plain-text fallback).
+func extractStreamText(line string) string {
+	var ev struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+		Message struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+				Name string `json:"name"`
+			} `json:"content"`
+		} `json:"message"`
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(line), &ev); err != nil {
+		return strings.TrimSpace(line) // not JSON — pass through verbatim
+	}
+	switch ev.Type {
+	case "assistant":
+		var sb strings.Builder
+		for _, c := range ev.Message.Content {
+			switch c.Type {
+			case "text":
+				if t := strings.TrimSpace(c.Text); t != "" {
+					sb.WriteString(t)
+					sb.WriteByte('\n')
+				}
+			case "tool_use":
+				fmt.Fprintf(&sb, "[%s]\n", c.Name)
+			}
+		}
+		return strings.TrimRight(sb.String(), "\n")
+	case "result":
+		return strings.TrimSpace(ev.Result)
+	}
+	return ""
 }
 
 // spinnerFrames are the braille Unicode characters used for the spinner animation.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1147,7 +1147,11 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			logFile.Close()
 			return fmt.Errorf("os.Pipe: %w", err)
 		}
-		agentCmd.Args = append(agentCmd.Args, "--output-format", "stream-json")
+		// --output-format stream-json is a Claude-specific flag; only inject it
+		// for the claude adapter to avoid unknown-flag errors with other adapters.
+		if adapterName == "claude" {
+			agentCmd.Args = append(agentCmd.Args, "--output-format", "stream-json")
+		}
 		agentCmd.Stdout = pw
 		agentCmd.Stderr = pw
 	} else {
@@ -1290,7 +1294,7 @@ func extractStreamText(line string) string {
 		Result string `json:"result"`
 	}
 	if err := json.Unmarshal([]byte(line), &ev); err != nil {
-		return strings.TrimSpace(line) // not JSON — pass through verbatim
+		return line // not JSON — pass through verbatim
 	}
 	switch ev.Type {
 	case "assistant":

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1181,11 +1181,20 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			defer convWg.Done()
 			defer pr.Close()
 			defer logFile.Close()
-			sc := bufio.NewScanner(pr)
-			sc.Buffer(make([]byte, 512*1024), 512*1024)
-			for sc.Scan() {
-				if text := extractStreamText(sc.Text()); text != "" {
-					fmt.Fprintln(logFile, text)
+
+			r := bufio.NewReader(pr)
+			for {
+				line, err := r.ReadString('\n')
+				if line != "" {
+					if text := extractStreamText(strings.TrimSuffix(line, "\n")); text != "" {
+						fmt.Fprintln(logFile, text)
+					}
+				}
+				if err != nil {
+					if !errors.Is(err, io.EOF) {
+						fmt.Fprintf(logFile, "converter read error: %v\n", err)
+					}
+					break
 				}
 			}
 		}()

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1155,6 +1155,12 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 		agentCmd.Stdout = pw
 		agentCmd.Stderr = pw
 	} else {
+		// --verbose is Claude-specific; inject it for headless Claude runs so
+		// agent.log receives the same verbose output as before this feature was
+		// introduced. Interactive mode uses --output-format stream-json instead.
+		if adapterName == "claude" {
+			agentCmd.Args = append(agentCmd.Args, "--verbose")
+		}
 		agentCmd.Stdout = logFile
 		agentCmd.Stderr = logFile
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1001,3 +1001,60 @@ func TestAttachLog_agentRunning(t *testing.T) {
 		t.Errorf("attachLog took too long (%v)", elapsed)
 	}
 }
+
+func TestExtractStreamText(t *testing.T) {
+	cases := []struct {
+		name  string
+		line  string
+		want  string
+	}{
+		{
+			name:  "assistant text",
+			line:  `{"type":"assistant","message":{"content":[{"type":"text","text":"I'll fix the bug."}]}}`,
+			want:  "I'll fix the bug.",
+		},
+		{
+			name:  "assistant tool_use",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"bash","input":{"command":"ls"}}]}}`,
+			want:  "[bash]",
+		},
+		{
+			name:  "assistant text + tool_use",
+			line:  `{"type":"assistant","message":{"content":[{"type":"text","text":"Running ls."},{"type":"tool_use","name":"bash","input":{}}]}}`,
+			want:  "Running ls.\n[bash]",
+		},
+		{
+			name:  "result success",
+			line:  `{"type":"result","subtype":"success","result":"PR opened."}`,
+			want:  "PR opened.",
+		},
+		{
+			name:  "system event skipped",
+			line:  `{"type":"system","subtype":"init","model":"claude-opus-4-5"}`,
+			want:  "",
+		},
+		{
+			name:  "user event skipped",
+			line:  `{"type":"user","message":{"role":"user","content":[]}}`,
+			want:  "",
+		},
+		{
+			name:  "non-JSON passed through",
+			line:  "plain text output",
+			want:  "plain text output",
+		},
+		{
+			name:  "empty assistant text skipped",
+			line:  `{"type":"assistant","message":{"content":[{"type":"text","text":"   "}]}}`,
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractStreamText(tc.line)
+			if got != tc.want {
+				t.Errorf("extractStreamText(%q) = %q, want %q", tc.line, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- In interactive mode (`agentctl start` without `--headless`), captures agent stdout/stderr via an OS pipe instead of directing to the log file. Appends `--output-format stream-json` to the claude adapter args so claude emits JSON stream events as it executes.
- A converter goroutine reads JSON events from the pipe, extracts human-readable text (`assistant` text/tool-use blocks and the final `result`), and writes it to `agent.log` progressively. `followLog` then streams that content to the terminal as it appears.
- A `convWg` wait group ensures all buffered pipe data is drained into the log file before `followLog` does its final read on agent exit — no content is lost at the boundary.
- Headless mode is unchanged: the agent writes its output directly to `agent.log`; no pipe, no stream-json injection.
- Removes `--verbose` from the claude adapter (superseded by `--output-format stream-json`).
- Adds `TestExtractStreamText` covering assistant text, tool-use, result, system/user skip, non-JSON passthrough, and empty text cases.

## Before

Agent ran silently for the entire duration; only the final summary appeared at the very end (buffered, written all at once when claude exited).

## After

Assistant reasoning, tool calls (`[bash]`, `[write_file]`, …), and the final result are written to `agent.log` as each JSON event arrives, and streamed to the terminal in real-time alongside the spinner.

## Test plan

- [ ] `go test ./...` — no new failures
- [ ] Run `agentctl start <issue>` on a real issue and confirm tool calls and assistant text appear progressively in the terminal during the agent run
- [ ] Confirm `--headless` mode is unaffected (agent.log has plain-text final output, no JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)