### PR TITLE
feat: combine cleanup-merged + cleanup-all-merged into cleanup [--all]

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ agentctl start https://github.com/owner/repo/issues/42
 
 # Back in your application repo's primary worktree
 cd /path/to/your/app-repo
-agentctl cleanup-merged 42
+agentctl cleanup 42
 ```
 
 `agentctl --help` and `agentctl <command> --help` list all flags.

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -7,8 +7,7 @@
 //	agentctl approve-spec  <issue>
 //	agentctl revise-spec   <issue> <feedback>
 //	agentctl discard       [issue]
-//	agentctl cleanup-merged [issue]
-//	agentctl cleanup-all-merged
+//	agentctl cleanup       [issue | --all]
 //	agentctl status [--verbose]
 //	agentctl logs   [--lines N] [--no-follow] <issue>
 //	agentctl attach <issue>
@@ -37,8 +36,8 @@ func main() {
   # Check status of all active worktrees
   agentctl status
 
-  # Merge and clean up when the PR for issue #42 is merged
-  agentctl cleanup-merged 42`,
+  # Clean up after the PR for issue #42 is merged
+  agentctl cleanup 42`,
 		SilenceUsage: true,
 	}
 
@@ -47,8 +46,7 @@ func main() {
 		cmd.NewApproveSpecCmd(),
 		cmd.NewReviseSpecCmd(),
 		cmd.NewDiscardCmd(),
-		cmd.NewCleanupMergedCmd(),
-		cmd.NewCleanupAllMergedCmd(),
+		cmd.NewCleanupCmd(),
 		cmd.NewStatusCmd(),
 		cmd.NewLogsCmd(),
 		cmd.NewAttachCmd(),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,10 +86,11 @@ Spec states:
 
 PR states come from `gh pr view <branch>` and are usually `none`, `OPEN`, `MERGED`, or `CLOSED`.
 
-### `agentctl cleanup-merged`
+### `agentctl cleanup`
 
 ```bash
-agentctl cleanup-merged [issue-number]
+agentctl cleanup [issue-number]
+agentctl cleanup --all
 ```
 
 Cleans up a worktree after its PR is merged.
@@ -104,17 +105,9 @@ Behavior:
 - Removes the linked worktree.
 - Deletes local and remote branches.
 
+Use `--all` to scan all linked worktrees and run the cleanup flow for every branch whose PR state is `MERGED`. Branches without PRs, unmerged PRs, detached worktrees, or branches without a numeric issue prefix are skipped.
+
 If the PR is not merged, use `agentctl discard` for abandoned work.
-
-### `agentctl cleanup-all-merged`
-
-```bash
-agentctl cleanup-all-merged
-```
-
-Scans linked worktrees and runs the merged cleanup flow for each branch whose PR state is `MERGED`.
-
-Branches without PRs, unmerged PRs, detached worktrees, or branches without a numeric issue prefix are skipped.
 
 ### `agentctl discard`
 
@@ -126,7 +119,7 @@ Permanently discards a worktree and deletes local/remote branches. This is unrec
 
 Use this for abandoned or failed work where the PR should not be merged.
 
-Like `cleanup-merged`, the issue number can be inferred from the current branch when run inside a linked worktree.
+Like `cleanup`, the issue number can be inferred from the current branch when run inside a linked worktree.
 
 ### `agentctl logs`
 
@@ -205,7 +198,7 @@ agentctl start --quiet 42
 After the PR is merged:
 
 ```bash
-agentctl cleanup-merged 42
+agentctl cleanup 42
 ```
 
 ### Headless single-issue workflow
@@ -228,7 +221,7 @@ agentctl approve-spec 42
 agentctl revise-spec 42 "Narrow scope to the API layer; avoid UI changes."
 
 # Clean up after merge
-agentctl cleanup-merged 42
+agentctl cleanup 42
 ```
 
 ### Batch headless workflow
@@ -249,7 +242,7 @@ agentctl status
 agentctl status --verbose
 
 # Sweep merged PRs
-agentctl cleanup-all-merged
+agentctl cleanup --all
 ```
 
 ### Spec-driven development (SDD)
@@ -282,7 +275,7 @@ Run cleanup/discard from inside a linked worktree without passing the issue numb
 
 ```bash
 cd ../myrepo-42-my-feature
-agentctl cleanup-merged
+agentctl cleanup
 # or
 agentctl discard
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -197,5 +197,5 @@ Functions in `internal/git` that shell out to the `git` CLI are tested with real
 ### What is not tested (and why)
 
 - **Cobra command wiring** (`cmd/agentctl/main.go`): the entry point is a thin dispatch layer; coverage comes from the `internal/cmd` tests above.
-- **`runStart`, `runCleanupMerged`, `runStatus`**: these call `gh`, `npm`, `lsof`, and `uuidgen`; stub-based integration tests are tracked in [#19](https://github.com/arun-gupta/agentctl/issues/19).
+- **`runStart`, `runCleanupMerged`, `runStatus`**: these call `gh`, `npm`, `lsof`, and `uuidgen`; stub-based integration tests are tracked in [#19](https://github.com/arun-gupta/agentctl/issues/19). (`runCleanupMerged` backs the `cleanup` command.)
 - **`ghPRState`, `slugFromIssue`**: require a real `gh` authentication context; not suitable for CI without credentials.

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,7 +9,7 @@ How to install **agentctl** and what you need on your machine.
 | Requirement | Purpose |
 |-------------|---------|
 | `git` ≥ 2.5 | worktree support |
-| `gh` CLI | PR management (`cleanup-merged`, `status`), slug-from-title |
+| `gh` CLI | PR management (`cleanup`, `status`), slug-from-title |
 
 ### Required for the default workflow
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -386,24 +386,37 @@ func runRemoveWorktree(issue string) error {
 // ─── cleanup-merged ───────────────────────────────────────────────────────────
 
 // NewCleanupMergedCmd creates the `cleanup-merged` subcommand.
-func NewCleanupMergedCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "cleanup-merged [issue]",
-		Short: "Post-merge: pull main, remove worktree, delete local+remote branch",
-		Long: `Post-merge cleanup for a specific issue: pull main, remove the worktree,
-and delete the local and remote branches.
+// NewCleanupCmd creates the `cleanup` subcommand.
+// With --all it sweeps all merged worktrees; otherwise it cleans up a single issue.
+func NewCleanupCmd() *cobra.Command {
+	var all bool
+	c := &cobra.Command{
+		Use:   "cleanup [issue]",
+		Short: "Remove a merged worktree and its branches",
+		Long: `Post-merge cleanup: pull main, remove the worktree, and delete the local
+and remote branches.
 
-If no issue number is given, it is inferred from the current branch when
-you are inside a linked worktree.`,
+Run without arguments inside a linked worktree to infer the issue number
+from the current branch.
+
+Use --all to sweep every linked worktree whose PR is MERGED in one pass.`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			issue, err := resolveIssueArg("cleanup-merged", args)
+			if all {
+				if len(args) > 0 {
+					return fmt.Errorf("--all and an issue number are mutually exclusive")
+				}
+				return runCleanupAllMerged()
+			}
+			issue, err := resolveIssueArg("cleanup", args)
 			if err != nil {
 				return err
 			}
 			return runCleanupMerged(issue)
 		},
 	}
+	c.Flags().BoolVar(&all, "all", false, "Clean up all worktrees whose PR is MERGED")
+	return c
 }
 
 func runCleanupMerged(issue string) error {
@@ -526,19 +539,7 @@ func cleanupMerged(repoRoot, issue string) error {
 	return nil
 }
 
-// ─── cleanup-all-merged ───────────────────────────────────────────────────────
-
-// NewCleanupAllMergedCmd creates the `cleanup-all-merged` subcommand.
-func NewCleanupAllMergedCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "cleanup-all-merged",
-		Short: "Batch sweep: run cleanup-merged on every worktree whose PR is MERGED",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCleanupAllMerged()
-		},
-	}
-}
+// ─── cleanup (--all sweep) ────────────────────────────────────────────────────
 
 func runCleanupAllMerged() error {
 	repoRoot, err := git.RepoRoot()


### PR DESCRIPTION
## Summary

- Replaces `cleanup-merged` and `cleanup-all-merged` with a single `cleanup` command
- `agentctl cleanup [issue]` — cleans up a specific merged worktree (issue inferred from branch when inside a worktree)
- `agentctl cleanup --all` — sweeps all linked worktrees whose PR is `MERGED`
- `--all` and an explicit issue number are mutually exclusive (returns an error if both are given)
- All docs updated: `README.md`, `docs/cli.md`, `docs/install.md`, `docs/development.md`
- No backward-compat aliases

## Test plan

- [ ] `agentctl cleanup 42` cleans up issue 42's worktree
- [ ] `agentctl cleanup` from inside a linked worktree infers the issue from the branch
- [ ] `agentctl cleanup --all` sweeps all merged worktrees
- [ ] `agentctl cleanup --all 42` returns an error
- [ ] `agentctl --help` shows `cleanup` (not the old two commands)
- [ ] `agentctl cleanup --help` shows the `--all` flag and correct description

🤖 Generated with [Claude Code](https://claude.com/claude-code)