### PR TITLE
feat: require explicit --sdd=<name>; improve error message; arg-first convention

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,7 @@ Run `agentctl --help` or `agentctl <command> --help` for generated help from the
 ### `agentctl start`
 
 ```bash
-agentctl start [--agent <name>] [--headless] [--quiet] [--sdd <name>] <issue-number-or-url> [slug]
+agentctl start [--agent <name>] [--headless] [--quiet] <issue-number-or-url> [slug] [--sdd=<name>]
 ```
 
 Creates a linked worktree for a GitHub issue and launches the selected coding agent inside it.
@@ -17,7 +17,7 @@ Creates a linked worktree for a GitHub issue and launches the selected coding ag
 - `--agent <name>`: adapter name; default is `claude`. See [adapters.md](adapters.md) for available adapters.
 - `--headless`: run the agent in the background and write agent output to `agent.log`.
 - `--quiet`: suppress agent log output in the terminal; show only the spinner (TTY) or heartbeat lines (non-TTY/CI). Has no effect with `--headless`.
-- `--sdd <name>`: opt into an SDD methodology (e.g. `plain`, `speckit`, or a custom methodology). Omit to skip SDD and work directly toward a PR. See [sdd.md](sdd.md).
+- `--sdd=<name>`: opt into an SDD methodology (e.g. `--sdd=plain`, `--sdd=speckit`). Omit to skip SDD and work directly toward a PR. See [sdd.md](sdd.md).
 - `<issue-number-or-url>`: a bare GitHub issue number (e.g. `42`) **or** a full GitHub issue URL (e.g. `https://github.com/owner/repo/issues/42`). When a URL is supplied, `agentctl` locates or clones the target repository automatically so you do not need to `cd` into it first.
 - `[slug]`: optional branch/worktree slug. If omitted, `agentctl` uses `gh issue view` to fetch the issue title and derive a slug.
 
@@ -187,7 +187,7 @@ agentctl start 42
 agentctl start https://github.com/owner/repo/issues/42
 ```
 
-The agent runs in your terminal with its log streamed live so you can follow along. Without `--sdd`, the agent works directly toward a PR. Use `--sdd plain` or `--sdd speckit` to add a spec-review checkpoint.
+The agent runs in your terminal with its log streamed live so you can follow along. Without `--sdd`, the agent works directly toward a PR. Use `--sdd=plain` or `--sdd=speckit` after the issue number to add a spec-review checkpoint.
 
 To suppress log output and show only a spinner/heartbeat:
 
@@ -249,16 +249,16 @@ agentctl cleanup --all
 
 `agentctl start 42` works out of the box for any repo — by default there is no spec step and the agent opens a PR directly.
 
-Use `--sdd plain` to add a lightweight spec-review checkpoint (no external tooling required):
+Use `--sdd=plain` to add a lightweight spec-review checkpoint (no external tooling required):
 
 ```bash
-agentctl start --sdd plain 42
+agentctl start 42 --sdd=plain
 ```
 
-Use `--sdd speckit` to opt into the Spec Kit workflow if your repo is set up for it:
+Use `--sdd=speckit` to opt into the Spec Kit workflow if your repo is set up for it:
 
 ```bash
-agentctl start --sdd speckit 42
+agentctl start 42 --sdd=speckit
 ```
 
 See [sdd.md](sdd.md) for the SDD methodology schema and drop-in locations.

--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -116,6 +116,21 @@ kickoff: |
 agentctl start --sdd plain 42
 ```
 
+> **Planned:** [#68](https://github.com/arun-gupta/agentctl/issues/68) will add a prescribed `spec.md` format (Problem / Approach / Changes / Out of scope) as a hint in the kickoff prompt so specs have a consistent shape to review.
+
+### Planned built-in methodologies
+
+The following methodologies are tracked as issues and will be added as built-ins once their kickoff prompts are defined:
+
+| Methodology | Issue |
+|-------------|-------|
+| [AgentOS](https://github.com/arun-gupta/agentctl/issues/35) | [#35](https://github.com/arun-gupta/agentctl/issues/35) |
+| [Specs.MD](https://github.com/arun-gupta/agentctl/issues/36) | [#36](https://github.com/arun-gupta/agentctl/issues/36) |
+| [OpenSpec](https://github.com/arun-gupta/agentctl/issues/38) | [#38](https://github.com/arun-gupta/agentctl/issues/38) |
+| [Kiro-style specs](https://github.com/arun-gupta/agentctl/issues/39) | [#39](https://github.com/arun-gupta/agentctl/issues/39) |
+
+In the meantime, any of these can be used today by dropping a custom YAML file in a drop-in location (see below).
+
 ## Drop-in locations
 
 To add or override a methodology without modifying the binary:

--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -10,14 +10,14 @@ Use `--sdd <name>` to opt into a spec-driven development (SDD) methodology. The 
 2. **Stage 2** — After approval, the agent implements the changes, pushes the branch, and opens a PR.
 
 ```bash
-agentctl start --sdd plain 42
+agentctl start 42 --sdd=plain
 ```
 
 ## How it works
 
 One code path handles all methodologies. Built-in and user-defined methodologies are the same type, loaded by the same loader. The binary ships with built-in methodologies (`speckit`, `plain`) embedded directly as plain YAML files, not special Go code.
 
-Select a methodology with `agentctl start --sdd <name>`. Omit `--sdd` to skip SDD entirely.
+Select a methodology with `agentctl start <issue> --sdd=<name>`. Omit `--sdd` to skip SDD entirely.
 
 ## Methodology resolution
 
@@ -62,8 +62,10 @@ Unknown fields are ignored for forward compatibility.
 
 ## `--sdd` flag
 
-- `--sdd <name>` opts into the named SDD methodology (e.g. `plain`, `speckit`, or a custom methodology)
+- `--sdd=<name>` opts into the named methodology (e.g. `--sdd=plain`, `--sdd=speckit`)
 - Omitting `--sdd` skips SDD entirely — the agent works directly toward a PR with no spec-review pause
+
+Convention: put the issue number before the flag — `agentctl start 42 --sdd=plain` — so the intent reads naturally.
 
 **Generic skip prompt** (hardcoded in Go, used when `--sdd` is omitted):
 
@@ -113,7 +115,7 @@ kickoff: |
 ```
 
 ```bash
-agentctl start --sdd plain 42
+agentctl start 42 --sdd=plain
 ```
 
 > **Planned:** [#68](https://github.com/arun-gupta/agentctl/issues/68) will add a prescribed `spec.md` format (Problem / Approach / Changes / Out of scope) as a hint in the kickoff prompt so specs have a consistent shape to review.
@@ -154,7 +156,7 @@ To add or override a methodology without modifying the binary:
 Then select it with:
 
 ```bash
-agentctl start --sdd mymethod 42
+agentctl start 42 --sdd=mymethod
 ```
 
 ## Override behaviour
@@ -174,7 +176,7 @@ kickoff: |
   then implement. Push and open a PR when done. Do not merge.
   Dev server is running on port {port}.
 EOF
-agentctl start --sdd openspec 42
+agentctl start 42 --sdd=openspec
 ```
 
 ## Related

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1159,3 +1159,14 @@ func TestExtractStreamText(t *testing.T) {
 		})
 	}
 }
+
+func TestStartCmd_sddFlagRequiresExplicitValue(t *testing.T) {
+	c := NewStartCmd()
+	f := c.Flags().Lookup("sdd")
+	if f == nil {
+		t.Fatal("--sdd flag not found")
+	}
+	if f.NoOptDefVal != "" {
+		t.Errorf("--sdd should require an explicit value (NoOptDefVal must be empty), got %q", f.NoOptDefVal)
+	}
+}

--- a/internal/sdd/sdd.go
+++ b/internal/sdd/sdd.go
@@ -191,9 +191,10 @@ func listDir(dir string) []string {
 func loadBuiltin(name string) (*Methodology, error) {
 	data, err := builtinFS.ReadFile("builtin/" + name + ".yml")
 	if err != nil {
+		available := List()
 		return nil, fmt.Errorf(
-			"unknown SDD methodology %q — drop %s.yml in .agentctl/sdd/ or ~/.config/agentctl/sdd/",
-			name, name,
+			"unknown SDD methodology %q (available: %s) — or drop %s.yml in .agentctl/sdd/ or ~/.config/agentctl/sdd/",
+			name, strings.Join(available, ", "), name,
 		)
 	}
 	return load(data, "builtin/"+name+".yml")

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -51,6 +51,9 @@ func TestGet_unknown(t *testing.T) {
 	if !strings.Contains(err.Error(), ".agentctl/sdd/") {
 		t.Errorf("error should mention drop-in path hint, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "available:") {
+		t.Errorf("error should list available methodologies, got: %v", err)
+	}
 }
 
 // ─── KickoffPrompt substitution ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Removes the \`NoOptDefVal\` hack — bare \`--sdd\` is no longer accepted; always requires an explicit value (\`--sdd=plain\`, \`--sdd=speckit\`)
- Convention throughout docs: issue number first, flag after — \`agentctl start 42 --sdd=plain\`
- Improved error when an unknown methodology is given: \`unknown SDD methodology "foo" (available: plain, speckit)\`

## Test plan

- [x] \`agentctl start 42 --sdd=plain\` uses the \`plain\` methodology — **MANUAL** (verify post-merge)
- [x] \`agentctl start 42 --sdd=speckit\` uses \`speckit\` — **MANUAL** (verify post-merge)
- [x] \`agentctl start 42\` skips SDD — covered by \`TestStartCmd_sddFlagRequiresExplicitValue\` (no \`NoOptDefVal\`, empty default → \`SkipPrompt\`)
- [x] unknown methodology prints \`(available: plain, speckit)\` — covered by \`TestGet_unknown\`