### PR TITLE
fix: show actionable error when worktree already exists for agentctl start

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -104,14 +104,7 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 
 	// Create the worktree.
 	if _, statErr := os.Stat(wtPath); statErr == nil {
-		af, readErr := state.Read(wtPath)
-		if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
-			return fmt.Errorf("agent is already running for issue %s — use 'agentctl attach %s' to follow its output, or 'agentctl discard %s' to start over", issueNum, issueNum, issueNum)
-		}
-		if readErr == nil && af.AgentPID != "" {
-			return fmt.Errorf("agent has finished for issue %s — use 'agentctl cleanup %s' if the PR is merged, or 'agentctl discard %s' to start over", issueNum, issueNum, issueNum)
-		}
-		return fmt.Errorf("worktree already exists for issue %s — use 'agentctl discard %s' to remove it and start over", issueNum, issueNum)
+		return worktreeExistsError(wtPath, issueNum)
 	}
 	if err := git.AddWorktree(repoRoot, wtPath, branch); err != nil {
 		return fmt.Errorf("git worktree add: %w", err)
@@ -1012,6 +1005,24 @@ func repoRootForIssue(arg string) (repoRoot, issueNum, ghIssueArg string, err er
 	// Pass the original URL to gh so it resolves without requiring a
 	// matching git remote in the working directory.
 	return root, issueNum, arg, nil
+}
+
+// worktreeExistsError returns a descriptive, actionable error for the case
+// where the target worktree directory already exists. It reads the .agent
+// metadata to distinguish between a still-running agent, a finished agent,
+// and a bare worktree with no .agent file, and includes a cd hint so the
+// suggested follow-up commands work regardless of the caller's current
+// directory (e.g. when start was invoked with a full GitHub issue URL from
+// outside the repo).
+func worktreeExistsError(wtPath, issueNum string) error {
+	af, readErr := state.Read(wtPath)
+	if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
+		return fmt.Errorf("agent is already running for issue %s — use 'cd %q && agentctl attach %s' to follow its output, or 'cd %q && agentctl discard %s' to start over", issueNum, wtPath, issueNum, wtPath, issueNum)
+	}
+	if readErr == nil && af.AgentPID != "" {
+		return fmt.Errorf("agent has finished for issue %s — use 'cd %q && agentctl cleanup %s' if the PR is merged, or 'cd %q && agentctl discard %s' to start over", issueNum, wtPath, issueNum, wtPath, issueNum)
+	}
+	return fmt.Errorf("worktree already exists for issue %s — use 'cd %q && agentctl discard %s' to remove it and start over", issueNum, wtPath, issueNum)
 }
 
 // slugFromIssue fetches the GitHub issue title and converts it to a slug.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -104,7 +104,14 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 
 	// Create the worktree.
 	if _, statErr := os.Stat(wtPath); statErr == nil {
-		return fmt.Errorf("worktree already exists: %s", wtPath)
+		af, readErr := state.Read(wtPath)
+		if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
+			return fmt.Errorf("agent is already running for issue %s — use 'agentctl attach %s' to follow its output, or 'agentctl discard %s' to start over", issueNum, issueNum, issueNum)
+		}
+		if readErr == nil && af.AgentPID != "" {
+			return fmt.Errorf("agent has finished for issue %s — use 'agentctl cleanup %s' if the PR is merged, or 'agentctl discard %s' to start over", issueNum, issueNum, issueNum)
+		}
+		return fmt.Errorf("worktree already exists for issue %s — use 'agentctl discard %s' to remove it and start over", issueNum, issueNum)
 	}
 	if err := git.AddWorktree(repoRoot, wtPath, branch); err != nil {
 		return fmt.Errorf("git worktree add: %w", err)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1170,3 +1170,93 @@ func TestStartCmd_sddFlagRequiresExplicitValue(t *testing.T) {
 		t.Errorf("--sdd should require an explicit value (NoOptDefVal must be empty), got %q", f.NoOptDefVal)
 	}
 }
+
+// ─── worktreeExistsError ──────────────────────────────────────────────────────
+
+// TestWorktreeExistsError_runningAgent verifies the error message when the
+// worktree already exists and the agent process is still alive.
+func TestWorktreeExistsError_runningAgent(t *testing.T) {
+	dir := t.TempDir()
+	alivePID := strconv.Itoa(os.Getpid()) // current process is definitely alive
+	if err := state.Write(dir, state.AgentFile{
+		Agent:    "claude",
+		SessionID: "sess-1",
+		DevPID:   "999",
+		AgentPID: alivePID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := worktreeExistsError(dir, "90")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "agent is already running for issue 90") {
+		t.Errorf("expected 'agent is already running for issue 90' in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agentctl attach 90") {
+		t.Errorf("expected 'agentctl attach 90' hint in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agentctl discard 90") {
+		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, dir) {
+		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
+	}
+}
+
+// TestWorktreeExistsError_finishedAgent verifies the error message when the
+// worktree already exists and the agent process is no longer running.
+func TestWorktreeExistsError_finishedAgent(t *testing.T) {
+	dir := t.TempDir()
+	deadPID := "9999999" // very unlikely to be a live process
+	if err := state.Write(dir, state.AgentFile{
+		Agent:    "claude",
+		SessionID: "sess-2",
+		DevPID:   "999",
+		AgentPID: deadPID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := worktreeExistsError(dir, "90")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "agent has finished for issue 90") {
+		t.Errorf("expected 'agent has finished for issue 90' in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agentctl cleanup 90") {
+		t.Errorf("expected 'agentctl cleanup 90' hint in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agentctl discard 90") {
+		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, dir) {
+		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
+	}
+}
+
+// TestWorktreeExistsError_noAgentFile verifies the error message when the
+// worktree already exists but there is no .agent metadata file.
+func TestWorktreeExistsError_noAgentFile(t *testing.T) {
+	dir := t.TempDir()
+	// No .agent file written — directory exists but is otherwise empty.
+
+	err := worktreeExistsError(dir, "90")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "worktree already exists for issue 90") {
+		t.Errorf("expected 'worktree already exists for issue 90' in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agentctl discard 90") {
+		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, dir) {
+		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the cryptic `worktree already exists: /path` error with a context-aware message that tells the user exactly what to do:

| State | Message |
|-------|---------|
| Agent still running | `agent is already running for issue 90 — use 'agentctl attach 90' to follow its output, or 'agentctl discard 90' to start over` |
| Agent finished | `agent has finished for issue 90 — use 'agentctl cleanup 90' if the PR is merged, or 'agentctl discard 90' to start over` |
| No `.agent` file | `worktree already exists for issue 90 — use 'agentctl discard 90' to remove it and start over` |

## Test plan

- [ ] `agentctl start <issue>` when worktree exists with running agent → shows attach/discard hint
- [ ] `agentctl start <issue>` when worktree exists with finished agent → shows cleanup/discard hint
- [ ] `agentctl start <issue>` when worktree exists without `.agent` → shows discard hint