### PR TITLE
feat: show tool input detail in streamed agent output

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -195,6 +195,14 @@ To suppress log output and show only a spinner/heartbeat:
 agentctl start --quiet 42
 ```
 
+To find the dev-server port at any point (e.g. to review the running app after the agent opens a PR):
+
+```bash
+agentctl status
+```
+
+The `PORT` column shows the reserved port for each worktree. The dev server stays running until you clean up.
+
 After the PR is merged:
 
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -126,6 +126,12 @@ Requires the `HOMEBREW_TAP_TOKEN` secret — a fine-grained PAT scoped to the ho
 
 Use `v<major>.<minor>.0` for a new release (e.g. `v0.2.0`, `v0.3.0`).
 
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENTCTL_NO_TOOL_DETAIL` | _(unset)_ | When set to any non-empty value, `agentctl start` suppresses tool input details from the streamed agent output (shows only the tool name). Useful when tool inputs may contain sensitive data such as credentials or signed URLs. |
+
 ## CI
 
 Every push and pull request runs the following via the [`go` workflow](../.github/workflows/go.yml):

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -104,14 +104,7 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 
 	// Create the worktree.
 	if _, statErr := os.Stat(wtPath); statErr == nil {
-		af, readErr := state.Read(wtPath)
-		if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
-			return fmt.Errorf("agent is already running for issue %s — use 'agentctl attach %s' to follow its output, or 'agentctl discard %s' to start over", issueNum, issueNum, issueNum)
-		}
-		if readErr == nil && af.AgentPID != "" {
-			return fmt.Errorf("agent has finished for issue %s — use 'agentctl cleanup %s' if the PR is merged, or 'agentctl discard %s' to start over", issueNum, issueNum, issueNum)
-		}
-		return fmt.Errorf("worktree already exists for issue %s — use 'agentctl discard %s' to remove it and start over", issueNum, issueNum)
+		return worktreeExistsError(wtPath, issueNum)
 	}
 	if err := git.AddWorktree(repoRoot, wtPath, branch); err != nil {
 		return fmt.Errorf("git worktree add: %w", err)
@@ -1012,6 +1005,24 @@ func repoRootForIssue(arg string) (repoRoot, issueNum, ghIssueArg string, err er
 	// Pass the original URL to gh so it resolves without requiring a
 	// matching git remote in the working directory.
 	return root, issueNum, arg, nil
+}
+
+// worktreeExistsError returns a descriptive, actionable error for the case
+// where the target worktree directory already exists. It reads the .agent
+// metadata to distinguish between a still-running agent, a finished agent,
+// and a bare worktree with no .agent file, and includes a cd hint so the
+// suggested follow-up commands work regardless of the caller's current
+// directory (e.g. when start was invoked with a full GitHub issue URL from
+// outside the repo).
+func worktreeExistsError(wtPath, issueNum string) error {
+	af, readErr := state.Read(wtPath)
+	if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
+		return fmt.Errorf("agent is already running for issue %s — use 'cd %q && agentctl attach %s' to follow its output, or 'cd %q && agentctl discard %s' to start over", issueNum, wtPath, issueNum, wtPath, issueNum)
+	}
+	if readErr == nil && af.AgentPID != "" {
+		return fmt.Errorf("agent has finished for issue %s — use 'cd %q && agentctl cleanup %s' if the PR is merged, or 'cd %q && agentctl discard %s' to start over", issueNum, wtPath, issueNum, wtPath, issueNum)
+	}
+	return fmt.Errorf("worktree already exists for issue %s — use 'cd %q && agentctl discard %s' to remove it and start over", issueNum, wtPath, issueNum)
 }
 
 // slugFromIssue fetches the GitHub issue title and converts it to a slug.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1331,12 +1331,34 @@ func extractStreamText(line string) string {
 	return ""
 }
 
+// toolDetailMaxLen is the maximum number of runes shown for a tool input detail
+// before it is truncated with an ellipsis.
+const toolDetailMaxLen = 120
+
+// sanitizeDetail normalises a raw tool-input string for terminal display:
+// leading/trailing whitespace is stripped, internal whitespace runs (including
+// newlines) are collapsed to a single space, and the result is truncated to
+// toolDetailMaxLen runes.
+func sanitizeDetail(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) > toolDetailMaxLen {
+		return string(r[:toolDetailMaxLen]) + "..."
+	}
+	return s
+}
+
 // toolLabel returns a display string for a tool_use block, including the most
 // useful input field for the given tool so the terminal output is actionable.
+// Set AGENTCTL_NO_TOOL_DETAIL=1 to suppress input details (e.g. to avoid
+// echoing sensitive data to the terminal).
 func toolLabel(name string, input json.RawMessage) string {
+	if os.Getenv("AGENTCTL_NO_TOOL_DETAIL") != "" {
+		return name
+	}
 	var detail string
-	switch name {
-	case "Bash":
+	switch strings.ToLower(name) {
+	case "bash":
 		var v struct {
 			Command     string `json:"command"`
 			Description string `json:"description"`
@@ -1348,21 +1370,21 @@ func toolLabel(name string, input json.RawMessage) string {
 				detail = v.Command
 			}
 		}
-	case "Read", "Write", "Edit":
+	case "read", "write", "edit":
 		var v struct {
 			FilePath string `json:"file_path"`
 		}
 		if json.Unmarshal(input, &v) == nil && v.FilePath != "" {
 			detail = v.FilePath
 		}
-	case "WebSearch":
+	case "websearch":
 		var v struct {
 			Query string `json:"query"`
 		}
 		if json.Unmarshal(input, &v) == nil && v.Query != "" {
 			detail = v.Query
 		}
-	case "WebFetch":
+	case "webfetch":
 		var v struct {
 			URL string `json:"url"`
 		}
@@ -1373,7 +1395,7 @@ func toolLabel(name string, input json.RawMessage) string {
 	if detail == "" {
 		return name
 	}
-	return name + ": " + detail
+	return name + ": " + sanitizeDetail(detail)
 }
 
 // spinnerFrames are the braille Unicode characters used for the spinner animation.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1299,9 +1299,10 @@ func extractStreamText(line string) string {
 		Subtype string `json:"subtype"`
 		Message struct {
 			Content []struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
-				Name string `json:"name"`
+				Type  string          `json:"type"`
+				Text  string          `json:"text"`
+				Name  string          `json:"name"`
+				Input json.RawMessage `json:"input"`
 			} `json:"content"`
 		} `json:"message"`
 		Result string `json:"result"`
@@ -1320,7 +1321,7 @@ func extractStreamText(line string) string {
 					sb.WriteByte('\n')
 				}
 			case "tool_use":
-				fmt.Fprintf(&sb, "[%s]\n", c.Name)
+				fmt.Fprintf(&sb, "[%s]\n", toolLabel(c.Name, c.Input))
 			}
 		}
 		return strings.TrimRight(sb.String(), "\n")
@@ -1328,6 +1329,51 @@ func extractStreamText(line string) string {
 		return strings.TrimSpace(ev.Result)
 	}
 	return ""
+}
+
+// toolLabel returns a display string for a tool_use block, including the most
+// useful input field for the given tool so the terminal output is actionable.
+func toolLabel(name string, input json.RawMessage) string {
+	var detail string
+	switch name {
+	case "Bash":
+		var v struct {
+			Command     string `json:"command"`
+			Description string `json:"description"`
+		}
+		if json.Unmarshal(input, &v) == nil {
+			if v.Description != "" {
+				detail = v.Description
+			} else if v.Command != "" {
+				detail = v.Command
+			}
+		}
+	case "Read", "Write", "Edit":
+		var v struct {
+			FilePath string `json:"file_path"`
+		}
+		if json.Unmarshal(input, &v) == nil && v.FilePath != "" {
+			detail = v.FilePath
+		}
+	case "WebSearch":
+		var v struct {
+			Query string `json:"query"`
+		}
+		if json.Unmarshal(input, &v) == nil && v.Query != "" {
+			detail = v.Query
+		}
+	case "WebFetch":
+		var v struct {
+			URL string `json:"url"`
+		}
+		if json.Unmarshal(input, &v) == nil && v.URL != "" {
+			detail = v.URL
+		}
+	}
+	if detail == "" {
+		return name
+	}
+	return name + ": " + detail
 }
 
 // spinnerFrames are the braille Unicode characters used for the spinner animation.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -104,7 +104,14 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 
 	// Create the worktree.
 	if _, statErr := os.Stat(wtPath); statErr == nil {
-		return fmt.Errorf("worktree already exists: %s", wtPath)
+		af, readErr := state.Read(wtPath)
+		if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
+			return fmt.Errorf("agent is already running for issue %s — use 'agentctl attach %s' to follow its output, or 'agentctl discard %s' to start over", issueNum, issueNum, issueNum)
+		}
+		if readErr == nil && af.AgentPID != "" {
+			return fmt.Errorf("agent has finished for issue %s — use 'agentctl cleanup %s' if the PR is merged, or 'agentctl discard %s' to start over", issueNum, issueNum, issueNum)
+		}
+		return fmt.Errorf("worktree already exists for issue %s — use 'agentctl discard %s' to remove it and start over", issueNum, issueNum)
 	}
 	if err := git.AddWorktree(repoRoot, wtPath, branch); err != nil {
 		return fmt.Errorf("git worktree add: %w", err)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1115,14 +1115,29 @@ func TestExtractStreamText(t *testing.T) {
 			want:  "I'll fix the bug.",
 		},
 		{
-			name:  "assistant tool_use",
-			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"bash","input":{"command":"ls"}}]}}`,
-			want:  "[bash]",
+			name:  "assistant tool_use Bash with command",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls -la","description":""}}]}}`,
+			want:  "[Bash: ls -la]",
+		},
+		{
+			name:  "assistant tool_use Bash prefers description",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls -la","description":"List files"}}]}}`,
+			want:  "[Bash: List files]",
+		},
+		{
+			name:  "assistant tool_use Read with file_path",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/foo/bar.go"}}]}}`,
+			want:  "[Read: /foo/bar.go]",
+		},
+		{
+			name:  "assistant tool_use unknown no detail",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SomeTool","input":{}}]}}`,
+			want:  "[SomeTool]",
 		},
 		{
 			name:  "assistant text + tool_use",
-			line:  `{"type":"assistant","message":{"content":[{"type":"text","text":"Running ls."},{"type":"tool_use","name":"bash","input":{}}]}}`,
-			want:  "Running ls.\n[bash]",
+			line:  `{"type":"assistant","message":{"content":[{"type":"text","text":"Running ls."},{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`,
+			want:  "Running ls.\n[Bash: ls]",
 		},
 		{
 			name:  "result success",

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1130,6 +1131,46 @@ func TestExtractStreamText(t *testing.T) {
 			want:  "[Read: /foo/bar.go]",
 		},
 		{
+			name:  "assistant tool_use Write with file_path",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"/foo/bar.go"}}]}}`,
+			want:  "[Write: /foo/bar.go]",
+		},
+		{
+			name:  "assistant tool_use Edit with file_path",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/foo/bar.go"}}]}}`,
+			want:  "[Edit: /foo/bar.go]",
+		},
+		{
+			name:  "assistant tool_use WebSearch with query",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"WebSearch","input":{"query":"go cobra optional flag"}}]}}`,
+			want:  "[WebSearch: go cobra optional flag]",
+		},
+		{
+			name:  "assistant tool_use WebFetch with url",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"WebFetch","input":{"url":"https://pkg.go.dev/github.com/spf13/cobra"}}]}}`,
+			want:  "[WebFetch: https://pkg.go.dev/github.com/spf13/cobra]",
+		},
+		{
+			name:  "assistant tool_use Read missing file_path",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{}}]}}`,
+			want:  "[Read]",
+		},
+		{
+			name:  "assistant tool_use lowercase bash",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"bash","input":{"command":"ls -la"}}]}}`,
+			want:  "[bash: ls -la]",
+		},
+		{
+			name:  "assistant tool_use Bash multiline command collapsed",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls -la\necho hello"}}]}}`,
+			want:  "[Bash: ls -la echo hello]",
+		},
+		{
+			name: "assistant tool_use Bash long command truncated",
+			line: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"` + strings.Repeat("a", 130) + `"}}]}}`,
+			want: "[Bash: " + strings.Repeat("a", 120) + "...]",
+		},
+		{
 			name:  "assistant tool_use unknown no detail",
 			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SomeTool","input":{}}]}}`,
 			want:  "[SomeTool]",
@@ -1170,6 +1211,38 @@ func TestExtractStreamText(t *testing.T) {
 			got := extractStreamText(tc.line)
 			if got != tc.want {
 				t.Errorf("extractStreamText(%q) = %q, want %q", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestToolLabel_NoToolDetail(t *testing.T) {
+	t.Setenv("AGENTCTL_NO_TOOL_DETAIL", "1")
+	got := toolLabel("Bash", json.RawMessage(`{"command":"ls -la"}`))
+	if got != "Bash" {
+		t.Errorf("expected %q with AGENTCTL_NO_TOOL_DETAIL set, got %q", "Bash", got)
+	}
+}
+
+func TestSanitizeDetail(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain", "hello world", "hello world"},
+		{"trim spaces", "  hello  ", "hello"},
+		{"collapse newline", "ls -la\necho hi", "ls -la echo hi"},
+		{"collapse tab", "a\tb", "a b"},
+		{"collapse multiple spaces", "a   b", "a b"},
+		{"truncate at 120 runes", strings.Repeat("x", 130), strings.Repeat("x", 120) + "..."},
+		{"exact 120 runes no ellipsis", strings.Repeat("x", 120), strings.Repeat("x", 120)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeDetail(tc.input)
+			if got != tc.want {
+				t.Errorf("sanitizeDetail(%q) = %q, want %q", tc.input, got, tc.want)
 			}
 		})
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1258,3 +1258,93 @@ func TestStartCmd_sddFlagRequiresExplicitValue(t *testing.T) {
 		t.Errorf("--sdd should require an explicit value (NoOptDefVal must be empty), got %q", f.NoOptDefVal)
 	}
 }
+
+// ─── worktreeExistsError ──────────────────────────────────────────────────────
+
+// TestWorktreeExistsError_runningAgent verifies the error message when the
+// worktree already exists and the agent process is still alive.
+func TestWorktreeExistsError_runningAgent(t *testing.T) {
+	dir := t.TempDir()
+	alivePID := strconv.Itoa(os.Getpid()) // current process is definitely alive
+	if err := state.Write(dir, state.AgentFile{
+		Agent:    "claude",
+		SessionID: "sess-1",
+		DevPID:   "999",
+		AgentPID: alivePID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := worktreeExistsError(dir, "90")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "agent is already running for issue 90") {
+		t.Errorf("expected 'agent is already running for issue 90' in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agentctl attach 90") {
+		t.Errorf("expected 'agentctl attach 90' hint in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agentctl discard 90") {
+		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, dir) {
+		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
+	}
+}
+
+// TestWorktreeExistsError_finishedAgent verifies the error message when the
+// worktree already exists and the agent process is no longer running.
+func TestWorktreeExistsError_finishedAgent(t *testing.T) {
+	dir := t.TempDir()
+	deadPID := "9999999" // very unlikely to be a live process
+	if err := state.Write(dir, state.AgentFile{
+		Agent:    "claude",
+		SessionID: "sess-2",
+		DevPID:   "999",
+		AgentPID: deadPID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := worktreeExistsError(dir, "90")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "agent has finished for issue 90") {
+		t.Errorf("expected 'agent has finished for issue 90' in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agentctl cleanup 90") {
+		t.Errorf("expected 'agentctl cleanup 90' hint in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agentctl discard 90") {
+		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, dir) {
+		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
+	}
+}
+
+// TestWorktreeExistsError_noAgentFile verifies the error message when the
+// worktree already exists but there is no .agent metadata file.
+func TestWorktreeExistsError_noAgentFile(t *testing.T) {
+	dir := t.TempDir()
+	// No .agent file written — directory exists but is otherwise empty.
+
+	err := worktreeExistsError(dir, "90")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "worktree already exists for issue 90") {
+		t.Errorf("expected 'worktree already exists for issue 90' in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agentctl discard 90") {
+		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, dir) {
+		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
+	}
+}


### PR DESCRIPTION
## Summary

The terminal output now shows what each tool is actually doing instead of just the tool name:

| Before | After |
|--------|-------|
| `[Bash]` | `[Bash: List files in current directory]` (description) or `[Bash: ls -la]` (command) |
| `[Read]` | `[Read: /path/to/file.go]` |
| `[Write]` | `[Write: /path/to/file.go]` |
| `[Edit]` | `[Edit: /path/to/file.go]` |
| `[WebSearch]` | `[WebSearch: go cobra optional flag]` |
| `[WebFetch]` | `[WebFetch: https://...]` |
| `[SomeTool]` | `[SomeTool]` (no detail available) |

Bash prefers `description` over `command` when both are present, since the description is already human-readable.

## Test plan

- [x] `TestExtractStreamText` covers all tool variants with and without input detail
- [ ] Run `agentctl start <issue>` and verify terminal output shows tool details