### PR TITLE
docs: mention agentctl status to find dev-server port after agent finishes

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -195,6 +195,14 @@ To suppress log output and show only a spinner/heartbeat:
 agentctl start --quiet 42
 ```
 
+To find the dev-server port at any point (e.g. to review the running app after the agent opens a PR):
+
+```bash
+agentctl status
+```
+
+The `PORT` column shows the reserved port for each worktree. The dev server stays running until you clean up.
+
 After the PR is merged:
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a note to the interactive single-issue workflow explaining how to find the dev-server port at any point — useful when reviewing the running app after the agent has opened a PR.

## Test plan

- [x] Docs render correctly on GitHub