### PR TITLE
feat: replace approve-spec + revise-spec with single resume command

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -1,16 +1,15 @@
 // agentctl – Go CLI for provisioning isolated git worktrees per GitHub issue
 // and launching coding agents inside each one.
 //
-// Command surface (start, approve-spec, …):
+// Command surface:
 //
-//	agentctl start [--agent name] [--headless] [--no-sdd] <issue> [slug]
-//	agentctl approve-spec  <issue>
-//	agentctl revise-spec   <issue> <feedback>
-//	agentctl discard       [issue]
-//	agentctl cleanup       [issue | --all]
-//	agentctl status [--verbose]
-//	agentctl logs   [--lines N] [--no-follow] <issue>
-//	agentctl attach <issue>
+//	agentctl start   [--agent name] [--headless] [--sdd=name] <issue> [slug]
+//	agentctl resume  <issue> [feedback]
+//	agentctl discard [issue]
+//	agentctl cleanup [issue | --all]
+//	agentctl status  [--verbose]
+//	agentctl logs    [--lines N] [--no-follow] <issue>
+//	agentctl attach  <issue>
 package main
 
 import (
@@ -43,8 +42,7 @@ func main() {
 
 	root.AddCommand(
 		cmd.NewStartCmd(),
-		cmd.NewApproveSpecCmd(),
-		cmd.NewReviseSpecCmd(),
+		cmd.NewResumeCmd(),
 		cmd.NewDiscardCmd(),
 		cmd.NewCleanupCmd(),
 		cmd.NewStatusCmd(),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,29 +31,23 @@ Side effects:
 - Runs `npm install --silent` and starts `npm run dev -- -p <port>`.
 - Launches the selected adapter.
 
-### `agentctl approve-spec`
+### `agentctl resume`
 
 ```bash
-agentctl approve-spec <issue-number>
+agentctl resume <issue-number>
+agentctl resume <issue-number> [feedback]
 ```
 
-Resumes a paused headless run after you approve the generated spec. This sends the approval prompt (`proceed`) to the adapter's `agent_resume` function.
+Resumes a paused headless agent after the spec-review checkpoint.
+
+- Without feedback: approves the spec and the agent begins implementation.
+- With feedback: sends the revision text and the agent rewrites the spec.
 
 The command requires:
 
 - A linked worktree for the issue.
 - A `.agent` metadata file with the selected agent and session ID.
 - A generated spec at `specs/*/spec.md`.
-
-### `agentctl revise-spec`
-
-```bash
-agentctl revise-spec <issue-number> <feedback>
-```
-
-Resumes a paused headless run with revision feedback instead of approval. Feedback must be non-empty.
-
-Use this when the generated spec needs changes before implementation begins.
 
 ### `agentctl status`
 
@@ -223,10 +217,10 @@ agentctl logs 42
 agentctl attach 42
 
 # Approve the spec after review
-agentctl approve-spec 42
+agentctl resume 42
 
 # Or request revisions instead
-agentctl revise-spec 42 "Narrow scope to the API layer; avoid UI changes."
+agentctl resume 42 "Narrow scope to the API layer; avoid UI changes."
 
 # Clean up after merge
 agentctl cleanup 42
@@ -242,7 +236,7 @@ done
 
 # Review generated specs, then approve each one
 for i in 210 211 212; do
-  agentctl approve-spec "$i"
+  agentctl resume "$i"
 done
 
 # Monitor all worktrees

--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -6,7 +6,7 @@ By default, **agentctl** has no spec step — the agent works directly toward a 
 
 Use `--sdd <name>` to opt into a spec-driven development (SDD) methodology. The selected methodology defines a kickoff prompt that instructs the agent to follow a spec lifecycle with a human-in-the-loop pause:
 
-1. **Stage 1** — The agent writes a spec, then stops for your approval or revision. In headless mode use `agentctl approve-spec` and `agentctl revise-spec`.
+1. **Stage 1** — The agent writes a spec, then stops for your approval or revision. In headless mode use `agentctl resume`.
 2. **Stage 2** — After approval, the agent implements the changes, pushes the branch, and opens a PR.
 
 ```bash

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1247,7 +1247,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 	if headless {
 		fmt.Printf("Agent PID %d — log: %s\n", pid, logPath)
 		fmt.Printf("Session ID: %s\n", sessionID)
-		fmt.Printf("Release the pause with: agentctl approve-spec %s\n", issue)
+		fmt.Printf("Release the pause with: agentctl resume %s [feedback]\n", issue)
 		return nil
 	}
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -198,33 +198,27 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 	return launchAgent(agentName, wtPath, issueNum, portStr, sessionID, kickoff, headless, quiet)
 }
 
-// ─── approve-spec ─────────────────────────────────────────────────────────────
+// ─── resume ───────────────────────────────────────────────────────────────────
 
-// NewApproveSpecCmd creates the `approve-spec` subcommand.
-func NewApproveSpecCmd() *cobra.Command {
+// NewResumeCmd creates the `resume` subcommand.
+func NewResumeCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "approve-spec <issue>",
-		Short: "Release the spec-review pause for a paused headless start",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runReleasePausedSession(args[0], "proceed")
-		},
-	}
-}
+		Use:   "resume <issue> [feedback]",
+		Short: "Resume a paused spec review: approve or revise",
+		Long: `Resume a paused headless agent after the spec-review checkpoint.
 
-// ─── revise-spec ──────────────────────────────────────────────────────────────
-
-// NewReviseSpecCmd creates the `revise-spec` subcommand.
-func NewReviseSpecCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "revise-spec <issue> <feedback>",
-		Short: "Send non-empty revision feedback to a paused start",
-		Args:  cobra.ExactArgs(2),
+Without feedback, sends approval ("proceed") and the agent begins implementation.
+With feedback, sends the revision text and the agent rewrites the spec.`,
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if strings.TrimSpace(args[1]) == "" {
-				return fmt.Errorf("revise-spec requires non-empty feedback")
+			prompt := "proceed"
+			if len(args) == 2 {
+				if strings.TrimSpace(args[1]) == "" {
+					return fmt.Errorf("feedback must be non-empty; omit it entirely to approve")
+				}
+				prompt = args[1]
 			}
-			return runReleasePausedSession(args[0], args[1])
+			return runReleasePausedSession(args[0], prompt)
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Replaces the two-command surface with a single intuitive command:

| Before | After |
|--------|-------|
| `agentctl approve-spec 42` | `agentctl resume 42` |
| `agentctl revise-spec 42 "feedback"` | `agentctl resume 42 "feedback"` |

Omitting the feedback argument approves; passing feedback revises. Same underlying `runReleasePausedSession` logic — just a cleaner entry point.

## Test plan

- [ ] `agentctl resume 42` approves a paused headless run
- [ ] `agentctl resume 42 "narrow to API layer"` sends revision feedback
- [ ] `agentctl resume 42 ""` (empty feedback) returns a clear error
- [ ] `agentctl approve-spec` and `agentctl revise-spec` are gone from `--help`