### PR TITLE
fix: prevent error from printing twice on command failure

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -23,7 +23,7 @@ import (
 
 var version = "dev"
 
-func main() {
+func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:     "agentctl",
 		Version: version,
@@ -37,7 +37,8 @@ func main() {
 
   # Clean up after the PR for issue #42 is merged
   agentctl cleanup 42`,
-		SilenceUsage: true,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	root.AddCommand(
@@ -49,8 +50,11 @@ func main() {
 		cmd.NewLogsCmd(),
 		cmd.NewAttachCmd(),
 	)
+	return root
+}
 
-	if err := root.Execute(); err != nil {
+func main() {
+	if err := newRootCmd().Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/cmd/agentctl/main_test.go
+++ b/cmd/agentctl/main_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+// TestRootCmdSilenceErrors verifies that the root command suppresses cobra's
+// built-in error printing so errors are not echoed twice (once by cobra, once
+// by main's fmt.Fprintln).
+func TestRootCmdSilenceErrors(t *testing.T) {
+	root := newRootCmd()
+	if !root.SilenceErrors {
+		t.Error("root command must set SilenceErrors: true to prevent cobra from printing errors a second time after main already prints them")
+	}
+}


### PR DESCRIPTION
Fixes #103.

## Summary

- `SilenceErrors` was not set on the root cobra command, so when any subcommand returned an error cobra printed `Error: <msg>` to stderr **and** `main()` also called `fmt.Fprintln(os.Stderr, err)`, producing the message twice.
- Adds `SilenceErrors: true` so cobra's copy is suppressed; `main`'s `Fprintln` is the single source of truth.
- Extracts `newRootCmd()` to make the property testable.

Fixes the duplicate output seen in `agentctl start`:
```
Error: npm install: exit status 254
npm install: exit status 254
```

## Test plan

- [ ] `go test ./cmd/agentctl/...` passes (new `TestRootCmdSilenceErrors`)
- [ ] `go test ./...` — pre-existing failures in `internal/adapters`, `internal/sdd`, and three path-comparison tests in `internal/cmd` are unrelated to this change
- [ ] Manual: run any failing `agentctl` command and confirm the error appears only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)