### PR TITLE
ci: pass GITHUB_TOKEN to claude-code-action to fix write access error

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'


### PR DESCRIPTION
## Summary

- The `claude-code-review` workflow was failing with `User does not have write access on this repository` because `anthropics/claude-code-action` needs an explicit `github_token` to post PR review comments.
- Without it the action had no GitHub credentials to authenticate with the GitHub API.
- Adds `github_token: ${{ secrets.GITHUB_TOKEN }}` to the step's `with:` block.

## Test plan

- [ ] Merge this PR and open a new PR — the Claude Code Review job should complete without the write-access error

🤖 Generated with [Claude Code](https://claude.com/claude-code)