### PR TITLE
ci: disable Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: false
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary
- Adds `if: false` to the `claude-review` job in `claude-code-review.yml`
- Workflow file is kept intact for easy re-enable

## Test plan
- [ ] Verify no Claude code review runs on the next PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)