### PR TITLE
fix: remove noisy .env.local warning and empty-file creation

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -110,29 +110,14 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 		return fmt.Errorf("git worktree add: %w", err)
 	}
 
-	// Seed .env.local from main repo, then append PORT.
+	// Seed .env.local from main repo (if present), then append PORT.
 	envLocal := filepath.Join(wtPath, ".env.local")
 	mainEnvLocal := filepath.Join(repoRoot, ".env.local")
-	if data, readErr := os.ReadFile(mainEnvLocal); readErr == nil {
-		// Strip any existing PORT= line.
-		var filtered []string
-		for _, line := range strings.Split(string(data), "\n") {
-			if !strings.HasPrefix(line, "PORT=") {
-				filtered = append(filtered, line)
-			}
-		}
-		if err := os.WriteFile(envLocal, []byte(strings.Join(filtered, "\n")), 0o600); err != nil {
-			return err
-		}
-		fmt.Printf("Copied .env.local from %s\n", repoRoot)
-	} else {
-		if err := os.WriteFile(envLocal, nil, 0o600); err != nil {
-			return err
-		}
-		fmt.Fprintf(os.Stderr, "WARNING: %s/.env.local not found — worktree will start without OAuth creds\n", repoRoot)
+	if err := seedEnvLocal(mainEnvLocal, envLocal); err != nil {
+		return err
 	}
 	portLine := fmt.Sprintf("\nPORT=%d\n", port)
-	f, err := os.OpenFile(envLocal, os.O_APPEND|os.O_WRONLY, 0o600)
+	f, err := os.OpenFile(envLocal, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
@@ -1081,6 +1066,26 @@ func titleToSlug(title string) string {
 		s = strings.TrimRight(s[:40], "-")
 	}
 	return s
+}
+
+// seedEnvLocal copies src to dst, stripping any PORT= lines. If src does not
+// exist, dst is left untouched — the caller creates it on demand when appending
+// the port assignment.
+func seedEnvLocal(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var filtered []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "PORT=") {
+			filtered = append(filtered, line)
+		}
+	}
+	return os.WriteFile(dst, []byte(strings.Join(filtered, "\n")), 0o600)
 }
 
 // findFreePort scans the [lo, hi] range for a port that is not in LISTEN state.

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1348,3 +1348,40 @@ func TestWorktreeExistsError_noAgentFile(t *testing.T) {
 		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
 	}
 }
+
+func TestSeedEnvLocal_missing(t *testing.T) {
+	src := filepath.Join(t.TempDir(), ".env.local") // does not exist
+	dst := filepath.Join(t.TempDir(), ".env.local")
+
+	if err := seedEnvLocal(src, dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Dest should not exist when source is absent — no empty file created.
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Errorf("expected dst to not exist when src is absent, but stat returned: %v", err)
+	}
+}
+
+func TestSeedEnvLocal_copies_and_strips_port(t *testing.T) {
+	srcDir := t.TempDir()
+	src := filepath.Join(srcDir, ".env.local")
+	if err := os.WriteFile(src, []byte("FOO=bar\nPORT=3000\nBAZ=qux\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), ".env.local")
+
+	if err := seedEnvLocal(src, dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("dst not created: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, "PORT=") {
+		t.Errorf("seedEnvLocal should strip PORT= lines, got:\n%s", got)
+	}
+	if !strings.Contains(got, "FOO=bar") || !strings.Contains(got, "BAZ=qux") {
+		t.Errorf("seedEnvLocal should preserve other vars, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `agentctl start` printed `WARNING: .../.env.local not found — worktree will start without OAuth creds` even when the project has nothing to do with OAuth — confusing noise for any non-Next.js repo.
- An empty `.env.local` was explicitly created just so the subsequent `O_APPEND` open wouldn't fail. Switching to `O_CREATE|O_APPEND|O_WRONLY` means the file is created on-demand when the `PORT=` line is appended, with no empty intermediate file.
- Also removes the `Copied .env.local from <path>` success print — the user doesn't need to know this happened.

Extracts `seedEnvLocal(src, dst string) error` to keep the logic testable.

## Test plan

- [ ] `go test ./internal/cmd/ -run TestSeedEnvLocal` passes (two new tests)
- [ ] `go test ./...` — only pre-existing failures
- [ ] Manual: `agentctl start` in a repo without `.env.local` → no warning printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)