### PR TITLE
feat: pluggable dev server via .agentctl.yml; skip npm for non-Node repos

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1105,13 +1105,15 @@ func startCustomDevServer(dir string, cfg *projectConfig) (devPID, portStr strin
 	}
 	portStr = fmt.Sprintf("%d", port)
 
-	cmdStr := strings.ReplaceAll(cfg.DevServer, "{port}", portStr)
-	parts := strings.Fields(cmdStr)
+	cmdStr := strings.TrimSpace(strings.ReplaceAll(cfg.DevServer, "{port}", portStr))
+	if cmdStr == "" {
+		return "", "", fmt.Errorf("dev_server in .agentctl.yml is empty")
+	}
 	devLog, err := os.Create(filepath.Join(dir, "dev.log"))
 	if err != nil {
 		return "", "", err
 	}
-	devCmd := exec.Command(parts[0], parts[1:]...) //nolint:gosec
+	devCmd := exec.Command("sh", "-c", cmdStr) //nolint:gosec
 	devCmd.Dir = dir
 	devCmd.Stdout = devLog
 	devCmd.Stderr = devLog
@@ -1119,10 +1121,18 @@ func startCustomDevServer(dir string, cfg *projectConfig) (devPID, portStr strin
 		devLog.Close()
 		return "", "", fmt.Errorf("start dev server: %w", err)
 	}
+	if err := devLog.Close(); err != nil {
+		return "", "", fmt.Errorf("close dev log: %w", err)
+	}
 	fmt.Printf("Dev server: http://localhost:%s (log: %s/dev.log)\n", portStr, dir)
 
 	cfg.Port = port
-	_ = writeAgentctlConfig(dir, cfg)
+	if err := writeAgentctlConfig(dir, cfg); err != nil {
+		if killErr := devCmd.Process.Kill(); killErr != nil {
+			return "", "", fmt.Errorf("persist .agentctl.yml after starting dev server: %w (also failed to stop dev server pid %d: %v)", err, devCmd.Process.Pid, killErr)
+		}
+		return "", "", fmt.Errorf("persist .agentctl.yml after starting dev server: %w", err)
+	}
 	return fmt.Sprintf("%d", devCmd.Process.Pid), portStr, nil
 }
 
@@ -1157,10 +1167,18 @@ func startNodeDevServer(dir string, cfg *projectConfig) (devPID, portStr string,
 		devLog.Close()
 		return "", "", fmt.Errorf("start dev server: %w", err)
 	}
+	if err := devLog.Close(); err != nil {
+		return "", "", fmt.Errorf("close dev log: %w", err)
+	}
 	fmt.Printf("Dev server: http://localhost:%s (log: %s/dev.log)\n", portStr, dir)
 
 	cfg.Port = port
-	_ = writeAgentctlConfig(dir, cfg)
+	if err := writeAgentctlConfig(dir, cfg); err != nil {
+		if killErr := devCmd.Process.Kill(); killErr != nil {
+			return "", "", fmt.Errorf("persist .agentctl.yml after starting dev server: %w (also failed to stop dev server pid %d: %v)", err, devCmd.Process.Pid, killErr)
+		}
+		return "", "", fmt.Errorf("persist .agentctl.yml after starting dev server: %w", err)
+	}
 	return fmt.Sprintf("%d", devCmd.Process.Pid), portStr, nil
 }
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1031,25 +1031,6 @@ func titleToSlug(title string) string {
 	return s
 }
 
-// projectConfig mirrors config.AgentctlConfig but is local to this package so
-// startDevServer helpers don't need to import internal/config directly.
-type projectConfig struct {
-	DevServer string
-	Port      int
-}
-
-func agentctlConfig(dir string) (*projectConfig, error) {
-	cfg, err := config.Read(dir)
-	if err != nil {
-		return nil, fmt.Errorf("reading .agentctl.yml: %w", err)
-	}
-	return &projectConfig{DevServer: cfg.DevServer, Port: cfg.Port}, nil
-}
-
-func writeAgentctlConfig(dir string, cfg *projectConfig) error {
-	return config.Write(dir, &config.AgentctlConfig{DevServer: cfg.DevServer, Port: cfg.Port})
-}
-
 // seedEnvLocal copies src to dst, stripping any PORT= lines. If src does not
 // exist, dst is left untouched.
 func seedEnvLocal(src, dst string) error {
@@ -1078,9 +1059,9 @@ func seedEnvLocal(src, dst string) error {
 // as the single source of truth for all agentctl repo config. w receives the
 // informational message when no dev server is configured.
 func startDevServer(dir string, w io.Writer) (devPID, portStr string, err error) {
-	cfg, err := agentctlConfig(dir)
+	cfg, err := config.Read(dir)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("reading .agentctl.yml: %w", err)
 	}
 
 	// Case 1: explicit dev_server in .agentctl.yml
@@ -1098,7 +1079,7 @@ func startDevServer(dir string, w io.Writer) (devPID, portStr string, err error)
 	return "", "", nil
 }
 
-func startCustomDevServer(dir string, cfg *projectConfig) (devPID, portStr string, err error) {
+func startCustomDevServer(dir string, cfg *config.AgentctlConfig) (devPID, portStr string, err error) {
 	port, err := findFreePort(3010, 3100)
 	if err != nil {
 		return "", "", err
@@ -1122,31 +1103,20 @@ func startCustomDevServer(dir string, cfg *projectConfig) (devPID, portStr strin
 		return "", "", fmt.Errorf("start dev server: %w", err)
 	}
 	if err := devLog.Close(); err != nil {
-		return "", "", fmt.Errorf("close dev log: %w", err)
+		fmt.Fprintf(os.Stderr, "warning: close dev log: %v\n", err)
 	}
 	fmt.Printf("Dev server: http://localhost:%s (log: %s/dev.log)\n", portStr, dir)
 
 	cfg.Port = port
-	if err := writeAgentctlConfig(dir, cfg); err != nil {
-		if killErr := devCmd.Process.Kill(); killErr != nil {
-			return "", "", fmt.Errorf("persist .agentctl.yml after starting dev server: %w (also failed to stop dev server pid %d: %v)", err, devCmd.Process.Pid, killErr)
-		}
-		return "", "", fmt.Errorf("persist .agentctl.yml after starting dev server: %w", err)
+	if err := config.Write(dir, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not persist port to .agentctl.yml: %v\n", err)
 	}
 	return fmt.Sprintf("%d", devCmd.Process.Pid), portStr, nil
 }
 
-func startNodeDevServer(dir string, cfg *projectConfig) (devPID, portStr string, err error) {
-	if _, err := exec.LookPath("npm"); err != nil {
-		return "", "", fmt.Errorf("npm not found in PATH\nInstall Node.js from https://nodejs.org and ensure npm is on your PATH, then re-run agentctl start")
-	}
-
-	install := exec.Command("npm", "install", "--loglevel=error")
-	install.Dir = dir
-	install.Stdout = os.Stdout
-	install.Stderr = os.Stderr
-	if err := install.Run(); err != nil {
-		return "", "", fmt.Errorf("dependency installation failed in %s: %w\n\nPossible causes:\n  • Node version mismatch (check .nvmrc or the project's required Node version)\n  • Network error or private registry credentials required\n\nTo debug: cd %s && npm install", dir, err, dir)
+func startNodeDevServer(dir string, cfg *config.AgentctlConfig) (devPID, portStr string, err error) {
+	if err := runNpmInstall(dir); err != nil {
+		return "", "", err
 	}
 
 	port, err := findFreePort(3010, 3100)
@@ -1168,16 +1138,13 @@ func startNodeDevServer(dir string, cfg *projectConfig) (devPID, portStr string,
 		return "", "", fmt.Errorf("start dev server: %w", err)
 	}
 	if err := devLog.Close(); err != nil {
-		return "", "", fmt.Errorf("close dev log: %w", err)
+		fmt.Fprintf(os.Stderr, "warning: close dev log: %v\n", err)
 	}
 	fmt.Printf("Dev server: http://localhost:%s (log: %s/dev.log)\n", portStr, dir)
 
 	cfg.Port = port
-	if err := writeAgentctlConfig(dir, cfg); err != nil {
-		if killErr := devCmd.Process.Kill(); killErr != nil {
-			return "", "", fmt.Errorf("persist .agentctl.yml after starting dev server: %w (also failed to stop dev server pid %d: %v)", err, devCmd.Process.Pid, killErr)
-		}
-		return "", "", fmt.Errorf("persist .agentctl.yml after starting dev server: %w", err)
+	if err := config.Write(dir, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not persist port to .agentctl.yml: %v\n", err)
 	}
 	return fmt.Sprintf("%d", devCmd.Process.Pid), portStr, nil
 }

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -116,19 +116,6 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 		return err
 	}
 
-	// When a dev server is running, record its port in .env.local.
-	if portStr != "" {
-		f, ferr := os.OpenFile(filepath.Join(wtPath, ".env.local"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
-		if ferr != nil {
-			return ferr
-		}
-		_, ferr = f.WriteString("\nPORT=" + portStr + "\n")
-		f.Close()
-		if ferr != nil {
-			return ferr
-		}
-	}
-
 	// Generate session ID.
 	sessionID, err := generateUUID()
 	if err != nil {

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/arun-gupta/agentctl/internal/adapters"
+	"github.com/arun-gupta/agentctl/internal/config"
 	"github.com/arun-gupta/agentctl/internal/git"
 	"github.com/arun-gupta/agentctl/internal/process"
 	"github.com/arun-gupta/agentctl/internal/sdd"
@@ -1043,6 +1044,25 @@ func titleToSlug(title string) string {
 	return s
 }
 
+// projectConfig mirrors config.AgentctlConfig but is local to this package so
+// startDevServer helpers don't need to import internal/config directly.
+type projectConfig struct {
+	DevServer string
+	Port      int
+}
+
+func agentctlConfig(dir string) (*projectConfig, error) {
+	cfg, err := config.Read(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading .agentctl.yml: %w", err)
+	}
+	return &projectConfig{DevServer: cfg.DevServer, Port: cfg.Port}, nil
+}
+
+func writeAgentctlConfig(dir string, cfg *projectConfig) error {
+	return config.Write(dir, &config.AgentctlConfig{DevServer: cfg.DevServer, Port: cfg.Port})
+}
+
 // seedEnvLocal copies src to dst, stripping any PORT= lines. If src does not
 // exist, dst is left untouched.
 func seedEnvLocal(src, dst string) error {
@@ -1062,22 +1082,68 @@ func seedEnvLocal(src, dst string) error {
 	return os.WriteFile(dst, []byte(strings.Join(filtered, "\n")), 0o600)
 }
 
-// startDevServer detects whether the project in dir has a Node.js dev server
-// (package.json present) and, if so, runs npm install and starts npm run dev
-// on a free port. Returns (devPID, portStr, nil) on success, or ("", "", nil)
-// when no dev server is detected. w receives the informational message printed
-// when no dev server config is found.
+// startDevServer starts a dev server for the project in dir. Detection order:
+//  1. .agentctl.yml with dev_server field  → run that command with {port} substituted
+//  2. package.json present                 → npm install + npm run dev
+//  3. neither                              → print hint, return ("","",nil)
+//
+// On success the allocated port is written back to .agentctl.yml so it serves
+// as the single source of truth for all agentctl repo config. w receives the
+// informational message when no dev server is configured.
 func startDevServer(dir string, w io.Writer) (devPID, portStr string, err error) {
-	if _, statErr := os.Stat(filepath.Join(dir, "package.json")); os.IsNotExist(statErr) {
-		fmt.Fprintf(w, "No dev server configured for this project. Add a dev_server command to .agentctl.yml to start one automatically.\n")
-		return "", "", nil
+	cfg, err := agentctlConfig(dir)
+	if err != nil {
+		return "", "", err
 	}
 
+	// Case 1: explicit dev_server in .agentctl.yml
+	if cfg.DevServer != "" {
+		return startCustomDevServer(dir, cfg)
+	}
+
+	// Case 2: Node.js project
+	if _, statErr := os.Stat(filepath.Join(dir, "package.json")); statErr == nil {
+		return startNodeDevServer(dir, cfg)
+	}
+
+	// Case 3: no dev server configured
+	fmt.Fprintf(w, "No dev server configured for this project. Add a dev_server command to .agentctl.yml to start one automatically.\n")
+	return "", "", nil
+}
+
+func startCustomDevServer(dir string, cfg *projectConfig) (devPID, portStr string, err error) {
+	port, err := findFreePort(3010, 3100)
+	if err != nil {
+		return "", "", err
+	}
+	portStr = fmt.Sprintf("%d", port)
+
+	cmdStr := strings.ReplaceAll(cfg.DevServer, "{port}", portStr)
+	parts := strings.Fields(cmdStr)
+	devLog, err := os.Create(filepath.Join(dir, "dev.log"))
+	if err != nil {
+		return "", "", err
+	}
+	devCmd := exec.Command(parts[0], parts[1:]...) //nolint:gosec
+	devCmd.Dir = dir
+	devCmd.Stdout = devLog
+	devCmd.Stderr = devLog
+	if err := devCmd.Start(); err != nil {
+		devLog.Close()
+		return "", "", fmt.Errorf("start dev server: %w", err)
+	}
+	fmt.Printf("Dev server: http://localhost:%s (log: %s/dev.log)\n", portStr, dir)
+
+	cfg.Port = port
+	_ = writeAgentctlConfig(dir, cfg)
+	return fmt.Sprintf("%d", devCmd.Process.Pid), portStr, nil
+}
+
+func startNodeDevServer(dir string, cfg *projectConfig) (devPID, portStr string, err error) {
 	if _, err := exec.LookPath("npm"); err != nil {
 		return "", "", fmt.Errorf("npm not found in PATH\nInstall Node.js from https://nodejs.org and ensure npm is on your PATH, then re-run agentctl start")
 	}
 
-	// npm install
 	install := exec.Command("npm", "install", "--loglevel=error")
 	install.Dir = dir
 	install.Stdout = os.Stdout
@@ -1105,6 +1171,9 @@ func startDevServer(dir string, w io.Writer) (devPID, portStr string, err error)
 		return "", "", fmt.Errorf("start dev server: %w", err)
 	}
 	fmt.Printf("Dev server: http://localhost:%s (log: %s/dev.log)\n", portStr, dir)
+
+	cfg.Port = port
+	_ = writeAgentctlConfig(dir, cfg)
 	return fmt.Sprintf("%d", devCmd.Process.Pid), portStr, nil
 }
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -96,12 +96,6 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 	branch := issueNum + "-" + slug
 	wtPath := filepath.Join(parentDir, repoName+"-"+issueNum+"-"+slug)
 
-	// Find a free port in the 3010-3100 range.
-	port, err := findFreePort(3010, 3100)
-	if err != nil {
-		return err
-	}
-
 	// Create the worktree.
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		return worktreeExistsError(wtPath, issueNum)
@@ -110,58 +104,29 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 		return fmt.Errorf("git worktree add: %w", err)
 	}
 
-	// Seed .env.local from main repo, then append PORT.
-	envLocal := filepath.Join(wtPath, ".env.local")
-	mainEnvLocal := filepath.Join(repoRoot, ".env.local")
-	if data, readErr := os.ReadFile(mainEnvLocal); readErr == nil {
-		// Strip any existing PORT= line.
-		var filtered []string
-		for _, line := range strings.Split(string(data), "\n") {
-			if !strings.HasPrefix(line, "PORT=") {
-				filtered = append(filtered, line)
-			}
-		}
-		if err := os.WriteFile(envLocal, []byte(strings.Join(filtered, "\n")), 0o600); err != nil {
-			return err
-		}
-		fmt.Printf("Copied .env.local from %s\n", repoRoot)
-	} else {
-		if err := os.WriteFile(envLocal, nil, 0o600); err != nil {
-			return err
-		}
-		fmt.Fprintf(os.Stderr, "WARNING: %s/.env.local not found — worktree will start without OAuth creds\n", repoRoot)
-	}
-	portLine := fmt.Sprintf("\nPORT=%d\n", port)
-	f, err := os.OpenFile(envLocal, os.O_APPEND|os.O_WRONLY, 0o600)
-	if err != nil {
+	// Seed .env.local from main repo if present (strips any existing PORT= line).
+	if err := seedEnvLocal(filepath.Join(repoRoot, ".env.local"), filepath.Join(wtPath, ".env.local")); err != nil {
 		return err
 	}
-	_, err = f.WriteString(portLine)
-	f.Close()
+
+	// Start dev server if the project supports it; returns empty strings when skipped.
+	devPID, portStr, err := startDevServer(wtPath, os.Stderr)
 	if err != nil {
 		return err
 	}
 
-	// npm install
-	if err := runNpmInstall(wtPath); err != nil {
-		return err
+	// When a dev server is running, record its port in .env.local.
+	if portStr != "" {
+		f, ferr := os.OpenFile(filepath.Join(wtPath, ".env.local"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if ferr != nil {
+			return ferr
+		}
+		_, ferr = f.WriteString("\nPORT=" + portStr + "\n")
+		f.Close()
+		if ferr != nil {
+			return ferr
+		}
 	}
-
-	// Start dev server.
-	devLog, err := os.Create(filepath.Join(wtPath, "dev.log"))
-	if err != nil {
-		return err
-	}
-	devCmd := exec.Command("npm", "run", "dev", "--", "-p", fmt.Sprintf("%d", port))
-	devCmd.Dir = wtPath
-	devCmd.Stdout = devLog
-	devCmd.Stderr = devLog
-	if err := devCmd.Start(); err != nil {
-		devLog.Close()
-		return fmt.Errorf("start dev server: %w", err)
-	}
-	devPID := fmt.Sprintf("%d", devCmd.Process.Pid)
-	fmt.Printf("Dev server: http://localhost:%d (log: %s/dev.log)\n", port, wtPath)
 
 	// Generate session ID.
 	sessionID, err := generateUUID()
@@ -180,7 +145,6 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 	}
 
 	var kickoff string
-	portStr := fmt.Sprintf("%d", port)
 	if sddName == "" {
 		kickoff = sdd.SkipPrompt(issueNum, portStr)
 	} else {
@@ -1077,6 +1041,71 @@ func titleToSlug(title string) string {
 		s = strings.TrimRight(s[:40], "-")
 	}
 	return s
+}
+
+// seedEnvLocal copies src to dst, stripping any PORT= lines. If src does not
+// exist, dst is left untouched.
+func seedEnvLocal(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var filtered []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "PORT=") {
+			filtered = append(filtered, line)
+		}
+	}
+	return os.WriteFile(dst, []byte(strings.Join(filtered, "\n")), 0o600)
+}
+
+// startDevServer detects whether the project in dir has a Node.js dev server
+// (package.json present) and, if so, runs npm install and starts npm run dev
+// on a free port. Returns (devPID, portStr, nil) on success, or ("", "", nil)
+// when no dev server is detected. w receives the informational message printed
+// when no dev server config is found.
+func startDevServer(dir string, w io.Writer) (devPID, portStr string, err error) {
+	if _, statErr := os.Stat(filepath.Join(dir, "package.json")); os.IsNotExist(statErr) {
+		fmt.Fprintf(w, "No dev server configured for this project. Add a dev_server command to .agentctl.yml to start one automatically.\n")
+		return "", "", nil
+	}
+
+	if _, err := exec.LookPath("npm"); err != nil {
+		return "", "", fmt.Errorf("npm not found in PATH\nInstall Node.js from https://nodejs.org and ensure npm is on your PATH, then re-run agentctl start")
+	}
+
+	// npm install
+	install := exec.Command("npm", "install", "--loglevel=error")
+	install.Dir = dir
+	install.Stdout = os.Stdout
+	install.Stderr = os.Stderr
+	if err := install.Run(); err != nil {
+		return "", "", fmt.Errorf("dependency installation failed in %s: %w\n\nPossible causes:\n  • Node version mismatch (check .nvmrc or the project's required Node version)\n  • Network error or private registry credentials required\n\nTo debug: cd %s && npm install", dir, err, dir)
+	}
+
+	port, err := findFreePort(3010, 3100)
+	if err != nil {
+		return "", "", err
+	}
+	portStr = fmt.Sprintf("%d", port)
+
+	devLog, err := os.Create(filepath.Join(dir, "dev.log"))
+	if err != nil {
+		return "", "", err
+	}
+	devCmd := exec.Command("npm", "run", "dev", "--", "-p", portStr)
+	devCmd.Dir = dir
+	devCmd.Stdout = devLog
+	devCmd.Stderr = devLog
+	if err := devCmd.Start(); err != nil {
+		devLog.Close()
+		return "", "", fmt.Errorf("start dev server: %w", err)
+	}
+	fmt.Printf("Dev server: http://localhost:%s (log: %s/dev.log)\n", portStr, dir)
+	return fmt.Sprintf("%d", devCmd.Process.Pid), portStr, nil
 }
 
 func runNpmInstall(dir string) error {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1388,3 +1388,22 @@ func TestRunNpmInstall_errorIncludesDebugHint(t *testing.T) {
 		t.Errorf("error %q does not contain manual repro command", msg)
 	}
 }
+
+func TestStartDevServer_noPackageJSON_returnsEmptyPort(t *testing.T) {
+	dir := t.TempDir() // no package.json
+	var stderr strings.Builder
+	pid, port, err := startDevServer(dir, &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != "" {
+		t.Errorf("expected empty pid when no dev server started, got %q", pid)
+	}
+	if port != "" {
+		t.Errorf("expected empty port when no dev server started, got %q", port)
+	}
+	hint := stderr.String()
+	if !strings.Contains(hint, ".agentctl.yml") {
+		t.Errorf("expected hint about .agentctl.yml, got: %q", hint)
+	}
+}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1413,7 +1413,7 @@ func TestStartDevServer_noPackageJSON_returnsEmptyPort(t *testing.T) {
 func TestStartDevServer_agentctlYml_writesPortBack(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),
-		[]byte("dev_server: \"sh -c 'sleep 100'\"\n"), 0o644); err != nil {
+		[]byte("dev_server: \"echo ok\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	var stderr strings.Builder

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1351,6 +1351,44 @@ func TestWorktreeExistsError_noAgentFile(t *testing.T) {
 	}
 }
 
+func TestSeedEnvLocal_missingSource_doesNothing(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, ".env.local")
+	if err := seedEnvLocal(filepath.Join(dir, "nonexistent"), dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Errorf("expected dst to not exist, but it does")
+	}
+}
+
+func TestSeedEnvLocal_copiesAndStripsPort(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.env.local")
+	dst := filepath.Join(dir, "dst.env.local")
+	content := "API_KEY=secret\nPORT=3000\nDATABASE_URL=postgres://localhost/db\nPORT=4000\n"
+	if err := os.WriteFile(src, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedEnvLocal(src, dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("could not read dst: %v", err)
+	}
+	result := string(got)
+	if strings.Contains(result, "PORT=") {
+		t.Errorf("PORT= lines should be stripped, got: %q", result)
+	}
+	if !strings.Contains(result, "API_KEY=secret") {
+		t.Errorf("API_KEY should be preserved, got: %q", result)
+	}
+	if !strings.Contains(result, "DATABASE_URL=postgres://localhost/db") {
+		t.Errorf("DATABASE_URL should be preserved, got: %q", result)
+	}
+}
+
 func TestRunNpmInstall_notNodeProject(t *testing.T) {
 	dir := t.TempDir() // no package.json — simulates a Python/Go/Java project
 	err := runNpmInstall(dir)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1412,23 +1412,30 @@ func TestStartDevServer_noPackageJSON_returnsEmptyPort(t *testing.T) {
 
 func TestStartDevServer_agentctlYml_writesPortBack(t *testing.T) {
 	dir := t.TempDir()
-	// Write a .agentctl.yml with a dev_server that will fail immediately
-	// (we only care that the port is written back before the process check).
-	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),
-		[]byte("dev_server: \"false\"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// Expect an error (false exits non-zero), but the port write happens before start.
-	// Instead just verify Read after a successful-ish scenario.
-	// Use a no-op command that exits 0 to avoid blocking in test.
 	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),
 		[]byte("dev_server: \"sh -c 'sleep 100'\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	var stderr strings.Builder
-	_, portStr, err := startDevServer(dir, &stderr)
+	pidStr, portStr, err := startDevServer(dir, &stderr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if pidStr != "" {
+		t.Cleanup(func() {
+			pid, parseErr := strconv.Atoi(pidStr)
+			if parseErr != nil {
+				t.Logf("cleanup: could not parse dev server pid %q: %v", pidStr, parseErr)
+				return
+			}
+			proc, findErr := os.FindProcess(pid)
+			if findErr != nil {
+				t.Logf("cleanup: could not find dev server process %d: %v", pid, findErr)
+				return
+			}
+			_ = proc.Kill()
+			_, _ = proc.Wait()
+		})
 	}
 	if portStr == "" {
 		t.Fatal("expected non-empty port when dev_server is set")

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/arun-gupta/agentctl/internal/config"
 	"github.com/arun-gupta/agentctl/internal/sdd"
 	"github.com/arun-gupta/agentctl/internal/state"
 )
@@ -1405,5 +1407,38 @@ func TestStartDevServer_noPackageJSON_returnsEmptyPort(t *testing.T) {
 	hint := stderr.String()
 	if !strings.Contains(hint, ".agentctl.yml") {
 		t.Errorf("expected hint about .agentctl.yml, got: %q", hint)
+	}
+}
+
+func TestStartDevServer_agentctlYml_writesPortBack(t *testing.T) {
+	dir := t.TempDir()
+	// Write a .agentctl.yml with a dev_server that will fail immediately
+	// (we only care that the port is written back before the process check).
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),
+		[]byte("dev_server: \"false\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Expect an error (false exits non-zero), but the port write happens before start.
+	// Instead just verify Read after a successful-ish scenario.
+	// Use a no-op command that exits 0 to avoid blocking in test.
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),
+		[]byte("dev_server: \"sh -c 'sleep 100'\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var stderr strings.Builder
+	_, portStr, err := startDevServer(dir, &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if portStr == "" {
+		t.Fatal("expected non-empty port when dev_server is set")
+	}
+	// Verify port was written back to .agentctl.yml.
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fmt.Sprintf("%d", cfg.Port) != portStr {
+		t.Errorf("port in .agentctl.yml = %d, want %s", cfg.Port, portStr)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,51 @@
+// Package config handles reading and writing the per-repo .agentctl.yml file.
+// This file is the single source of truth for all agentctl repo-level config:
+// developers write the dev_server field; agentctl writes back the allocated port.
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const Filename = ".agentctl.yml"
+
+// AgentctlConfig is the schema for .agentctl.yml.
+type AgentctlConfig struct {
+	// DevServer is the command to start the project's dev server.
+	// Use {port} as a placeholder; agentctl substitutes the allocated port.
+	// Example: "uvicorn main:app --port {port}"
+	DevServer string `yaml:"dev_server,omitempty"`
+
+	// Port is written back by agentctl after it allocates a port for the dev
+	// server. Read-only for the developer.
+	Port int `yaml:"port,omitempty"`
+}
+
+// Read loads .agentctl.yml from dir. If the file does not exist, an empty
+// config is returned with no error.
+func Read(dir string) (*AgentctlConfig, error) {
+	data, err := os.ReadFile(filepath.Join(dir, Filename))
+	if os.IsNotExist(err) {
+		return &AgentctlConfig{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var cfg AgentctlConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// Write serialises cfg to .agentctl.yml in dir, creating the file if needed.
+func Write(dir string, cfg *AgentctlConfig) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, Filename), data, 0o644)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,75 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arun-gupta/agentctl/internal/config"
+)
+
+func TestRead_missingFile_returnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DevServer != "" || cfg.Port != 0 {
+		t.Errorf("expected empty config for missing file, got %+v", cfg)
+	}
+}
+
+func TestRead_parsesDevServer(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"uvicorn main:app --port {port}\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DevServer != "uvicorn main:app --port {port}" {
+		t.Errorf("DevServer = %q, want %q", cfg.DevServer, "uvicorn main:app --port {port}")
+	}
+}
+
+func TestWrite_persistsPort(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"uvicorn main:app --port {port}\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Port = 3042
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+
+	got, err := config.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Port != 3042 {
+		t.Errorf("Port = %d, want 3042", got.Port)
+	}
+	if got.DevServer != "uvicorn main:app --port {port}" {
+		t.Errorf("DevServer lost after Write: %q", got.DevServer)
+	}
+}
+
+func TestWrite_createsFileWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{Port: 3010}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	got, err := config.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Port != 3010 {
+		t.Errorf("Port = %d, want 3010", got.Port)
+	}
+}

--- a/internal/sdd/sdd.go
+++ b/internal/sdd/sdd.go
@@ -20,7 +20,8 @@ var builtinFS embed.FS
 // It never varies by methodology.
 const genericSkipPrompt = `Work on GitHub issue #{issue}. Read CLAUDE.md for project conventions.
 Skip the SDD lifecycle — make the changes directly, push the branch,
-and open a PR. Do not merge. Dev server is running on port {port}.`
+and open a PR. Do not merge.
+Dev server is running on port {port}.`
 
 // Methodology describes a single SDD lifecycle. The name is derived from the
 // YAML filename stem (e.g. "speckit.yml" → "speckit"). There is no name: field.

--- a/internal/sdd/sdd.go
+++ b/internal/sdd/sdd.go
@@ -31,19 +31,33 @@ type Methodology struct {
 }
 
 // KickoffPrompt substitutes {issue} and {port} in the methodology's kickoff
-// template and returns the resulting prompt.
+// template and returns the resulting prompt. When port is empty, any line
+// containing {port} is removed so the agent is not told about a dev server.
 func (m *Methodology) KickoffPrompt(issue, port string) string {
 	s := strings.ReplaceAll(m.Kickoff, "{issue}", issue)
-	s = strings.ReplaceAll(s, "{port}", port)
-	return s
+	return substitutePort(s, port)
 }
 
 // SkipPrompt returns the generic skip prompt with {issue} and {port} substituted.
 // This is always the same regardless of which methodology is active.
 func SkipPrompt(issue, port string) string {
 	s := strings.ReplaceAll(genericSkipPrompt, "{issue}", issue)
-	s = strings.ReplaceAll(s, "{port}", port)
-	return s
+	return substitutePort(s, port)
+}
+
+// substitutePort replaces {port} with the given value. When port is empty,
+// every line that contains {port} is dropped entirely.
+func substitutePort(s, port string) string {
+	if port == "" {
+		var lines []string
+		for _, line := range strings.Split(s, "\n") {
+			if !strings.Contains(line, "{port}") {
+				lines = append(lines, line)
+			}
+		}
+		return strings.TrimRight(strings.Join(lines, "\n"), "\n")
+	}
+	return strings.ReplaceAll(s, "{port}", port)
 }
 
 // Get resolves the named methodology using the three-level lookup (first match wins):

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -308,3 +308,23 @@ func captureStderr(t *testing.T, fn func()) string {
 	r.Close()
 	return buf.String()
 }
+
+// ─── port-free prompts ────────────────────────────────────────────────────────
+
+func TestSkipPrompt_noPort_omitsDevServerLine(t *testing.T) {
+	prompt := sdd.SkipPrompt("42", "")
+	if strings.Contains(prompt, "port") || strings.Contains(prompt, "{port}") {
+		t.Errorf("SkipPrompt with empty port must not mention port, got:\n%s", prompt)
+	}
+}
+
+func TestKickoffPrompt_noPort_omitsDevServerLine(t *testing.T) {
+	m, err := sdd.Get("speckit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := m.KickoffPrompt("42", "")
+	if strings.Contains(prompt, "port") || strings.Contains(prompt, "{port}") {
+		t.Errorf("KickoffPrompt with empty port must not mention port, got:\n%s", prompt)
+	}
+}

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -311,11 +311,22 @@ func captureStderr(t *testing.T, fn func()) string {
 
 // ─── port-free prompts ────────────────────────────────────────────────────────
 
+func assertPromptWithoutPortKeepsGuidance(t *testing.T, promptName, prompt string) {
+	t.Helper()
+	if strings.Contains(prompt, "port") || strings.Contains(prompt, "{port}") {
+		t.Errorf("%s with empty port must not mention port, got:\n%s", promptName, prompt)
+	}
+	if !strings.Contains(prompt, "open a PR") {
+		t.Errorf("%s with empty port must still instruct to open a PR, got:\n%s", promptName, prompt)
+	}
+	if !strings.Contains(prompt, "Do not merge") {
+		t.Errorf("%s with empty port must still instruct not to merge, got:\n%s", promptName, prompt)
+	}
+}
+
 func TestSkipPrompt_noPort_omitsDevServerLine(t *testing.T) {
 	prompt := sdd.SkipPrompt("42", "")
-	if strings.Contains(prompt, "port") || strings.Contains(prompt, "{port}") {
-		t.Errorf("SkipPrompt with empty port must not mention port, got:\n%s", prompt)
-	}
+	assertPromptWithoutPortKeepsGuidance(t, "SkipPrompt", prompt)
 }
 
 func TestKickoffPrompt_noPort_omitsDevServerLine(t *testing.T) {
@@ -324,7 +335,5 @@ func TestKickoffPrompt_noPort_omitsDevServerLine(t *testing.T) {
 		t.Fatal(err)
 	}
 	prompt := m.KickoffPrompt("42", "")
-	if strings.Contains(prompt, "port") || strings.Contains(prompt, "{port}") {
-		t.Errorf("KickoffPrompt with empty port must not mention port, got:\n%s", prompt)
-	}
+	assertPromptWithoutPortKeepsGuidance(t, "KickoffPrompt", prompt)
 }


### PR DESCRIPTION
Closes #103 (root cause). Closes #109. Supersedes #108.

## What changed

`.agentctl.yml` is the single source of truth for all agentctl repo-level config.

### Detection order in `agentctl start`

| Project has | Behaviour |
|---|---|
| `.agentctl.yml` with `dev_server` | Runs that command with `{port}` substituted; writes allocated port back |
| `package.json` | npm install + npm run dev (unchanged); writes allocated port back |
| Neither | Prints guidance, launches agent without dev server |

### `.agentctl.yml` schema

```yaml
# Written by developer:
dev_server: "uvicorn main:app --port {port}"

# Written back by agentctl after start:
port: 3010
```

### Output for a non-Node.js repo with no `.agentctl.yml`

```
No dev server configured for this project. Add a dev_server command to .agentctl.yml to start one automatically.
```

## Implementation

- New **`internal/config`** package — `Read`/`Write` for `.agentctl.yml`; single schema definition
- **`startDevServer`** — three paths (custom, Node.js, none); writes port back to `.agentctl.yml`
- **`seedEnvLocal`** — copies `.env.local` from main repo to worktree, stripping any existing `PORT=` lines
- **`sdd.SkipPrompt` / `KickoffPrompt`** — drop the dev-server line when port is empty

## Test plan

- [x] `go test ./internal/config/` — 4 tests: `Read_missingFile`, `Read_parsesDevServer`, `Write_persistsPort`, `Write_createsFileWhenAbsent`
- [x] `go test ./internal/cmd/ -run TestStartDevServer` — 2 tests: `noPackageJSON_returnsEmptyPort`, `agentctlYml_writesPortBack`
- [x] `go test ./internal/cmd/ -run TestRunNpmInstall` — 2 tests: `notNodeProject`, `errorIncludesDebugHint`
- [x] `go test ./internal/sdd/ -run "TestSkipPrompt_noPort|TestKickoffPrompt_noPort"` — 2 tests
- [x] `go test ./internal/cmd/ -run TestSeedEnvLocal` — 2 tests: `missingSource_doesNothing`, `copiesAndStripsPort`
- [ ] `go test ./...` — only pre-existing failures in `internal/adapters`, `internal/sdd`, `internal/cmd` (path-comparison)
- [ ] Manual: `agentctl start` on a non-Node repo → guidance printed, agent launches
- [ ] Manual: `agentctl start` on a repo with `.agentctl.yml` `dev_server` → custom server starts, port written back to `.agentctl.yml`
- [ ] Manual: `agentctl start` on a Node.js repo → unchanged behaviour, port written to `.agentctl.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)