### PR TITLE
fix: copilot adapter uses session_type: directory, not --session-id

### DIFF
--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -335,17 +335,45 @@ func TestLoad_missingBinary(t *testing.T) {
 	}
 }
 
-func TestResumeCmd_copilot_resumeIDFallsBackToSession(t *testing.T) {
-	// copilot.yml has session: --session-id but no resume_id,
-	// so ResumeCmd should fall back to using --session-id.
+func TestLaunchCmd_copilot_noSessionFlag(t *testing.T) {
+	// copilot uses session_type: directory — session continuity is implicit in
+	// the worktree, so no --session-id flag should be appended.
+	a, err := adapters.Get("copilot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := a.LaunchCmd("do the thing", "sess-cp")
+	args := cmd.Args
+	assertContains(t, args, "copilot")
+	assertContains(t, args, "do the thing")
+	for _, arg := range args {
+		if arg == "sess-cp" {
+			t.Errorf("copilot LaunchCmd should not pass session ID as flag, got args: %v", args)
+		}
+		if arg == "--session-id" {
+			t.Errorf("copilot LaunchCmd should not include --session-id, got args: %v", args)
+		}
+	}
+}
+
+func TestResumeCmd_copilot_noSessionFlag(t *testing.T) {
+	// copilot uses session_type: directory — session continuity is implicit in
+	// the worktree, so no --session-id flag should be appended on resume either.
 	a, err := adapters.Get("copilot")
 	if err != nil {
 		t.Fatal(err)
 	}
 	cmd := a.ResumeCmd("fix it", "sess-cp")
 	args := cmd.Args
-	assertContains(t, args, "--session-id") // falls back to Session flag
-	assertContains(t, args, "sess-cp")
+	assertContains(t, args, "copilot")
+	for _, arg := range args {
+		if arg == "sess-cp" {
+			t.Errorf("copilot ResumeCmd should not pass session ID, got args: %v", args)
+		}
+		if arg == "--session-id" {
+			t.Errorf("copilot ResumeCmd should not include --session-id, got args: %v", args)
+		}
+	}
 }
 
 // ─── install hints ────────────────────────────────────────────────────────────

--- a/internal/adapters/builtin/copilot.yml
+++ b/internal/adapters/builtin/copilot.yml
@@ -1,3 +1,3 @@
 binary: copilot
-session: --session-id
+session_type: directory
 install: npm install -g @github/copilot

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1403,9 +1403,9 @@ func waitForFile(path string, timeout time.Duration) error {
 
 // extractStreamText converts a single claude --output-format stream-json line
 // into human-readable text. wtDir is the worktree directory; file paths inside
-// it are shown as relative paths to reduce noise in terminal output.
-// into human-readable text. It extracts assistant text/tool-use blocks and the
-// final result. Non-JSON lines are returned as-is (plain-text fallback).
+// it are shown as relative paths to reduce noise in terminal output. It
+// extracts assistant text, tool-use blocks, and the final result. Non-JSON
+// lines are returned as-is (plain-text fallback).
 func extractStreamText(line, wtDir string) string {
 	var ev struct {
 		Type    string `json:"type"`
@@ -1522,7 +1522,7 @@ func relativePath(path, base string) string {
 	if err != nil || strings.HasPrefix(rel, "..") {
 		return path
 	}
-	return rel
+	return filepath.ToSlash(rel)
 }
 
 // spinnerFrames are the braille Unicode characters used for the spinner animation.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1312,7 +1312,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			for {
 				line, err := r.ReadString('\n')
 				if line != "" {
-					if text := extractStreamText(strings.TrimSuffix(line, "\n")); text != "" {
+					if text := extractStreamText(strings.TrimSuffix(line, "\n"), wtPath); text != "" {
 						fmt.Fprintln(logFile, text)
 					}
 				}
@@ -1402,9 +1402,11 @@ func waitForFile(path string, timeout time.Duration) error {
 }
 
 // extractStreamText converts a single claude --output-format stream-json line
+// into human-readable text. wtDir is the worktree directory; file paths inside
+// it are shown as relative paths to reduce noise in terminal output.
 // into human-readable text. It extracts assistant text/tool-use blocks and the
 // final result. Non-JSON lines are returned as-is (plain-text fallback).
-func extractStreamText(line string) string {
+func extractStreamText(line, wtDir string) string {
 	var ev struct {
 		Type    string `json:"type"`
 		Subtype string `json:"subtype"`
@@ -1432,7 +1434,7 @@ func extractStreamText(line string) string {
 					sb.WriteByte('\n')
 				}
 			case "tool_use":
-				fmt.Fprintf(&sb, "[%s]\n", toolLabel(c.Name, c.Input))
+				fmt.Fprintf(&sb, "[%s]\n", toolLabel(c.Name, c.Input, wtDir))
 			}
 		}
 		return strings.TrimRight(sb.String(), "\n")
@@ -1461,9 +1463,10 @@ func sanitizeDetail(s string) string {
 
 // toolLabel returns a display string for a tool_use block, including the most
 // useful input field for the given tool so the terminal output is actionable.
+// File paths are shown relative to wtDir when they fall inside it.
 // Set AGENTCTL_NO_TOOL_DETAIL=1 to suppress input details (e.g. to avoid
 // echoing sensitive data to the terminal).
-func toolLabel(name string, input json.RawMessage) string {
+func toolLabel(name string, input json.RawMessage, wtDir string) string {
 	if os.Getenv("AGENTCTL_NO_TOOL_DETAIL") != "" {
 		return name
 	}
@@ -1486,7 +1489,7 @@ func toolLabel(name string, input json.RawMessage) string {
 			FilePath string `json:"file_path"`
 		}
 		if json.Unmarshal(input, &v) == nil && v.FilePath != "" {
-			detail = v.FilePath
+			detail = relativePath(v.FilePath, wtDir)
 		}
 	case "websearch":
 		var v struct {
@@ -1507,6 +1510,19 @@ func toolLabel(name string, input json.RawMessage) string {
 		return name
 	}
 	return name + ": " + sanitizeDetail(detail)
+}
+
+// relativePath returns path relative to base when path is inside base,
+// otherwise returns path unchanged.
+func relativePath(path, base string) string {
+	if base == "" {
+		return path
+	}
+	rel, err := filepath.Rel(base, path)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return path
+	}
+	return rel
 }
 
 // spinnerFrames are the braille Unicode characters used for the spinner animation.

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1110,6 +1110,7 @@ func TestExtractStreamText(t *testing.T) {
 	cases := []struct {
 		name  string
 		line  string
+		wtDir string
 		want  string
 	}{
 		{
@@ -1207,10 +1208,40 @@ func TestExtractStreamText(t *testing.T) {
 			line:  `{"type":"assistant","message":{"content":[{"type":"text","text":"   "}]}}`,
 			want:  "",
 		},
+		{
+			name:  "Read path stripped to relative when under wtDir",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/worktree/components/Foo.tsx"}}]}}`,
+			wtDir: "/worktree",
+			want:  "[Read: components/Foo.tsx]",
+		},
+		{
+			name:  "Write path stripped to relative when under wtDir",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"/worktree/lib/bar.ts"}}]}}`,
+			wtDir: "/worktree",
+			want:  "[Write: lib/bar.ts]",
+		},
+		{
+			name:  "Edit path stripped to relative when under wtDir",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/worktree/app/page.tsx"}}]}}`,
+			wtDir: "/worktree",
+			want:  "[Edit: app/page.tsx]",
+		},
+		{
+			name:  "Read path outside wtDir shown as-is",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/other/file.go"}}]}}`,
+			wtDir: "/worktree",
+			want:  "[Read: /other/file.go]",
+		},
+		{
+			name:  "Read path with empty wtDir shown as-is",
+			line:  `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/some/path.go"}}]}}`,
+			wtDir: "",
+			want:  "[Read: /some/path.go]",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := extractStreamText(tc.line)
+			got := extractStreamText(tc.line, tc.wtDir)
 			if got != tc.want {
 				t.Errorf("extractStreamText(%q) = %q, want %q", tc.line, got, tc.want)
 			}
@@ -1220,7 +1251,7 @@ func TestExtractStreamText(t *testing.T) {
 
 func TestToolLabel_NoToolDetail(t *testing.T) {
 	t.Setenv("AGENTCTL_NO_TOOL_DETAIL", "1")
-	got := toolLabel("Bash", json.RawMessage(`{"command":"ls -la"}`))
+	got := toolLabel("Bash", json.RawMessage(`{"command":"ls -la"}`), "")
 	if got != "Bash" {
 		t.Errorf("expected %q with AGENTCTL_NO_TOOL_DETAIL set, got %q", "Bash", got)
 	}


### PR DESCRIPTION
## Summary

- Fixes #115: `agentctl start <issue> --agent copilot` exited immediately with `error: unknown option '--session-id'`
- Replaced `session: --session-id` in `internal/adapters/builtin/copilot.yml` with `session_type: directory`, matching how the gemini adapter works
- Updated tests: replaced `TestResumeCmd_copilot_resumeIDFallsBackToSession` (which tested the broken behavior) with `TestLaunchCmd_copilot_noSessionFlag` and `TestResumeCmd_copilot_noSessionFlag` that verify no session flag is passed

## Root cause

`copilot.yml` had `session: --session-id`, causing `buildStructuredCmd` to append `--session-id <uuid>` to every copilot invocation. The GitHub Copilot CLI does not recognize that flag. Session continuity for copilot is implicit in the working directory (worktree), not a CLI flag.

## Test plan

- [ ] `go test ./internal/adapters/...` passes with new `noSessionFlag` tests green
- [ ] `go build ./...` and `go vet ./...` are clean
- [ ] `agentctl start <issue> --agent copilot` no longer exits with `unknown option '--session-id'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)