### PR TITLE
feat: validate dev-server config before creating worktree

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -97,6 +97,12 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 	branch := issueNum + "-" + slug
 	wtPath := filepath.Join(parentDir, repoName+"-"+issueNum+"-"+slug)
 
+	// Fail fast if the project has no viable dev-server config — before touching
+	// any worktree state.
+	if err := checkDevServerConfig(repoRoot); err != nil {
+		return err
+	}
+
 	// Create the worktree.
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		return worktreeExistsError(wtPath, issueNum)
@@ -1048,6 +1054,29 @@ func seedEnvLocal(src, dst string) error {
 		}
 	}
 	return os.WriteFile(dst, []byte(strings.Join(filtered, "\n")), 0o600)
+}
+
+// checkDevServerConfig validates that dir has a viable dev-server configuration
+// before any worktree is created.  Decision tree:
+//  1. .agentctl.yml present and dev_server non-empty → nil (custom server)
+//  2. .agentctl.yml present but dev_server empty     → error (config error)
+//  3. package.json present, no .agentctl.yml         → nil (Node path)
+//  4. neither                                         → error (not configured)
+func checkDevServerConfig(dir string) error {
+	if _, err := os.Stat(filepath.Join(dir, config.Filename)); err == nil {
+		cfg, readErr := config.Read(dir)
+		if readErr != nil {
+			return fmt.Errorf("reading .agentctl.yml: %w", readErr)
+		}
+		if cfg.DevServer == "" {
+			return fmt.Errorf(".agentctl.yml found but dev_server field is missing. Add it:\n\n  dev_server: \"uvicorn main:app --port {port}\"")
+		}
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(dir, "package.json")); err == nil {
+		return nil
+	}
+	return fmt.Errorf("No dev server configured. Create .agentctl.yml with a dev_server field first:\n\n  echo 'dev_server: \"uvicorn main:app --port {port}\"' > .agentctl.yml\n\nThen re-run agentctl start.")
 }
 
 // startDevServer starts a dev server for the project in dir. Detection order:

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1479,6 +1479,63 @@ func TestStartDevServer_noPackageJSON_returnsEmptyPort(t *testing.T) {
 	}
 }
 
+func TestCheckDevServerConfig_noAgentctlYml_noPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	err := checkDevServerConfig(dir)
+	if err == nil {
+		t.Fatal("expected error for project with neither .agentctl.yml nor package.json, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, ".agentctl.yml") {
+		t.Errorf("error %q should mention .agentctl.yml", msg)
+	}
+	if !strings.Contains(msg, "dev_server") {
+		t.Errorf("error %q should mention dev_server", msg)
+	}
+}
+
+func TestCheckDevServerConfig_agentctlYmlNoDevServer(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("port: 3010\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := checkDevServerConfig(dir)
+	if err == nil {
+		t.Fatal("expected error for .agentctl.yml without dev_server field, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, ".agentctl.yml") {
+		t.Errorf("error %q should mention .agentctl.yml", msg)
+	}
+	if !strings.Contains(msg, "dev_server") {
+		t.Errorf("error %q should mention dev_server", msg)
+	}
+	if !strings.Contains(msg, "missing") {
+		t.Errorf("error %q should mention the field is missing", msg)
+	}
+}
+
+func TestCheckDevServerConfig_agentctlYmlWithDevServer(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),
+		[]byte("dev_server: \"uvicorn main:app --port {port}\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkDevServerConfig(dir); err != nil {
+		t.Errorf("expected no error for .agentctl.yml with dev_server set, got %v", err)
+	}
+}
+
+func TestCheckDevServerConfig_packageJSON_noAgentctlYml(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"test"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkDevServerConfig(dir); err != nil {
+		t.Errorf("expected no error for Node project without .agentctl.yml, got %v", err)
+	}
+}
+
 func TestStartDevServer_agentctlYml_writesPortBack(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),


### PR DESCRIPTION
## Summary

- Adds `checkDevServerConfig(repoRoot)` called in `runStart` before `git.AddWorktree`, implementing the fail-fast decision tree from issue #114
- Non-Node projects with no `.agentctl.yml` now exit with an actionable message before any worktree state is created
- `.agentctl.yml` present but missing `dev_server` field also exits early with a distinct "field missing" message
- Node projects (`package.json`, no `.agentctl.yml`) and projects with a valid `dev_server` in `.agentctl.yml` proceed unchanged

## Test plan

- [ ] `go test ./internal/cmd/ -run TestCheckDevServerConfig` — 4 new unit tests cover all four decision-tree branches
- [ ] `go test ./...` — full suite passes (pre-existing macOS symlink failures in `TestLocateOrCloneRepo` / `TestRepoRootForIssue` are unrelated to this change)
- [ ] `go vet ./...` — clean
- [ ] `go build ./...` — clean

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)