### PR TITLE
fix: improve worktreeExistsError messages — remove cd, multi-line format

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -971,19 +971,16 @@ func repoRootForIssue(arg string) (repoRoot, issueNum, ghIssueArg string, err er
 // worktreeExistsError returns a descriptive, actionable error for the case
 // where the target worktree directory already exists. It reads the .agent
 // metadata to distinguish between a still-running agent, a finished agent,
-// and a bare worktree with no .agent file, and includes a cd hint so the
-// suggested follow-up commands work regardless of the caller's current
-// directory (e.g. when start was invoked with a full GitHub issue URL from
-// outside the repo).
+// and a bare worktree with no .agent file.
 func worktreeExistsError(wtPath, issueNum string) error {
 	af, readErr := state.Read(wtPath)
 	if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
-		return fmt.Errorf("agent is already running for issue %s — use 'cd %q && agentctl attach %s' to follow its output, or 'cd %q && agentctl discard %s' to start over", issueNum, wtPath, issueNum, wtPath, issueNum)
+		return fmt.Errorf("Worktree already exists for issue %s — agent is still running.\n\n  agentctl attach %s   to follow its output\n  agentctl discard %s   to delete the worktree and start over", issueNum, issueNum, issueNum)
 	}
 	if readErr == nil && af.AgentPID != "" {
-		return fmt.Errorf("agent has finished for issue %s — use 'cd %q && agentctl cleanup %s' if the PR is merged, or 'cd %q && agentctl discard %s' to start over", issueNum, wtPath, issueNum, wtPath, issueNum)
+		return fmt.Errorf("Worktree already exists for issue %s — agent has finished.\n\n  agentctl cleanup %s   if the PR is merged\n  agentctl discard %s   to delete the worktree and start over", issueNum, issueNum, issueNum)
 	}
-	return fmt.Errorf("worktree already exists for issue %s — use 'cd %q && agentctl discard %s' to remove it and start over", issueNum, wtPath, issueNum)
+	return fmt.Errorf("Worktree already exists for issue %s.\n\n  agentctl discard %s   to delete the worktree and start over", issueNum, issueNum)
 }
 
 // slugFromIssue fetches the GitHub issue title and converts it to a slug.

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1300,10 +1300,10 @@ func TestWorktreeExistsError_runningAgent(t *testing.T) {
 	dir := t.TempDir()
 	alivePID := strconv.Itoa(os.Getpid()) // current process is definitely alive
 	if err := state.Write(dir, state.AgentFile{
-		Agent:    "claude",
+		Agent:     "claude",
 		SessionID: "sess-1",
-		DevPID:   "999",
-		AgentPID: alivePID,
+		DevPID:    "999",
+		AgentPID:  alivePID,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1313,8 +1313,11 @@ func TestWorktreeExistsError_runningAgent(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "agent is already running for issue 90") {
-		t.Errorf("expected 'agent is already running for issue 90' in error; got: %q", msg)
+	if !strings.Contains(msg, "Worktree already exists for issue 90") {
+		t.Errorf("expected 'Worktree already exists for issue 90' in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agent is still running") {
+		t.Errorf("expected 'agent is still running' in error; got: %q", msg)
 	}
 	if !strings.Contains(msg, "agentctl attach 90") {
 		t.Errorf("expected 'agentctl attach 90' hint in error; got: %q", msg)
@@ -1322,8 +1325,8 @@ func TestWorktreeExistsError_runningAgent(t *testing.T) {
 	if !strings.Contains(msg, "agentctl discard 90") {
 		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
 	}
-	if !strings.Contains(msg, dir) {
-		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
+	if strings.Contains(msg, "cd ") {
+		t.Errorf("error must not contain 'cd ' (commands work from any directory); got: %q", msg)
 	}
 }
 
@@ -1333,10 +1336,10 @@ func TestWorktreeExistsError_finishedAgent(t *testing.T) {
 	dir := t.TempDir()
 	deadPID := "9999999" // very unlikely to be a live process
 	if err := state.Write(dir, state.AgentFile{
-		Agent:    "claude",
+		Agent:     "claude",
 		SessionID: "sess-2",
-		DevPID:   "999",
-		AgentPID: deadPID,
+		DevPID:    "999",
+		AgentPID:  deadPID,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1346,8 +1349,11 @@ func TestWorktreeExistsError_finishedAgent(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "agent has finished for issue 90") {
-		t.Errorf("expected 'agent has finished for issue 90' in error; got: %q", msg)
+	if !strings.Contains(msg, "Worktree already exists for issue 90") {
+		t.Errorf("expected 'Worktree already exists for issue 90' in error; got: %q", msg)
+	}
+	if !strings.Contains(msg, "agent has finished") {
+		t.Errorf("expected 'agent has finished' in error; got: %q", msg)
 	}
 	if !strings.Contains(msg, "agentctl cleanup 90") {
 		t.Errorf("expected 'agentctl cleanup 90' hint in error; got: %q", msg)
@@ -1355,8 +1361,8 @@ func TestWorktreeExistsError_finishedAgent(t *testing.T) {
 	if !strings.Contains(msg, "agentctl discard 90") {
 		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
 	}
-	if !strings.Contains(msg, dir) {
-		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
+	if strings.Contains(msg, "cd ") {
+		t.Errorf("error must not contain 'cd ' (commands work from any directory); got: %q", msg)
 	}
 }
 
@@ -1371,14 +1377,14 @@ func TestWorktreeExistsError_noAgentFile(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "worktree already exists for issue 90") {
-		t.Errorf("expected 'worktree already exists for issue 90' in error; got: %q", msg)
+	if !strings.Contains(msg, "Worktree already exists for issue 90") {
+		t.Errorf("expected 'Worktree already exists for issue 90' in error; got: %q", msg)
 	}
 	if !strings.Contains(msg, "agentctl discard 90") {
 		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
 	}
-	if !strings.Contains(msg, dir) {
-		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
+	if strings.Contains(msg, "cd ") {
+		t.Errorf("error must not contain 'cd ' (commands work from any directory); got: %q", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #118.

- Removes redundant `cd "<path>"` prefixes from all three `worktreeExistsError` variants — `agentctl cleanup`, `discard`, and `attach` work from any directory since #112
- Reformats the hints from a single long line to a readable two-line indented block
- Capitalises the leading sentence for consistency

**Before:**
```
agent has finished for issue 2 — use 'cd "/Users/arungupta/workspaces/agentctl-test-2-add-task-priority-levels-low-medium-high" && agentctl cleanup 2' if the PR is merged, or 'cd "/Users/arungupta/workspaces/agentctl-test-2-add-task-priority-levels-low-medium-high" && agentctl discard 2' to start over
```

**After:**
```
Worktree already exists for issue 2 — agent has finished.

  agentctl cleanup 2   if the PR is merged
  agentctl discard 2   to delete the worktree and start over
```

## Test plan

- [ ] `go test ./internal/cmd/... -run TestWorktreeExistsError` — all three variants pass
- [ ] `go test ./...` — no new failures introduced
- [ ] `go vet ./...` — clean
- [ ] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)