### PR TITLE
fix: opencode adapter passes kickoff as positional arg, not -p

### DIFF
--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -160,6 +160,54 @@ func TestLaunchCmd_opencode_multiTokenBinary(t *testing.T) {
 	assertContains(t, args, "build it")
 }
 
+func TestLaunchCmd_opencode_noPromptFlag(t *testing.T) {
+	// opencode uses -p for --password, not for the message; kickoff must be
+	// passed as a positional argument via the launch template, never via -p.
+	a, err := adapters.Get("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := a.LaunchCmd("do the work", "sess-oc")
+	args := cmd.Args
+	assertContains(t, args, "run")
+	assertContains(t, args, "do the work")
+	for _, arg := range args {
+		if arg == "-p" {
+			t.Errorf("opencode LaunchCmd must not pass -p (--password flag), got args: %v", args)
+		}
+		if arg == "--session" {
+			t.Errorf("opencode LaunchCmd must not pass --session flag, got args: %v", args)
+		}
+		if arg == "sess-oc" {
+			t.Errorf("opencode LaunchCmd must not pass session ID as flag, got args: %v", args)
+		}
+	}
+}
+
+func TestResumeCmd_opencode(t *testing.T) {
+	// opencode resume must use --continue and must not pass a session flag.
+	a, err := adapters.Get("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := a.ResumeCmd("fix the bug", "sess-oc")
+	args := cmd.Args
+	assertContains(t, args, "run")
+	assertContains(t, args, "fix the bug")
+	assertContains(t, args, "--continue")
+	for _, arg := range args {
+		if arg == "-p" {
+			t.Errorf("opencode ResumeCmd must not pass -p, got args: %v", args)
+		}
+		if arg == "--session" {
+			t.Errorf("opencode ResumeCmd must not pass --session flag, got args: %v", args)
+		}
+		if arg == "sess-oc" {
+			t.Errorf("opencode ResumeCmd must not pass session ID as flag, got args: %v", args)
+		}
+	}
+}
+
 func TestLaunchCmd_minimal(t *testing.T) {
 	a := loadTestdata(t, "minimal.yml")
 	cmd := a.LaunchCmd("hello world", "sess-min")

--- a/internal/adapters/builtin/opencode.yml
+++ b/internal/adapters/builtin/opencode.yml
@@ -1,3 +1,5 @@
 binary: opencode run
-session: --session
+launch: opencode run {kickoff}
+resume_cmd: opencode run {prompt} --continue
+session_type: directory
 install: npm install -g opencode@latest


### PR DESCRIPTION
## Summary

- `opencode run -p <text>` was treating `<text>` as the basic-auth password (`-p`/`--password`), not a message, so opencode received no prompt and exited with `Error: You must provide a message or a command`
- Replace the `session: --session` structured config with explicit `launch`/`resume_cmd` templates that pass the kickoff and prompt as positional arguments (`opencode run {kickoff}` / `opencode run {prompt} --continue`)
- Add `session_type: directory` so no session ID flag is appended (same pattern as the copilot adapter)

## Test plan

- [ ] `go test ./internal/adapters/... -run TestLaunchCmd_opencode` — launch cmd is `opencode run <kickoff>` with no `-p` or `--session`
- [ ] `go test ./internal/adapters/... -run TestResumeCmd_opencode` — resume cmd is `opencode run <prompt> --continue` with no `--session`
- [ ] `go test ./internal/adapters/...` — all adapter tests pass (two pre-existing XDG_CONFIG_HOME failures on macOS are unrelated)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)