### PR TITLE
fix: write .claude/settings.json so sub-agents inherit bypass permissions

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1245,7 +1245,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 		return err
 	}
 
-	if adapterName == "claude" {
+	if headless && adapterName == "claude" {
 		if err := writeClaudeSettings(wtPath); err != nil {
 			return err
 		}
@@ -1633,12 +1633,18 @@ func isWriterTerminal(w io.Writer) bool {
 // exists (e.g. committed in the repo) it is left untouched.
 func writeClaudeSettings(wtPath string) error {
 	dir := filepath.Join(wtPath, ".claude")
+	// Reject symlinks to prevent writing outside the worktree.
+	if fi, err := os.Lstat(dir); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf(".claude is a symlink; refusing to write settings to an unverified location")
+	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create .claude dir: %w", err)
 	}
 	dst := filepath.Join(dir, "settings.json")
 	if _, err := os.Stat(dst); err == nil {
 		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat claude settings: %w", err)
 	}
 	data, err := json.Marshal(map[string]any{
 		"permissions": map[string]any{
@@ -1648,7 +1654,10 @@ func writeClaudeSettings(wtPath string) error {
 	if err != nil {
 		return fmt.Errorf("marshal claude settings: %w", err)
 	}
-	return os.WriteFile(dst, data, 0o644)
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		return fmt.Errorf("write .claude/settings.json: %w", err)
+	}
+	return nil
 }
 
 // agentResume starts the coding agent in resume mode using the named adapter.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1245,6 +1245,12 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 		return err
 	}
 
+	if adapterName == "claude" {
+		if err := writeClaudeSettings(wtPath); err != nil {
+			return err
+		}
+	}
+
 	agentCmd := ad.LaunchCmd(kickoff, sessionID)
 	agentCmd.Dir = wtPath
 
@@ -1619,6 +1625,30 @@ func isWriterTerminal(w io.Writer) bool {
 		return false
 	}
 	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// writeClaudeSettings creates .claude/settings.json in wtPath with a
+// wildcard allow-list so that sub-agents spawned by the top-level Claude
+// process inherit the same bypass-permissions mode. If the file already
+// exists (e.g. committed in the repo) it is left untouched.
+func writeClaudeSettings(wtPath string) error {
+	dir := filepath.Join(wtPath, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create .claude dir: %w", err)
+	}
+	dst := filepath.Join(dir, "settings.json")
+	if _, err := os.Stat(dst); err == nil {
+		return nil
+	}
+	data, err := json.Marshal(map[string]any{
+		"permissions": map[string]any{
+			"allow": []string{"*"},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal claude settings: %w", err)
+	}
+	return os.WriteFile(dst, data, 0o644)
 }
 
 // agentResume starts the coding agent in resume mode using the named adapter.

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1518,3 +1518,99 @@ func TestStartDevServer_agentctlYml_writesPortBack(t *testing.T) {
 		t.Errorf("port in .agentctl.yml = %d, want %s", cfg.Port, portStr)
 	}
 }
+
+// ─── writeClaudeSettings ──────────────────────────────────────────────────────
+
+func TestWriteClaudeSettings_createsFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeClaudeSettings(dir); err != nil {
+		t.Fatalf("writeClaudeSettings: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf(".claude/settings.json not created: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal settings.json: %v", err)
+	}
+	perms, ok := got["permissions"].(map[string]any)
+	if !ok {
+		t.Fatal("settings.json missing 'permissions' object")
+	}
+	allow, ok := perms["allow"].([]any)
+	if !ok || len(allow) == 0 || allow[0] != "*" {
+		t.Errorf("permissions.allow = %v, want [\"*\"]", allow)
+	}
+}
+
+func TestWriteClaudeSettings_doesNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte(`{"custom":"value"}`)
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	if err := os.WriteFile(settingsPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeClaudeSettings(dir); err != nil {
+		t.Fatalf("writeClaudeSettings: %v", err)
+	}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(original) {
+		t.Errorf("existing settings.json was overwritten: got %q, want %q", data, original)
+	}
+}
+
+func TestLaunchAgent_claudeHeadlessWritesSettingsJson(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "argv.txt")
+	scriptPath := filepath.Join(dir, "claude-stub")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"" + argsFile + "\"\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeLocalAdapter(t, dir, "claude", "binary: "+scriptPath+"\nsession: --session\n")
+	chdirTemp(t, dir)
+
+	if err := launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", true, false); err != nil {
+		t.Fatalf("launchAgent headless: %v", err)
+	}
+
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf(".claude/settings.json not found after claude launch: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal settings.json: %v", err)
+	}
+	perms, ok := got["permissions"].(map[string]any)
+	if !ok {
+		t.Fatal("settings.json missing 'permissions'")
+	}
+	allow, ok := perms["allow"].([]any)
+	if !ok || len(allow) == 0 || allow[0] != "*" {
+		t.Errorf("permissions.allow = %v, want [\"*\"]", allow)
+	}
+}
+
+func TestLaunchAgent_nonClaudeDoesNotWriteSettingsJson(t *testing.T) {
+	dir := t.TempDir()
+	writeLocalAdapter(t, dir, "echoagent", "binary: echo\nsession: --session\n")
+	chdirTemp(t, dir)
+
+	if err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", true, false); err != nil {
+		t.Fatalf("launchAgent headless: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".claude", "settings.json")); err == nil {
+		t.Error("non-claude adapter must not write .claude/settings.json")
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes #119: sub-agents spawned by a headless Claude session fail with `Permission denied` because they start without `--permission-mode bypassPermissions`
- Before launching the top-level `claude` process, `agentctl` now writes `.claude/settings.json` with `{"permissions":{"allow":["*"]}}` into the worktree
- Claude Code reads this project-level settings file for all processes running inside the worktree — including sub-agents — so they inherit the same allow-all permission mode
- The file is not written if one already exists (the repo may ship its own settings)

## Test plan

- [ ] `go test ./internal/cmd/ -run TestWriteClaudeSettings` — unit tests for the new `writeClaudeSettings` function (idempotency + content)
- [ ] `go test ./internal/cmd/ -run TestLaunchAgent_claudeHeadlessWritesSettingsJson` — verifies `launchAgent` creates the file for the `claude` adapter
- [ ] `go test ./internal/cmd/ -run TestLaunchAgent_nonClaudeDoesNotWriteSettingsJson` — verifies non-claude adapters are not affected
- [ ] `go build ./...` and `go vet ./...` pass with no errors
- [ ] Manual: run `agentctl start <issue> --headless` and confirm a sub-agent (e.g. General-purpose agent) can read files and run commands without "Permission denied"

🤖 Generated with [Claude Code](https://claude.com/claude-code)