### PR TITLE
fix: show worktree path once in worktreeExistsError messages

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -975,12 +975,12 @@ func repoRootForIssue(arg string) (repoRoot, issueNum, ghIssueArg string, err er
 func worktreeExistsError(wtPath, issueNum string) error {
 	af, readErr := state.Read(wtPath)
 	if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
-		return fmt.Errorf("Worktree already exists for issue %s — agent is still running.\n\n  agentctl attach %s   to follow its output\n  agentctl discard %s   to delete the worktree and start over", issueNum, issueNum, issueNum)
+		return fmt.Errorf("Worktree already exists for issue %s — agent is still running.\nWorktree: %s\n\n  agentctl attach %s   to follow its output\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, issueNum, issueNum)
 	}
 	if readErr == nil && af.AgentPID != "" {
-		return fmt.Errorf("Worktree already exists for issue %s — agent has finished.\n\n  agentctl cleanup %s   if the PR is merged\n  agentctl discard %s   to delete the worktree and start over", issueNum, issueNum, issueNum)
+		return fmt.Errorf("Worktree already exists for issue %s — agent has finished.\nWorktree: %s\n\n  agentctl cleanup %s   if the PR is merged\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, issueNum, issueNum)
 	}
-	return fmt.Errorf("Worktree already exists for issue %s.\n\n  agentctl discard %s   to delete the worktree and start over", issueNum, issueNum)
+	return fmt.Errorf("Worktree already exists for issue %s.\nWorktree: %s\n\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, issueNum)
 }
 
 // slugFromIssue fetches the GitHub issue title and converts it to a slug.

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1325,8 +1325,8 @@ func TestWorktreeExistsError_runningAgent(t *testing.T) {
 	if !strings.Contains(msg, "agentctl discard 90") {
 		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
 	}
-	if strings.Contains(msg, "cd ") {
-		t.Errorf("error must not contain 'cd ' (commands work from any directory); got: %q", msg)
+	if !strings.Contains(msg, dir) {
+		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
 	}
 }
 
@@ -1361,8 +1361,8 @@ func TestWorktreeExistsError_finishedAgent(t *testing.T) {
 	if !strings.Contains(msg, "agentctl discard 90") {
 		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
 	}
-	if strings.Contains(msg, "cd ") {
-		t.Errorf("error must not contain 'cd ' (commands work from any directory); got: %q", msg)
+	if !strings.Contains(msg, dir) {
+		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
 	}
 }
 
@@ -1383,8 +1383,8 @@ func TestWorktreeExistsError_noAgentFile(t *testing.T) {
 	if !strings.Contains(msg, "agentctl discard 90") {
 		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
 	}
-	if strings.Contains(msg, "cd ") {
-		t.Errorf("error must not contain 'cd ' (commands work from any directory); got: %q", msg)
+	if !strings.Contains(msg, dir) {
+		t.Errorf("expected worktree path %q in error; got: %q", dir, msg)
 	}
 }
 


### PR DESCRIPTION
Addresses unresolved Copilot comments on #122.

## Problem

#122 removed `cd "<path>" &&` from all three `worktreeExistsError` variants. Copilot correctly noted that `attach`, `cleanup`, and `discard` all call `git.RepoRoot()` internally, so they fail when run from outside a git repo. Without the path shown anywhere, the hints become non-actionable for users who invoked `agentctl start` from outside the repo via an issue URL.

## Fix

Show the worktree path once per message on its own `Worktree:` line. The commands are listed without a path prefix, keeping them clean, but the user always knows where the worktree is.

**Before (from #122):**
```
Worktree already exists for issue 2 — agent has finished.

  agentctl cleanup 2   if the PR is merged
  agentctl discard 2   to delete the worktree and start over
```

**After:**
```
Worktree already exists for issue 2 — agent has finished.
Worktree: /Users/arungupta/workspaces/agentctl-test-2-add-task-priority-levels-low-medium-high

  agentctl cleanup 2   if the PR is merged
  agentctl discard 2   to delete the worktree and start over
```

## Test plan

- [x] `go test ./internal/cmd/ -run TestWorktreeExistsError` — all 3 variants pass; assertions now check path is present
- [ ] `go test ./...` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)