### PR TITLE
fix: suppress stack traces and JSON blobs from terminal stream

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -1366,7 +1367,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		followLog(logPath, os.Stdout, logDone, quiet)
+		followLog(logPath, os.Stdout, logDone, quiet, true)
 	}()
 
 	sigCh := make(chan os.Signal, 1)
@@ -1525,6 +1526,24 @@ func relativePath(path, base string) string {
 	return filepath.ToSlash(rel)
 }
 
+// stackFrameRe matches JavaScript/Node.js stack-frame lines, e.g.
+//   at Gaxios._request (file:///path/bundle.js:8578:19)
+var stackFrameRe = regexp.MustCompile(`^\s+at\s+\S`)
+
+// isStderrNoise reports whether line is verbose agent error noise that should
+// be suppressed from the terminal stream. It matches JavaScript/Node.js stack
+// frames and standalone JSON blobs. The raw line is still written to agent.log.
+func isStderrNoise(line string) bool {
+	if stackFrameRe.MatchString(line) {
+		return true
+	}
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') && json.Valid([]byte(trimmed)) {
+		return true
+	}
+	return false
+}
+
 // spinnerFrames are the braille Unicode characters used for the spinner animation.
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
@@ -1541,7 +1560,7 @@ var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "�
 // is shown. After done is closed, any remaining content is flushed (unless quiet).
 // Note: agent-process hang-on-exit (issue #78) is a separate concern and is
 // not addressed here; that fix belongs in the process-monitoring loop.
-func followLog(logPath string, out io.Writer, done <-chan struct{}, quiet bool) {
+func followLog(logPath string, out io.Writer, done <-chan struct{}, quiet bool, filterNoise bool) {
 	f, err := os.Open(logPath)
 	if err != nil {
 		fmt.Fprintf(out, "warning: unable to follow log: %v\n", err)
@@ -1570,8 +1589,10 @@ func followLog(logPath string, out io.Writer, done <-chan struct{}, quiet bool) 
 		for {
 			line, err := reader.ReadString('\n')
 			if line != "" && !quiet {
-				clearSpinner()
-				fmt.Fprint(out, line)
+				if !filterNoise || !isStderrNoise(strings.TrimRight(line, "\r\n")) {
+					clearSpinner()
+					fmt.Fprint(out, line)
+				}
 			}
 			if errors.Is(err, io.EOF) {
 				// ReadString may return a partial line (no trailing '\n') together

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -882,7 +882,7 @@ func TestFollowLog_drainsContentAndExits(t *testing.T) {
 	finished := make(chan struct{})
 	go func() {
 		defer close(finished)
-		followLog(logPath, &buf, done, false)
+		followLog(logPath, &buf, done, false, false)
 	}()
 
 	// Poll until followLog has picked up the initial content.
@@ -944,7 +944,7 @@ func TestFollowLog_heartbeatOnNonTTY(t *testing.T) {
 	finished := make(chan struct{})
 	go func() {
 		defer close(finished)
-		followLog(logPath, &buf, done, false)
+		followLog(logPath, &buf, done, false, false)
 	}()
 
 	// The first heartbeat is emitted immediately (lastHeartbeat starts 30s in the
@@ -978,7 +978,7 @@ func TestFollowLog_quietSuppressesLogLines(t *testing.T) {
 	finished := make(chan struct{})
 	go func() {
 		defer close(finished)
-		followLog(logPath, &buf, done, true)
+		followLog(logPath, &buf, done, true, false)
 	}()
 
 	time.Sleep(300 * time.Millisecond)
@@ -1476,6 +1476,176 @@ func TestStartDevServer_noPackageJSON_returnsEmptyPort(t *testing.T) {
 	hint := stderr.String()
 	if !strings.Contains(hint, ".agentctl.yml") {
 		t.Errorf("expected hint about .agentctl.yml, got: %q", hint)
+	}
+}
+
+// ─── isStderrNoise ────────────────────────────────────────────────────────────
+
+func TestIsStderrNoise(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		// JavaScript/Node.js stack frames
+		{
+			name: "stack frame 4 spaces",
+			line: "    at Gaxios._request (file:///opt/homebrew/Cellar/gemini-cli/bundle/chunk.js:8578:19)",
+			want: true,
+		},
+		{
+			name: "stack frame node internals",
+			line: "    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)",
+			want: true,
+		},
+		{
+			name: "stack frame 2 spaces",
+			line: "  at foo (bar.ts:1:2)",
+			want: true,
+		},
+		{
+			name: "stack frame tab-indented",
+			line: "\tat SomeClass.method (file.js:10:5)",
+			want: true,
+		},
+		// Raw JSON blobs
+		{
+			name: "json object blob",
+			line: `{"error":{"code":429,"message":"No capacity"}}`,
+			want: true,
+		},
+		{
+			name: "json array blob",
+			line: `[{"error":"something"}]`,
+			want: true,
+		},
+		{
+			name: "json object with leading whitespace",
+			line: `  {"code": 429}`,
+			want: true,
+		},
+		// Not noise — should pass through
+		{
+			name: "human-readable error summary",
+			line: "Attempt 2 failed with status 429. Retrying with backoff...",
+			want: false,
+		},
+		{
+			name: "normal agent output",
+			line: "Starting agent...",
+			want: false,
+		},
+		{
+			name: "empty line",
+			line: "",
+			want: false,
+		},
+		{
+			name: "incomplete json not a blob",
+			line: `{"type": "assistant"`,
+			want: false,
+		},
+		{
+			name: "plain text that mentions at",
+			line: "looking at the problem",
+			want: false,
+		},
+		{
+			name: "json fragment property line",
+			line: `  "error": {`,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isStderrNoise(tc.line)
+			if got != tc.want {
+				t.Errorf("isStderrNoise(%q) = %v, want %v", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFollowLog_filterNoise_suppressesStackTracesAndJsonBlobs verifies that
+// when filterNoise is true, followLog omits stack frames and JSON blobs but
+// still shows normal lines. The raw content remains in the file.
+func TestFollowLog_filterNoise_suppressesStackTracesAndJsonBlobs(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.log")
+
+	content := strings.Join([]string{
+		"Starting agent",
+		`    at Gaxios._request (file:///path/to/bundle.js:8578:19)`,
+		`    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)`,
+		`{"error":{"code":429,"message":"No capacity"}}`,
+		"normal output after error",
+		"",
+	}, "\n")
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		followLog(logPath, &buf, done, false, true)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(buf.String(), "normal output") {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	close(done)
+	<-finished
+
+	out := buf.String()
+	if strings.Contains(out, "at Gaxios._request") {
+		t.Errorf("stack frame should be suppressed; got: %q", out)
+	}
+	if strings.Contains(out, `"code":429`) {
+		t.Errorf("JSON blob should be suppressed; got: %q", out)
+	}
+	if !strings.Contains(out, "Starting agent") {
+		t.Errorf("normal line should pass through; got: %q", out)
+	}
+	if !strings.Contains(out, "normal output after error") {
+		t.Errorf("normal line should pass through; got: %q", out)
+	}
+}
+
+// TestFollowLog_filterNoise_false_passesEverything verifies that when
+// filterNoise is false, followLog streams everything including stack frames.
+func TestFollowLog_filterNoise_false_passesEverything(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.log")
+
+	content := "normal line\n    at Gaxios._request (file:///path.js:1:1)\n"
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		followLog(logPath, &buf, done, false, false)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !strings.Contains(buf.String(), "at Gaxios") {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	close(done)
+	<-finished
+
+	out := buf.String()
+	if !strings.Contains(out, "at Gaxios._request") {
+		t.Errorf("without filterNoise, stack frame should be present; got: %q", out)
 	}
 }
 


### PR DESCRIPTION
Fixes #125.

## Summary

- Adds `isStderrNoise(line string) bool` that returns `true` for JavaScript/Node.js stack frames (`    at Func (file:line:col)`) and standalone JSON blobs (valid JSON starting with `{` or `[`).
- Adds `filterNoise bool` parameter to `followLog`; `launchAgent` passes `true` so the live terminal stream is clean.
- The full raw output (including stack traces) is still written to `agent.log` for debugging — no change to file content.
- `agentctl logs` and `agentctl attach` are unaffected: they use `tail` directly on `agent.log` and do not call `followLog`.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./internal/cmd/ -run TestIsStderrNoise` — all 13 sub-cases pass
- [ ] `go test ./internal/cmd/ -run TestFollowLog_filterNoise` — both new cases pass
- [ ] All existing `followLog` tests continue to pass (`TestFollowLog_drainsContentAndExits`, `TestFollowLog_heartbeatOnNonTTY`, `TestFollowLog_quietSuppressesLogLines`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)