### PR TITLE
feat: add {worktree} placeholder to adapter launch templates

### DIFF
--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -45,7 +45,7 @@ type Adapter struct {
 	LaunchTemplate string `yaml:"launch"`
 
 	// ResumeCmdTemplate is a full resume command override. Placeholders:
-	// {prompt}, {session_id}, {kickoff}, {worktree}. When set,
+	// {prompt}, {session_id}, {worktree}. When set,
 	// Binary/Prompt/ResumeID are ignored for resume.
 	ResumeCmdTemplate string `yaml:"resume_cmd"`
 

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -40,13 +40,13 @@ type Adapter struct {
 	SessionType string `yaml:"session_type"`
 
 	// LaunchTemplate is a full launch command override. Placeholders:
-	// {kickoff}, {session_id}. When set, Binary/Prompt/Session are
+	// {kickoff}, {session_id}, {worktree}. When set, Binary/Prompt/Session are
 	// ignored for launch.
 	LaunchTemplate string `yaml:"launch"`
 
 	// ResumeCmdTemplate is a full resume command override. Placeholders:
-	// {prompt}, {session_id}, {kickoff}. When set, Binary/Prompt/ResumeID are
-	// ignored for resume.
+	// {prompt}, {session_id}, {kickoff}, {worktree}. When set,
+	// Binary/Prompt/ResumeID are ignored for resume.
 	ResumeCmdTemplate string `yaml:"resume_cmd"`
 
 	// Install is an optional hint shown when the binary is not found on PATH.
@@ -59,24 +59,29 @@ type Adapter struct {
 
 // LaunchCmd returns an *exec.Cmd that starts the agent in the given worktree.
 // kickoff is the multi-line kickoff prompt; sessionID is the UUID assigned by
-// agentctl.
-func (a *Adapter) LaunchCmd(kickoff, sessionID string) *exec.Cmd {
+// agentctl; wtPath is the absolute path to the worktree (used by {worktree}
+// in template adapters that require an explicit directory permission flag).
+func (a *Adapter) LaunchCmd(kickoff, sessionID, wtPath string) *exec.Cmd {
 	if a.LaunchTemplate != "" {
 		return buildFromTemplate(a.LaunchTemplate, map[string]string{
 			"{kickoff}":    kickoff,
 			"{session_id}": sessionID,
+			"{worktree}":   wtPath,
 		})
 	}
 	return a.buildStructuredCmd(kickoff, a.Session, sessionID)
 }
 
 // ResumeCmd returns an *exec.Cmd that resumes the agent with a new prompt.
-// prompt is the revision/feedback text; sessionID is read from .agent.
-func (a *Adapter) ResumeCmd(prompt, sessionID string) *exec.Cmd {
+// prompt is the revision/feedback text; sessionID is read from .agent;
+// wtPath is the absolute path to the worktree (used by {worktree} in
+// template adapters that require an explicit directory permission flag).
+func (a *Adapter) ResumeCmd(prompt, sessionID, wtPath string) *exec.Cmd {
 	if a.ResumeCmdTemplate != "" {
 		return buildFromTemplate(a.ResumeCmdTemplate, map[string]string{
 			"{prompt}":     prompt,
 			"{session_id}": sessionID,
+			"{worktree}":   wtPath,
 		})
 	}
 	resumeID := a.ResumeID

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -411,8 +411,7 @@ func TestLaunchCmd_copilot_addsWorktreeDir(t *testing.T) {
 	}
 	cmd := a.LaunchCmd("do the thing", "sess-cp", "/tmp/wt")
 	args := cmd.Args
-	assertContains(t, args, "--add-dir")
-	assertContains(t, args, "/tmp/wt")
+	assertAdjacentArgs(t, args, "--add-dir", "/tmp/wt")
 }
 
 func TestResumeCmd_copilot_noSessionFlag(t *testing.T) {
@@ -442,8 +441,7 @@ func TestResumeCmd_copilot_addsWorktreeDir(t *testing.T) {
 	}
 	cmd := a.ResumeCmd("fix it", "sess-cp", "/tmp/wt")
 	args := cmd.Args
-	assertContains(t, args, "--add-dir")
-	assertContains(t, args, "/tmp/wt")
+	assertAdjacentArgs(t, args, "--add-dir", "/tmp/wt")
 }
 
 // ─── install hints ────────────────────────────────────────────────────────────
@@ -562,6 +560,20 @@ func assertContains(t *testing.T, args []string, want string) {
 		}
 	}
 	t.Errorf("args %v does not contain %q", args, want)
+}
+
+func assertAdjacentArgs(t *testing.T, args []string, flag, value string) {
+	t.Helper()
+	for i, a := range args {
+		if a == flag {
+			if i+1 < len(args) && args[i+1] == value {
+				return
+			}
+			t.Errorf("args %v: %q not immediately followed by %q", args, flag, value)
+			return
+		}
+	}
+	t.Errorf("args %v does not contain %q", args, flag)
 }
 
 func loadTestdata(t *testing.T, filename string) *adapters.Adapter {

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -61,7 +61,7 @@ func TestLaunchCmd_claude(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.LaunchCmd("do the thing", "sess-123")
+	cmd := a.LaunchCmd("do the thing", "sess-123", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "claude")
 	assertContains(t, args, "do the thing")
@@ -75,7 +75,7 @@ func TestResumeCmd_claude(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.ResumeCmd("my feedback", "sess-123")
+	cmd := a.ResumeCmd("my feedback", "sess-123", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "claude")
 	assertContains(t, args, "my feedback")
@@ -88,7 +88,7 @@ func TestLaunchCmd_gemini_noSessionFlag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.LaunchCmd("do gemini stuff", "sess-abc")
+	cmd := a.LaunchCmd("do gemini stuff", "sess-abc", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "gemini")
 	assertContains(t, args, "do gemini stuff")
@@ -105,7 +105,7 @@ func TestResumeCmd_gemini_noSessionFlag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.ResumeCmd("revise this", "sess-abc")
+	cmd := a.ResumeCmd("revise this", "sess-abc", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "gemini")
 	for _, arg := range args {
@@ -120,7 +120,7 @@ func TestLaunchCmd_codex_structuredFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.LaunchCmd("write tests", "sess-xyz")
+	cmd := a.LaunchCmd("write tests", "sess-xyz", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "codex")
 	assertContains(t, args, "-q")
@@ -134,7 +134,7 @@ func TestResumeCmd_codex_usesResumeID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.ResumeCmd("fix the bug", "sess-xyz")
+	cmd := a.ResumeCmd("fix the bug", "sess-xyz", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "--resume")
 	assertContains(t, args, "sess-xyz")
@@ -150,7 +150,7 @@ func TestLaunchCmd_opencode_multiTokenBinary(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.LaunchCmd("build it", "sess-oc")
+	cmd := a.LaunchCmd("build it", "sess-oc", "/tmp/wt")
 	// Path should point to "opencode" binary, "run" should be first arg
 	if !strings.HasSuffix(cmd.Path, "opencode") {
 		t.Errorf("opencode LaunchCmd Path should be opencode, got %q", cmd.Path)
@@ -167,7 +167,7 @@ func TestLaunchCmd_opencode_noPromptFlag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.LaunchCmd("do the work", "sess-oc")
+	cmd := a.LaunchCmd("do the work", "sess-oc", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "run")
 	assertContains(t, args, "do the work")
@@ -190,7 +190,7 @@ func TestResumeCmd_opencode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.ResumeCmd("fix the bug", "sess-oc")
+	cmd := a.ResumeCmd("fix the bug", "sess-oc", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "run")
 	assertContains(t, args, "fix the bug")
@@ -210,7 +210,7 @@ func TestResumeCmd_opencode(t *testing.T) {
 
 func TestLaunchCmd_minimal(t *testing.T) {
 	a := loadTestdata(t, "minimal.yml")
-	cmd := a.LaunchCmd("hello world", "sess-min")
+	cmd := a.LaunchCmd("hello world", "sess-min", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "minbot")
 	assertContains(t, args, "-p")
@@ -220,7 +220,7 @@ func TestLaunchCmd_minimal(t *testing.T) {
 
 func TestLaunchCmd_fullOverride(t *testing.T) {
 	a := loadTestdata(t, "full-override.yml")
-	cmd := a.LaunchCmd("my kickoff", "sess-99")
+	cmd := a.LaunchCmd("my kickoff", "sess-99", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "mybot")
 	assertContains(t, args, "--init")
@@ -231,7 +231,7 @@ func TestLaunchCmd_fullOverride(t *testing.T) {
 
 func TestResumeCmd_fullOverride(t *testing.T) {
 	a := loadTestdata(t, "full-override.yml")
-	cmd := a.ResumeCmd("please fix", "sess-99")
+	cmd := a.ResumeCmd("please fix", "sess-99", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "mybot")
 	assertContains(t, args, "--continue")
@@ -242,7 +242,7 @@ func TestResumeCmd_fullOverride(t *testing.T) {
 
 func TestLaunchCmd_structured(t *testing.T) {
 	a := loadTestdata(t, "structured.yml")
-	cmd := a.LaunchCmd("do work", "sess-st")
+	cmd := a.LaunchCmd("do work", "sess-st", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "structbot")
 	assertContains(t, args, "-q")
@@ -253,7 +253,7 @@ func TestLaunchCmd_structured(t *testing.T) {
 
 func TestResumeCmd_structured_usesResumeID(t *testing.T) {
 	a := loadTestdata(t, "structured.yml")
-	cmd := a.ResumeCmd("feedback", "sess-st")
+	cmd := a.ResumeCmd("feedback", "sess-st", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "--resume")
 	assertContains(t, args, "sess-st")
@@ -390,7 +390,7 @@ func TestLaunchCmd_copilot_noSessionFlag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.LaunchCmd("do the thing", "sess-cp")
+	cmd := a.LaunchCmd("do the thing", "sess-cp", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "copilot")
 	assertContains(t, args, "do the thing")
@@ -404,6 +404,17 @@ func TestLaunchCmd_copilot_noSessionFlag(t *testing.T) {
 	}
 }
 
+func TestLaunchCmd_copilot_addsWorktreeDir(t *testing.T) {
+	a, err := adapters.Get("copilot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := a.LaunchCmd("do the thing", "sess-cp", "/tmp/wt")
+	args := cmd.Args
+	assertContains(t, args, "--add-dir")
+	assertContains(t, args, "/tmp/wt")
+}
+
 func TestResumeCmd_copilot_noSessionFlag(t *testing.T) {
 	// copilot uses session_type: directory — session continuity is implicit in
 	// the worktree, so no --session-id flag should be appended on resume either.
@@ -411,7 +422,7 @@ func TestResumeCmd_copilot_noSessionFlag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := a.ResumeCmd("fix it", "sess-cp")
+	cmd := a.ResumeCmd("fix it", "sess-cp", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "copilot")
 	for _, arg := range args {
@@ -422,6 +433,17 @@ func TestResumeCmd_copilot_noSessionFlag(t *testing.T) {
 			t.Errorf("copilot ResumeCmd should not include --session-id, got args: %v", args)
 		}
 	}
+}
+
+func TestResumeCmd_copilot_addsWorktreeDir(t *testing.T) {
+	a, err := adapters.Get("copilot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := a.ResumeCmd("fix it", "sess-cp", "/tmp/wt")
+	args := cmd.Args
+	assertContains(t, args, "--add-dir")
+	assertContains(t, args, "/tmp/wt")
 }
 
 // ─── install hints ────────────────────────────────────────────────────────────

--- a/internal/adapters/builtin/copilot.yml
+++ b/internal/adapters/builtin/copilot.yml
@@ -1,3 +1,5 @@
 binary: copilot
+launch: copilot --add-dir {worktree} -p {kickoff}
+resume_cmd: copilot --add-dir {worktree} -p {prompt} --continue
 session_type: directory
 install: npm install -g @github/copilot

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1249,7 +1249,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 		}
 	}
 
-	agentCmd := ad.LaunchCmd(kickoff, sessionID)
+	agentCmd := ad.LaunchCmd(kickoff, sessionID, wtPath)
 	agentCmd.Dir = wtPath
 
 	logPath := filepath.Join(wtPath, "agent.log")
@@ -1685,7 +1685,7 @@ func agentResume(adapterName, wtPath, sessionID, prompt string) error {
 		return err
 	}
 
-	resumeCmd := ad.ResumeCmd(prompt, sessionID)
+	resumeCmd := ad.ResumeCmd(prompt, sessionID, wtPath)
 	resumeCmd.Dir = wtPath
 
 	logFile, err := os.OpenFile(filepath.Join(wtPath, "agent.log"),


### PR DESCRIPTION
## Summary

- Adds `{worktree}` as a supported placeholder in `LaunchTemplate` and `ResumeCmdTemplate`, alongside `{kickoff}`, `{session_id}`, and `{prompt}`
- Updates `LaunchCmd` and `ResumeCmd` signatures to accept `wtPath string` as a third argument; both call sites in `commands.go` updated accordingly
- Updates `copilot.yml` to add `launch` and `resume_cmd` templates using `--add-dir {worktree}`, granting sub-agents explicit write permission to the worktree
- `{worktree}` is template-only; structured adapters (e.g. codex) must define a `launch:` template to use it — documented in field comments

## Test plan

- [x] All existing `LaunchCmd`/`ResumeCmd` test calls updated to pass `wtPath` (`"/tmp/wt"`)
- [x] `TestLaunchCmd_copilot_addsWorktreeDir` — asserts `--add-dir /tmp/wt` in launch args
- [x] `TestResumeCmd_copilot_addsWorktreeDir` — asserts `--add-dir /tmp/wt` in resume args
- [x] `TestLaunchCmd_copilot_noSessionFlag` — still asserts session ID is not passed
- [x] `TestResumeCmd_copilot_noSessionFlag` — still asserts session ID is not passed on resume
- [x] `go build ./...` and `go vet ./...` clean

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)