### PR TITLE
fix: speckit STAGE 1 tells user to run agentctl resume, not reply in chat

### DIFF
--- a/internal/sdd/builtin/speckit.yml
+++ b/internal/sdd/builtin/speckit.yml
@@ -1,9 +1,11 @@
 kickoff: |
   Work on GitHub issue #{issue}. Read CLAUDE.md for project conventions.
   Follow the SpecKit spec-driven development lifecycle:
-  - STAGE 1: Run /speckit.specify to create a spec. When the spec is ready, tell the user
-    to run `agentctl resume {issue}` to approve, or `agentctl resume {issue} "your feedback"`
-    to request revisions. Do not proceed until resumed.
+  - STAGE 1: Run /speckit.specify to create a spec. Note: /speckit.* commands are
+    internal-only; do not mention them to the user. When the spec is ready, tell the
+    user to run `agentctl resume {issue}` to approve, or
+    `agentctl resume {issue} "your feedback"` to request revisions.
+    Do not proceed until resumed.
   - STAGE 2: Run /speckit.plan to break the spec into a plan.
   - STAGE 3: Run /speckit.tasks to create task list.
   - STAGE 4: Run /speckit.implement to implement the tasks.

--- a/internal/sdd/builtin/speckit.yml
+++ b/internal/sdd/builtin/speckit.yml
@@ -2,7 +2,7 @@ kickoff: |
   Work on GitHub issue #{issue}. Read CLAUDE.md for project conventions.
   Follow the SpecKit spec-driven development lifecycle:
   - STAGE 1: Run /speckit.specify to create a spec. When the spec is ready, tell the user
-    to run `agentctl resume {issue}` to approve, or `agentctl resume {issue} "feedback"`
+    to run `agentctl resume {issue}` to approve, or `agentctl resume {issue} "your feedback"`
     to request revisions. Do not proceed until resumed.
   - STAGE 2: Run /speckit.plan to break the spec into a plan.
   - STAGE 3: Run /speckit.tasks to create task list.

--- a/internal/sdd/builtin/speckit.yml
+++ b/internal/sdd/builtin/speckit.yml
@@ -1,7 +1,9 @@
 kickoff: |
   Work on GitHub issue #{issue}. Read CLAUDE.md for project conventions.
   Follow the SpecKit spec-driven development lifecycle:
-  - STAGE 1: Run /speckit.specify to create a spec. Await human approval before continuing.
+  - STAGE 1: Run /speckit.specify to create a spec. When the spec is ready, tell the user
+    to run `agentctl resume {issue}` to approve, or `agentctl resume {issue} "feedback"`
+    to request revisions. Do not proceed until resumed.
   - STAGE 2: Run /speckit.plan to break the spec into a plan.
   - STAGE 3: Run /speckit.tasks to create task list.
   - STAGE 4: Run /speckit.implement to implement the tasks.

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -96,6 +96,24 @@ func TestKickoffPrompt_speckit_content(t *testing.T) {
 	}
 }
 
+func TestKickoffPrompt_speckit_resumeInstruction(t *testing.T) {
+	m, err := sdd.Get("speckit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := m.KickoffPrompt("55", "3030")
+	if !strings.Contains(prompt, "agentctl resume") {
+		t.Errorf("speckit prompt must tell user to run `agentctl resume`, got:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "Await human approval") {
+		t.Errorf("speckit prompt must not say 'Await human approval' (use agentctl resume instead), got:\n%s", prompt)
+	}
+	// The resume command should include the substituted issue number
+	if !strings.Contains(prompt, "agentctl resume 55") {
+		t.Errorf("speckit prompt must include `agentctl resume 55` with the issue number, got:\n%s", prompt)
+	}
+}
+
 // ─── SkipPrompt ───────────────────────────────────────────────────────────────
 
 func TestSkipPrompt_substitution(t *testing.T) {

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -112,6 +112,10 @@ func TestKickoffPrompt_speckit_resumeInstruction(t *testing.T) {
 	if !strings.Contains(prompt, "agentctl resume 55") {
 		t.Errorf("speckit prompt must include `agentctl resume 55` with the issue number, got:\n%s", prompt)
 	}
+	// /speckit.* commands must be marked as internal-only so the agent does not expose them to the user
+	if !strings.Contains(prompt, "internal-only") {
+		t.Errorf("speckit prompt must state that /speckit.* commands are internal-only, got:\n%s", prompt)
+	}
 }
 
 // ─── SkipPrompt ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fixes #133: the speckit kickoff prompt's STAGE 1 now instructs the agent to tell the user to run `agentctl resume <issue>` (to approve) or `agentctl resume <issue> "feedback"` (to request revisions), instead of the incorrect "Await human approval before continuing".
- Adds `TestKickoffPrompt_speckit_resumeInstruction` to verify the correct resume command is present and the old vague wording is absent.

## Test plan

- [ ] `go test ./internal/sdd/... -run TestKickoffPrompt_speckit_resumeInstruction` passes
- [ ] `go build ./...` succeeds
- [ ] `go vet ./...` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)