### PR TITLE
fix: visually separate PR links in agent terminal output

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1434,7 +1434,7 @@ func extractStreamText(line, wtDir string) string {
 			switch c.Type {
 			case "text":
 				if t := strings.TrimSpace(c.Text); t != "" {
-					sb.WriteString(t)
+					sb.WriteString(highlightPRURLs(t))
 					sb.WriteByte('\n')
 				}
 			case "tool_use":
@@ -1446,6 +1446,14 @@ func extractStreamText(line, wtDir string) string {
 		return strings.TrimSpace(ev.Result)
 	}
 	return ""
+}
+
+var githubPRURL = regexp.MustCompile(`https://github\.com/[^/]+/[^/]+/pull/\d+`)
+
+func highlightPRURLs(text string) string {
+	return githubPRURL.ReplaceAllStringFunc(text, func(url string) string {
+		return "\n>>> " + url + "\n"
+	})
 }
 
 // toolDetailMaxLen is the maximum number of runes shown for a tool input detail

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1441,7 +1441,7 @@ func extractStreamText(line, wtDir string) string {
 				fmt.Fprintf(&sb, "[%s]\n", toolLabel(c.Name, c.Input, wtDir))
 			}
 		}
-		return strings.TrimRight(sb.String(), "\n")
+		return strings.TrimSuffix(sb.String(), "\n")
 	case "result":
 		return strings.TrimSpace(ev.Result)
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1241,7 +1241,7 @@ func TestExtractStreamText(t *testing.T) {
 		{
 			name: "assistant text PR URL gets visual separation",
 			line: `{"type":"assistant","message":{"content":[{"type":"text","text":"https://github.com/arun-gupta/agentctl/pull/135"}]}}`,
-			want: "\n>>> https://github.com/arun-gupta/agentctl/pull/135",
+			want: "\n>>> https://github.com/arun-gupta/agentctl/pull/135\n",
 		},
 		{
 			name: "assistant text PR URL embedded in sentence",

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1238,6 +1238,21 @@ func TestExtractStreamText(t *testing.T) {
 			wtDir: "",
 			want:  "[Read: /some/path.go]",
 		},
+		{
+			name: "assistant text PR URL gets visual separation",
+			line: `{"type":"assistant","message":{"content":[{"type":"text","text":"https://github.com/arun-gupta/agentctl/pull/135"}]}}`,
+			want: "\n>>> https://github.com/arun-gupta/agentctl/pull/135",
+		},
+		{
+			name: "assistant text PR URL embedded in sentence",
+			line: `{"type":"assistant","message":{"content":[{"type":"text","text":"PR opened at https://github.com/arun-gupta/agentctl/pull/135 please review"}]}}`,
+			want: "PR opened at \n>>> https://github.com/arun-gupta/agentctl/pull/135\n please review",
+		},
+		{
+			name: "assistant text non-PR GitHub URL unchanged",
+			line: `{"type":"assistant","message":{"content":[{"type":"text","text":"See https://github.com/arun-gupta/agentctl/issues/137"}]}}`,
+			want: "See https://github.com/arun-gupta/agentctl/issues/137",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `highlightPRURLs` helper that wraps GitHub PR URLs (`https://github.com/<owner>/<repo>/pull/<n>`) with `\n>>> ...\n` so they stand out in terminal output
- Applies it to assistant text blocks inside `extractStreamText`
- Non-PR GitHub URLs (issues, repos) pass through unchanged

Closes #137

## Test plan

- [ ] `go test ./...` passes (new `TestExtractStreamText` cases: PR URL gets visual separation, PR URL embedded in sentence, non-PR GitHub URL unchanged)
- [ ] `go build ./...` and `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)