### PR TITLE
fix: speckit stages 2-4 proceed automatically after spec approval

### DIFF
--- a/internal/sdd/builtin/speckit.yml
+++ b/internal/sdd/builtin/speckit.yml
@@ -1,9 +1,11 @@
 kickoff: |
   Work on GitHub issue #{issue}. Read CLAUDE.md for project conventions.
   Follow the SpecKit spec-driven development lifecycle:
-  - STAGE 1: Run /speckit.specify to create a spec. Await human approval before continuing.
-  - STAGE 2: Run /speckit.plan to break the spec into a plan.
-  - STAGE 3: Run /speckit.tasks to create task list.
+  - STAGE 1: Run /speckit.specify to create a spec. When done, tell the user:
+    "Run `agentctl resume {issue}` to approve, or `agentctl resume {issue} \"feedback\"` to revise."
+    Do not proceed until resumed.
+  - STAGE 2: Run /speckit.plan to create an implementation plan. Proceed immediately — no pause.
+  - STAGE 3: Run /speckit.tasks to create a task list. Proceed immediately — no pause.
   - STAGE 4: Run /speckit.implement to implement the tasks.
   Push the branch and open a PR when done. Do not merge.
   Dev server is running on port {port}.

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -96,6 +96,27 @@ func TestKickoffPrompt_speckit_content(t *testing.T) {
 	}
 }
 
+func TestKickoffPrompt_speckit_stages_2_4_no_pause(t *testing.T) {
+	m, err := sdd.Get("speckit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := m.KickoffPrompt("139", "3030")
+
+	// Stage 1 must pause for human approval and tell the user how to resume.
+	if !strings.Contains(prompt, "Do not proceed until resumed") {
+		t.Errorf("stage 1 must instruct agent to wait; prompt: %s", prompt)
+	}
+	if !strings.Contains(prompt, "agentctl resume") {
+		t.Errorf("stage 1 must tell user to run agentctl resume; prompt: %s", prompt)
+	}
+
+	// Stages 2–4 must proceed without pausing.
+	if !strings.Contains(prompt, "Proceed immediately") {
+		t.Errorf("stages 2–4 must say 'Proceed immediately'; prompt: %s", prompt)
+	}
+}
+
 // ─── SkipPrompt ───────────────────────────────────────────────────────────────
 
 func TestSkipPrompt_substitution(t *testing.T) {


### PR DESCRIPTION
## Summary

- Updates `internal/sdd/builtin/speckit.yml` so the Stage 1 kickoff prompt tells the user how to call `agentctl resume` and says **"Do not proceed until resumed"**
- Stages 2–4 now say **"Proceed immediately — no pause"**, eliminating the three unnecessary `agentctl resume` calls
- Adds `TestKickoffPrompt_speckit_stages_2_4_no_pause` to enforce this contract going forward

Before this fix the UX required 4 commands; after it requires 2:
```
agentctl start 483 --sdd=speckit   # runs spec, pauses
agentctl resume 483                # approve → plan → tasks → implement → PR
```

Closes #139

## Test plan

- [ ] `go test ./internal/sdd/...` — new test `TestKickoffPrompt_speckit_stages_2_4_no_pause` passes
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)