### PR TITLE
fix: suppress dev server hint for non-web projects

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -112,7 +112,7 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 	}
 
 	// Start dev server if the project supports it; returns empty strings when skipped.
-	devPID, portStr, err := startDevServer(wtPath, os.Stderr)
+	devPID, portStr, err := startDevServer(wtPath)
 	if err != nil {
 		return err
 	}
@@ -1051,12 +1051,11 @@ func seedEnvLocal(src, dst string) error {
 // startDevServer starts a dev server for the project in dir. Detection order:
 //  1. .agentctl.yml with dev_server field  → run that command with {port} substituted
 //  2. package.json present                 → npm install + npm run dev
-//  3. neither                              → print hint, return ("","",nil)
+//  3. neither                              → silent skip, return ("","",nil)
 //
 // On success the allocated port is written back to .agentctl.yml so it serves
-// as the single source of truth for all agentctl repo config. w receives the
-// informational message when no dev server is configured.
-func startDevServer(dir string, w io.Writer) (devPID, portStr string, err error) {
+// as the single source of truth for all agentctl repo config.
+func startDevServer(dir string) (devPID, portStr string, err error) {
 	cfg, err := config.Read(dir)
 	if err != nil {
 		return "", "", fmt.Errorf("reading .agentctl.yml: %w", err)
@@ -1072,8 +1071,7 @@ func startDevServer(dir string, w io.Writer) (devPID, portStr string, err error)
 		return startNodeDevServer(dir, cfg)
 	}
 
-	// Case 3: no dev server configured
-	fmt.Fprintf(w, "No dev server configured for this project. Add a dev_server command to .agentctl.yml to start one automatically.\n")
+	// Case 3: no dev server configured — silently skip
 	return "", "", nil
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1483,8 +1483,7 @@ func TestRunNpmInstall_errorIncludesDebugHint(t *testing.T) {
 
 func TestStartDevServer_noPackageJSON_returnsEmptyPort(t *testing.T) {
 	dir := t.TempDir() // no package.json
-	var stderr strings.Builder
-	pid, port, err := startDevServer(dir, &stderr)
+	pid, port, err := startDevServer(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1493,10 +1492,6 @@ func TestStartDevServer_noPackageJSON_returnsEmptyPort(t *testing.T) {
 	}
 	if port != "" {
 		t.Errorf("expected empty port when no dev server started, got %q", port)
-	}
-	hint := stderr.String()
-	if !strings.Contains(hint, ".agentctl.yml") {
-		t.Errorf("expected hint about .agentctl.yml, got: %q", hint)
 	}
 }
 
@@ -1676,8 +1671,7 @@ func TestStartDevServer_agentctlYml_writesPortBack(t *testing.T) {
 		[]byte("dev_server: \"echo ok\"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	var stderr strings.Builder
-	pidStr, portStr, err := startDevServer(dir, &stderr)
+	pidStr, portStr, err := startDevServer(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Removes the "No dev server configured" message printed to stderr when neither `.agentctl.yml` (with `dev_server`) nor `package.json` is present
- Non-web projects now get a silent skip — dev server is fully opt-in
- Drops the unused `w io.Writer` parameter from `startDevServer` and updates both test call sites

Closes #123

## Test plan

- [ ] `go test ./internal/cmd/... -run TestStartDevServer` — both `TestStartDevServer_noPackageJSON_returnsEmptyPort` and `TestStartDevServer_agentctlYml_writesPortBack` pass
- [ ] Run `agentctl start` in a non-web project (no `package.json`, no `dev_server` in `.agentctl.yml`) and confirm no hint is printed to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)