### PR TITLE
fix: show agentctl logs and attach hints after Ctrl+C

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1388,6 +1388,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			fmt.Fprintf(os.Stdout, "agent still running in background\n")
 			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", issue)
 			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", issue)
+			fmt.Fprintf(os.Stdout, "  agentctl discard %s  # stop and remove worktree\n", issue)
 			return nil
 		}
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1386,6 +1386,8 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			close(logDone)
 			wg.Wait()
 			fmt.Fprintf(os.Stdout, "agent still running in background (pid %d)\n", pid)
+			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", issue)
+			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", issue)
 			return nil
 		}
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1388,7 +1388,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			fmt.Fprintf(os.Stdout, "agent still running in background\n")
 			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", issue)
 			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", issue)
-			fmt.Fprintf(os.Stdout, "  agentctl discard %s  # stop and remove worktree\n", issue)
+			fmt.Fprintf(os.Stdout, "  agentctl discard %s  # permanently delete worktree and branches\n", issue)
 			return nil
 		}
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1385,7 +1385,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			signal.Stop(sigCh)
 			close(logDone)
 			wg.Wait()
-			fmt.Fprintf(os.Stdout, "agent still running in background (pid %d)\n", pid)
+			fmt.Fprintf(os.Stdout, "agent still running in background\n")
 			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", issue)
 			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", issue)
 			return nil

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -750,6 +750,75 @@ func TestLaunchAgent_claudeHeadlessInjectsVerboseOnly(t *testing.T) {
 	}
 }
 
+// TestLaunchAgent_nonHeadless_sigintPrintsHints verifies that pressing Ctrl+C
+// while launchAgent is streaming output in non-headless mode prints the
+// expected reconnection hints (logs, attach, discard) to stdout.
+func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a stub agent that sleeps long enough for SIGINT to arrive first.
+	scriptPath := filepath.Join(dir, "sleepagent")
+	script := "#!/bin/sh\nsleep 30\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeLocalAdapter(t, dir, "sleepagent", "binary: "+scriptPath+"\n")
+	chdirTemp(t, dir)
+
+	// Redirect os.Stdout to a pipe so we can capture the hint output.
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- launchAgent("sleepagent", dir, "42", "3010", "sess-abc", "do the thing", false, false)
+	}()
+
+	// Give launchAgent time to start the agent process and register its signal
+	// handler before we send the interrupt.
+	time.Sleep(500 * time.Millisecond)
+
+	if p, err := os.FindProcess(os.Getpid()); err == nil {
+		_ = p.Signal(os.Interrupt)
+	}
+
+	select {
+	case launchErr := <-done:
+		if launchErr != nil {
+			t.Fatalf("launchAgent: %v", launchErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("launchAgent did not return after SIGINT")
+	}
+
+	// Close the write end and restore stdout before reading captured output.
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("reading captured stdout: %v", err)
+	}
+	r.Close()
+
+	out := buf.String()
+	for _, want := range []string{
+		"agent still running in background",
+		"agentctl logs 42",
+		"agentctl attach 42",
+		"agentctl discard 42",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in stdout after Ctrl+C, got:\n%s", want, out)
+		}
+	}
+}
+
 // ─── agentResume ─────────────────────────────────────────────────────────────
 
 func TestLaunchAgent_nonZeroExitLogsToStderr(t *testing.T) {


### PR DESCRIPTION
## Summary

- When the user presses Ctrl+C while `agentctl start` is streaming output, the agent keeps running but the only feedback was `agent still running in background (pid 12345)`
- Now prints the commands to reconnect so the user isn't left wondering what to do next

**Before:**
```
agent still running in background (pid 12345)
```

**After:**
```
agent still running in background (pid 12345)
  agentctl logs 143     # follow log
  agentctl attach 143   # stream live output
```

## Test plan

- [ ] Run `agentctl start <issue>` and press Ctrl+C — verify the two hint lines appear with the correct issue number
- [ ] Verify agent process is still running after Ctrl+C (`agentctl status`)
- [ ] Verify `agentctl logs <issue>` and `agentctl attach <issue>` work as advertised

🤖 Generated with [Claude Code](https://claude.com/claude-code)