### PR TITLE
feat: auto-link PR to issue by appending Closes #N

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1388,6 +1388,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			fmt.Fprintf(os.Stdout, "agent still running in background\n")
 			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", issue)
 			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", issue)
+			fmt.Fprintf(os.Stdout, "  agentctl discard %s  # stop and remove worktree\n", issue)
 			return nil
 		}
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -770,6 +770,11 @@ func attachLog(wtPath, issue string, w io.Writer, logWait time.Duration) error {
 		tail.Stderr = os.Stderr
 		_ = tail.Run()
 		fmt.Fprintln(w, "agent has already finished")
+		if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
+			if linkErr := linkPRToIssue(wtPath, branch, issue); linkErr != nil {
+				fmt.Fprintf(w, "note: could not link PR to issue: %v\n", linkErr)
+			}
+		}
 		return nil
 	}
 
@@ -801,6 +806,11 @@ func attachLog(wtPath, issue string, w io.Writer, logWait time.Duration) error {
 	time.Sleep(200 * time.Millisecond)
 	_ = tail.Process.Kill()
 	_ = tail.Wait()
+	if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
+		if linkErr := linkPRToIssue(wtPath, branch, issue); linkErr != nil {
+			fmt.Fprintf(w, "note: could not link PR to issue: %v\n", linkErr)
+		}
+	}
 	return nil
 }
 
@@ -872,6 +882,43 @@ func ghPRInfo(repoRoot, branch string) (state string, number int, err error) {
 func ghPRState(repoRoot, branch string) (string, error) {
 	state, _, err := ghPRInfo(repoRoot, branch)
 	return state, err
+}
+
+// linkPRToIssue appends "Closes #<issueNum>" to the open PR for branch,
+// unless the body already contains a closing keyword (closes/fixes).
+// Silently returns nil when no PR exists.
+func linkPRToIssue(dir, branch, issueNum string) error {
+	cmd := exec.Command("gh", "pr", "view", branch, "--json", "number,body")
+	cmd.Dir = dir
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil // no PR — silently skip
+	}
+
+	var pr struct {
+		Number int    `json:"number"`
+		Body   string `json:"body"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &pr); err != nil {
+		return nil
+	}
+
+	lower := strings.ToLower(pr.Body)
+	if strings.Contains(lower, "closes #"+issueNum) || strings.Contains(lower, "fixes #"+issueNum) {
+		return nil
+	}
+
+	newBody := strings.TrimRight(pr.Body, "\n") + "\n\nCloses #" + issueNum
+	editCmd := exec.Command("gh", "pr", "edit", strconv.Itoa(pr.Number), "--body", newBody)
+	editCmd.Dir = dir
+	var editErr bytes.Buffer
+	editCmd.Stderr = &editErr
+	if err := editCmd.Run(); err != nil {
+		return fmt.Errorf("gh pr edit: %w: %s", err, strings.TrimSpace(editErr.String()))
+	}
+	return nil
 }
 
 // parseIssueURL checks whether arg is a full GitHub issue URL of the form
@@ -1380,6 +1427,11 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			convWg.Wait() // drain remaining pipe → log before the final read
 			close(logDone)
 			wg.Wait()
+			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
+				if linkErr := linkPRToIssue(wtPath, branch, issue); linkErr != nil {
+					fmt.Fprintf(os.Stderr, "note: could not link PR to issue: %v\n", linkErr)
+				}
+			}
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1386,6 +1386,8 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			close(logDone)
 			wg.Wait()
 			fmt.Fprintf(os.Stdout, "agent still running in background (pid %d)\n", pid)
+			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", issue)
+			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", issue)
 			return nil
 		}
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1385,7 +1385,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			signal.Stop(sigCh)
 			close(logDone)
 			wg.Wait()
-			fmt.Fprintf(os.Stdout, "agent still running in background (pid %d)\n", pid)
+			fmt.Fprintf(os.Stdout, "agent still running in background\n")
 			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", issue)
 			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", issue)
 			return nil

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1799,3 +1799,157 @@ func TestLaunchAgent_nonClaudeDoesNotWriteSettingsJson(t *testing.T) {
 		t.Error("non-claude adapter must not write .claude/settings.json")
 	}
 }
+
+// ─── linkPRToIssue ────────────────────────────────────────────────────────────
+
+// makeGHStub writes a stub gh script to stubDir and returns the path to the
+// calls log file where the stub records each invocation (one arg per line).
+// viewJSON is written as the stdout for "gh pr view"; pass "" to simulate a
+// missing PR (gh exits 1).  For "gh pr edit" the stub always exits 0 unless
+// editFail is true.
+func makeGHStub(t *testing.T, stubDir, viewJSON string, editFail bool) string {
+	t.Helper()
+	callsFile := filepath.Join(stubDir, "gh-calls.txt")
+	responseFile := filepath.Join(stubDir, "gh-response.json")
+	if viewJSON != "" {
+		if err := os.WriteFile(responseFile, []byte(viewJSON), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	prViewExit := 0
+	if viewJSON == "" {
+		prViewExit = 1
+	}
+	prEditExit := 0
+	if editFail {
+		prEditExit = 1
+	}
+
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$@" >> %s
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  if [ -f %s ]; then cat %s; fi
+  exit %d
+fi
+if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+  exit %d
+fi
+exit 0`,
+		callsFile,
+		responseFile, responseFile,
+		prViewExit,
+		prEditExit,
+	)
+	ghPath := filepath.Join(stubDir, "gh")
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return callsFile
+}
+
+// prependPath prepends dir to the PATH for the duration of the test.
+func prependPath(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestLinkPRToIssue_noPR(t *testing.T) {
+	stubDir := t.TempDir()
+	callsFile := makeGHStub(t, stubDir, "", false)
+	prependPath(t, stubDir)
+
+	if err := linkPRToIssue(t.TempDir(), "42-my-feature", "42"); err != nil {
+		t.Errorf("expected nil for no-PR case, got: %v", err)
+	}
+
+	calls, _ := os.ReadFile(callsFile)
+	callsStr := string(calls)
+	if !strings.Contains(callsStr, "pr") {
+		t.Error("expected gh pr view to be called")
+	}
+	if strings.Contains(callsStr, "edit") {
+		t.Error("expected gh pr edit NOT to be called when no PR exists")
+	}
+}
+
+func TestLinkPRToIssue_alreadyLinked(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"closes_lower", "some work\n\ncloses #42"},
+		{"Closes_title", "some work\n\nCloses #42"},
+		{"CLOSES_upper", "some work\n\nCLOSES #42"},
+		{"fixes_lower", "some work\n\nfixes #42"},
+		{"Fixes_title", "some work\n\nFixes #42"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubDir := t.TempDir()
+			viewJSON := fmt.Sprintf(`{"number":7,"body":%q}`, tc.body)
+			callsFile := makeGHStub(t, stubDir, viewJSON, false)
+			prependPath(t, stubDir)
+
+			if err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
+				t.Errorf("expected nil, got: %v", err)
+			}
+			calls, _ := os.ReadFile(callsFile)
+			if strings.Contains(string(calls), "edit") {
+				t.Errorf("should not call gh pr edit when closing keyword already present; calls: %q", string(calls))
+			}
+		})
+	}
+}
+
+func TestLinkPRToIssue_addsLink(t *testing.T) {
+	stubDir := t.TempDir()
+	viewJSON := `{"number":7,"body":"some PR work"}`
+	callsFile := makeGHStub(t, stubDir, viewJSON, false)
+	prependPath(t, stubDir)
+
+	if err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
+		t.Fatalf("linkPRToIssue: %v", err)
+	}
+
+	calls, _ := os.ReadFile(callsFile)
+	callsStr := string(calls)
+	if !strings.Contains(callsStr, "edit") {
+		t.Error("expected gh pr edit to be called")
+	}
+	if !strings.Contains(callsStr, "Closes #42") {
+		t.Errorf("expected 'Closes #42' in gh pr edit args, got: %q", callsStr)
+	}
+}
+
+func TestLinkPRToIssue_addsLink_emptyBody(t *testing.T) {
+	stubDir := t.TempDir()
+	viewJSON := `{"number":3,"body":""}`
+	callsFile := makeGHStub(t, stubDir, viewJSON, false)
+	prependPath(t, stubDir)
+
+	if err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
+		t.Fatalf("linkPRToIssue: %v", err)
+	}
+
+	calls, _ := os.ReadFile(callsFile)
+	callsStr := string(calls)
+	if !strings.Contains(callsStr, "Closes #42") {
+		t.Errorf("expected 'Closes #42' in edit args, got: %q", callsStr)
+	}
+}
+
+func TestLinkPRToIssue_editError(t *testing.T) {
+	stubDir := t.TempDir()
+	viewJSON := `{"number":7,"body":"some work"}`
+	makeGHStub(t, stubDir, viewJSON, true) // editFail=true
+	prependPath(t, stubDir)
+
+	err := linkPRToIssue(t.TempDir(), "42-feature", "42")
+	if err == nil {
+		t.Error("expected error when gh pr edit fails")
+	}
+	if !strings.Contains(err.Error(), "gh pr edit") {
+		t.Errorf("expected 'gh pr edit' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `linkPRToIssue(dir, branch, issueNum)` that appends `Closes #N` to a PR body via `gh pr edit`, skipping silently when no PR exists
- Calls it in `launchAgent` after the agent exits (foreground path) and in `attachLog` after the headless agent finishes
- Check is case-insensitive (`closes`, `Closes`, `CLOSES`, `fixes`, `Fixes`) and idempotent — no duplicate keywords

## Test plan

- [x] `TestLinkPRToIssue_noPR` — silently returns nil when `gh pr view` exits non-zero
- [x] `TestLinkPRToIssue_alreadyLinked` — skips edit for all casing variants of closes/fixes
- [x] `TestLinkPRToIssue_addsLink` — calls `gh pr edit` with `Closes #42` appended
- [x] `TestLinkPRToIssue_addsLink_emptyBody` — handles empty PR body
- [x] `TestLinkPRToIssue_editError` — propagates `gh pr edit` failure
- [x] Run `go test ./...` — all new tests pass; pre-existing failures are unrelated to this change

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)