### PR TITLE
feat: add --stale flag to agentctl discard

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,11 +116,11 @@ Use this for abandoned or failed work where the PR should not be merged.
 
 Like `cleanup`, the issue number can be inferred from the current branch when run inside a linked worktree.
 
-Use `--stale` to discard all linked worktrees at once that have no running agent and no open PR. All matching worktrees are listed before the confirmation prompt. `--stale` and a positional issue number are mutually exclusive.
+Use `--stale` to discard all linked worktrees at once that have no running agent and no PR. All matching worktrees are listed before the confirmation prompt. `--stale` and a positional issue number are mutually exclusive.
 
 A worktree is considered stale when both conditions hold:
 1. No agent is running (no `.agent` file, empty `agent-pid`, or the recorded PID is not alive).
-2. No PR has been opened for the branch (`gh pr view` finds no PR).
+2. No PR of any state exists for the branch (`gh pr list --state all` returns no results).
 
 When `agentctl cleanup --all` skips worktrees with no PR, it prints a hint if any of them are also stale:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,6 +107,7 @@ If the PR is not merged, use `agentctl discard` for abandoned work.
 
 ```bash
 agentctl discard [issue-number]
+agentctl discard --stale
 ```
 
 Permanently discards a worktree and deletes local/remote branches. This is unrecoverable and prompts for `YES`.
@@ -114,6 +115,18 @@ Permanently discards a worktree and deletes local/remote branches. This is unrec
 Use this for abandoned or failed work where the PR should not be merged.
 
 Like `cleanup`, the issue number can be inferred from the current branch when run inside a linked worktree.
+
+Use `--stale` to discard all linked worktrees at once that have no running agent and no open PR. All matching worktrees are listed before the confirmation prompt. `--stale` and a positional issue number are mutually exclusive.
+
+A worktree is considered stale when both conditions hold:
+1. No agent is running (no `.agent` file, empty `agent-pid`, or the recorded PID is not alive).
+2. No PR has been opened for the branch (`gh pr view` finds no PR).
+
+When `agentctl cleanup --all` skips worktrees with no PR, it prints a hint if any of them are also stale:
+
+```
+Note: N stale worktree(s) found with no agent and no PR — run `agentctl discard --stale` to remove them.
+```
 
 ### `agentctl logs`
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -323,39 +323,45 @@ func runDiscardStale() error {
 		return fmt.Errorf("aborted")
 	}
 
-	discarded := 0
-	for _, e := range stale {
-		if e.wtPath != "" {
-			af, _ := state.Read(e.wtPath)
+	discardStaleEntry := func(wtPath, branch string) error {
+		if wtPath != "" {
+			af, _ := state.Read(wtPath)
 			process.Kill(af.DevPID)
 			process.Kill(af.AgentPID)
-			if err := git.RemoveWorktree(repoRoot, e.wtPath); err != nil {
-				fmt.Fprintf(os.Stderr, "FAILED to remove worktree %s: %v\n", e.wtPath, err)
-				continue
+			if err := git.RemoveWorktree(repoRoot, wtPath); err != nil {
+				return fmt.Errorf("remove worktree %s: %w", wtPath, err)
 			}
-			fmt.Printf("Removed %s\n", e.wtPath)
+			fmt.Printf("Removed %s\n", wtPath)
 		}
 
-		if e.branch != "" && e.branch != "HEAD" {
-			if git.BranchExists(repoRoot, e.branch) {
-				if err := git.DeleteLocalBranch(repoRoot, e.branch); err != nil {
-					fmt.Fprintf(os.Stderr, "WARNING: could not delete local branch %s: %v\n", e.branch, err)
+		if branch != "" && branch != "HEAD" {
+			if git.BranchExists(repoRoot, branch) {
+				if err := git.DeleteLocalBranch(repoRoot, branch); err != nil {
+					return fmt.Errorf("delete local branch %s: %w", branch, err)
 				}
 			} else {
-				fmt.Printf("Local branch %s already removed\n", e.branch)
+				fmt.Printf("Local branch %s already removed\n", branch)
 			}
-			msg, err := git.DeleteRemoteBranch(repoRoot, e.branch)
+
+			msg, err := git.DeleteRemoteBranch(repoRoot, branch)
 			if err != nil {
 				if strings.Contains(msg, "remote ref does not exist") {
-					fmt.Printf("Remote branch %s already removed\n", e.branch)
+					fmt.Printf("Remote branch %s already removed\n", branch)
 				} else {
-					fmt.Fprintf(os.Stderr, "WARNING: could not delete remote branch %s\n", e.branch)
-					fmt.Fprintln(os.Stderr, msg)
-					fmt.Fprintf(os.Stderr, "Delete the remote manually with:\n  git push origin --delete %s\n", e.branch)
+					return fmt.Errorf("delete remote branch %s: %s\nDelete the remote manually with:\n  git push origin --delete %s", branch, strings.TrimSpace(msg), branch)
 				}
 			} else {
-				fmt.Printf("Deleted remote branch origin/%s\n", e.branch)
+				fmt.Printf("Deleted remote branch origin/%s\n", branch)
 			}
+		}
+
+		return nil
+	}
+
+	discarded := 0
+	for _, e := range stale {
+		if err := discardStaleEntry(e.wtPath, e.branch); err != nil {
+			return err
 		}
 		discarded++
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -249,8 +249,15 @@ Use --stale to discard all worktrees that have no running agent and no open PR.`
 }
 
 // isAgentRunning returns true when the agent PID recorded in wtPath is alive.
+//
+// If the agent state cannot be read, treat the worktree conservatively as having
+// a running agent so stale-discard does not remove it based on unreadable or
+// corrupt state.
 func isAgentRunning(wtPath string) bool {
-	af, _ := state.Read(wtPath)
+	af, err := state.Read(wtPath)
+	if err != nil {
+		return true
+	}
 	return af.AgentPID != "" && process.IsAlive(af.AgentPID)
 }
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -228,7 +228,7 @@ This action is NOT recoverable. You will be prompted to type YES to confirm.
 If no issue number is given, it is inferred from the current branch when
 you are inside a linked worktree.
 
-Use --stale to discard all worktrees that have no running agent and no open PR.`,
+Use --stale to discard all worktrees that have no running agent and no PR.`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if stale {
@@ -244,7 +244,7 @@ Use --stale to discard all worktrees that have no running agent and no open PR.`
 			return runRemoveWorktree(issue)
 		},
 	}
-	c.Flags().BoolVar(&stale, "stale", false, "Discard all worktrees with no running agent and no open PR")
+	c.Flags().BoolVar(&stale, "stale", false, "Discard all worktrees with no running agent and no PR")
 	return c
 }
 
@@ -261,18 +261,19 @@ func isAgentRunning(wtPath string) bool {
 	return af.AgentPID != "" && process.IsAlive(af.AgentPID)
 }
 
-// isStaleWorktree returns true when no agent is running and no PR exists for branch.
-// If PR status cannot be determined reliably, it returns false to avoid discarding
-// a potentially active worktree based on transient GH CLI/auth/network failures.
+// isStaleWorktree returns true when no agent is running and no PR of any state
+// exists for the branch. Returns false conservatively when PR status cannot be
+// reliably determined (e.g. auth or network failures) to avoid discarding
+// potentially active worktrees.
 func isStaleWorktree(repoRoot, branch, wtPath string) bool {
 	if isAgentRunning(wtPath) {
 		return false
 	}
-	prState, _, err := ghPRInfo(repoRoot, branch)
+	hasPR, err := ghHasPR(repoRoot, branch)
 	if err != nil {
-		return false
+		return false // conservative: can't confirm no PR, skip
 	}
-	return prState == ""
+	return !hasPR
 }
 
 func runDiscardStale() error {
@@ -1020,6 +1021,23 @@ func ghPRInfo(repoRoot, branch string) (state string, number int, err error) {
 		return "", 0, fmt.Errorf("unexpected gh PR number %q in output %q: %w", parts[1], out.String(), err)
 	}
 	return parts[0], n, nil
+}
+
+// ghHasPR uses `gh pr list --head <branch> --state all` to check whether any
+// PR (open, closed, or merged) exists for the branch. It returns (true, nil)
+// when at least one PR exists, (false, nil) when none exist, and (false, err)
+// when the GH CLI call fails (e.g. auth or network failure) so callers can
+// treat the result conservatively.
+func ghHasPR(repoRoot, branch string) (bool, error) {
+	cmd := exec.Command("gh", "pr", "list", "--head", branch, "--state", "all", "--json", "number")
+	cmd.Dir = repoRoot
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	return strings.TrimSpace(out.String()) != "[]", nil
 }
 
 // ghPRState is a convenience wrapper that returns only the state string.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -262,12 +262,17 @@ func isAgentRunning(wtPath string) bool {
 }
 
 // isStaleWorktree returns true when no agent is running and no PR exists for branch.
+// If PR status cannot be determined reliably, it returns false to avoid discarding
+// a potentially active worktree based on transient GH CLI/auth/network failures.
 func isStaleWorktree(repoRoot, branch, wtPath string) bool {
 	if isAgentRunning(wtPath) {
 		return false
 	}
 	prState, _, err := ghPRInfo(repoRoot, branch)
-	return err != nil || prState == ""
+	if err != nil {
+		return false
+	}
+	return prState == ""
 }
 
 func runDiscardStale() error {

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -218,16 +218,25 @@ func specExists(wtPath string) bool {
 
 // NewDiscardCmd creates the `discard` subcommand.
 func NewDiscardCmd() *cobra.Command {
-	return &cobra.Command{
+	var stale bool
+	c := &cobra.Command{
 		Use:   "discard [issue]",
 		Short: "Permanently delete a worktree and its local/remote branches",
 		Long: `Discard the worktree for an issue and delete the local and remote branches.
 This action is NOT recoverable. You will be prompted to type YES to confirm.
 
 If no issue number is given, it is inferred from the current branch when
-you are inside a linked worktree.`,
+you are inside a linked worktree.
+
+Use --stale to discard all worktrees that have no running agent and no open PR.`,
 		Args: cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if stale {
+				if len(args) > 0 {
+					return fmt.Errorf("--stale and an issue number are mutually exclusive")
+				}
+				return runDiscardStale()
+			}
 			issue, err := resolveIssueArg("discard", args)
 			if err != nil {
 				return err
@@ -235,6 +244,117 @@ you are inside a linked worktree.`,
 			return runRemoveWorktree(issue)
 		},
 	}
+	c.Flags().BoolVar(&stale, "stale", false, "Discard all worktrees with no running agent and no open PR")
+	return c
+}
+
+// isAgentRunning returns true when the agent PID recorded in wtPath is alive.
+func isAgentRunning(wtPath string) bool {
+	af, _ := state.Read(wtPath)
+	return af.AgentPID != "" && process.IsAlive(af.AgentPID)
+}
+
+// isStaleWorktree returns true when no agent is running and no PR exists for branch.
+func isStaleWorktree(repoRoot, branch, wtPath string) bool {
+	if isAgentRunning(wtPath) {
+		return false
+	}
+	prState, _, err := ghPRInfo(repoRoot, branch)
+	return err != nil || prState == ""
+}
+
+func runDiscardStale() error {
+	repoRoot, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("cannot determine repo root: %w", err)
+	}
+
+	wts, err := git.LinkedWorktrees(repoRoot)
+	if err != nil {
+		return err
+	}
+
+	type staleEntry struct {
+		issue  string
+		branch string
+		wtPath string
+	}
+	var stale []staleEntry
+	for _, wt := range wts {
+		branch := wt.Branch
+		if branch == "" || branch == "HEAD" {
+			continue
+		}
+		if isStaleWorktree(repoRoot, branch, wt.Path) {
+			stale = append(stale, staleEntry{
+				issue:  git.InferIssue(branch),
+				branch: branch,
+				wtPath: wt.Path,
+			})
+		}
+	}
+
+	if len(stale) == 0 {
+		fmt.Println("No stale worktrees found.")
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "WARNING: The following stale worktrees will be permanently discarded:\n\n")
+	for _, e := range stale {
+		fmt.Fprintf(os.Stderr, "  issue #%s  branch %s\n", e.issue, e.branch)
+		fmt.Fprintf(os.Stderr, "             path   %s\n", e.wtPath)
+	}
+	fmt.Fprintf(os.Stderr, "\nThis action is NOT recoverable.\n")
+	fmt.Fprintf(os.Stderr, "Type YES to confirm: ")
+
+	var confirm string
+	sc := bufio.NewScanner(os.Stdin)
+	if sc.Scan() {
+		confirm = sc.Text()
+	}
+	if strings.ToLower(strings.TrimSpace(confirm)) != "yes" {
+		return fmt.Errorf("aborted")
+	}
+
+	discarded := 0
+	for _, e := range stale {
+		if e.wtPath != "" {
+			af, _ := state.Read(e.wtPath)
+			process.Kill(af.DevPID)
+			process.Kill(af.AgentPID)
+			if err := git.RemoveWorktree(repoRoot, e.wtPath); err != nil {
+				fmt.Fprintf(os.Stderr, "FAILED to remove worktree %s: %v\n", e.wtPath, err)
+				continue
+			}
+			fmt.Printf("Removed %s\n", e.wtPath)
+		}
+
+		if e.branch != "" && e.branch != "HEAD" {
+			if git.BranchExists(repoRoot, e.branch) {
+				if err := git.DeleteLocalBranch(repoRoot, e.branch); err != nil {
+					fmt.Fprintf(os.Stderr, "WARNING: could not delete local branch %s: %v\n", e.branch, err)
+				}
+			} else {
+				fmt.Printf("Local branch %s already removed\n", e.branch)
+			}
+			msg, err := git.DeleteRemoteBranch(repoRoot, e.branch)
+			if err != nil {
+				if strings.Contains(msg, "remote ref does not exist") {
+					fmt.Printf("Remote branch %s already removed\n", e.branch)
+				} else {
+					fmt.Fprintf(os.Stderr, "WARNING: could not delete remote branch %s\n", e.branch)
+					fmt.Fprintln(os.Stderr, msg)
+					fmt.Fprintf(os.Stderr, "Delete the remote manually with:\n  git push origin --delete %s\n", e.branch)
+				}
+			} else {
+				fmt.Printf("Deleted remote branch origin/%s\n", e.branch)
+			}
+		}
+		discarded++
+	}
+
+	fmt.Printf("\nDiscarded %d stale worktree(s)\n", discarded)
+	return nil
 }
 
 func runRemoveWorktree(issue string) error {
@@ -506,7 +626,7 @@ func runCleanupAllMerged() error {
 		return err
 	}
 
-	cleaned, skipped, failed := 0, 0, 0
+	cleaned, skipped, failed, staleCount := 0, 0, 0, 0
 	for _, wt := range wts {
 		branch := wt.Branch
 		if branch == "" || branch == "HEAD" {
@@ -516,6 +636,9 @@ func runCleanupAllMerged() error {
 		}
 		prState, err := ghPRState(repoRoot, branch)
 		if err != nil || prState == "" {
+			if !isAgentRunning(wt.Path) {
+				staleCount++
+			}
 			fmt.Printf("Skipping %s: no PR found\n", branch)
 			skipped++
 			continue
@@ -541,6 +664,9 @@ func runCleanupAllMerged() error {
 	}
 
 	fmt.Printf("\n%d merged worktrees cleaned, %d skipped\n", cleaned, skipped)
+	if staleCount > 0 {
+		fmt.Printf("Note: %d stale worktree(s) found with no agent and no PR — run `agentctl discard --stale` to remove them.\n", staleCount)
+	}
 	if failed > 0 {
 		fmt.Fprintf(os.Stderr, "%d cleanup(s) failed\n", failed)
 		return fmt.Errorf("%d cleanup(s) failed", failed)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2021,3 +2021,65 @@ func TestLinkPRToIssue_editError(t *testing.T) {
 		t.Errorf("expected 'gh pr edit' in error, got: %v", err)
 	}
 }
+
+// ─── discard --stale ─────────────────────────────────────────────────────────
+
+func TestDiscardCmd_staleFlagRegistered(t *testing.T) {
+	c := NewDiscardCmd()
+	if f := c.Flags().Lookup("stale"); f == nil {
+		t.Fatal("--stale flag must be registered on the discard command")
+	}
+}
+
+func TestDiscardCmd_staleMutuallyExclusiveWithIssue(t *testing.T) {
+	c := NewDiscardCmd()
+	var errBuf bytes.Buffer
+	c.SetErr(&errBuf)
+	c.SilenceUsage = true
+	c.SetArgs([]string{"--stale", "42"})
+	err := c.Execute()
+	if err == nil {
+		t.Fatal("expected error when --stale and issue number are both provided")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutually exclusive, got: %v", err)
+	}
+}
+
+func TestIsAgentRunning_noAgentFile(t *testing.T) {
+	dir := t.TempDir()
+	if isAgentRunning(dir) {
+		t.Error("expected isAgentRunning=false when no .agent file exists")
+	}
+}
+
+func TestIsAgentRunning_emptyPID(t *testing.T) {
+	dir := t.TempDir()
+	if err := state.Write(dir, state.AgentFile{Agent: "claude", SessionID: "s1"}); err != nil {
+		t.Fatal(err)
+	}
+	if isAgentRunning(dir) {
+		t.Error("expected isAgentRunning=false when AgentPID is empty")
+	}
+}
+
+func TestIsAgentRunning_deadPID(t *testing.T) {
+	dir := t.TempDir()
+	if err := state.Write(dir, state.AgentFile{Agent: "claude", AgentPID: "9999999"}); err != nil {
+		t.Fatal(err)
+	}
+	if isAgentRunning(dir) {
+		t.Error("expected isAgentRunning=false for a dead PID")
+	}
+}
+
+func TestIsAgentRunning_livePID(t *testing.T) {
+	dir := t.TempDir()
+	pid := strconv.Itoa(os.Getpid())
+	if err := state.Write(dir, state.AgentFile{Agent: "claude", AgentPID: pid}); err != nil {
+		t.Fatal(err)
+	}
+	if !isAgentRunning(dir) {
+		t.Error("expected isAgentRunning=true when AgentPID is the current process")
+	}
+}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1873,16 +1873,25 @@ func TestLaunchAgent_nonClaudeDoesNotWriteSettingsJson(t *testing.T) {
 // makeGHStub writes a stub gh script to stubDir and returns the path to the
 // calls log file where the stub records each invocation (one arg per line).
 // viewJSON is written as the stdout for "gh pr view"; pass "" to simulate a
-// missing PR (gh exits 1).  For "gh pr edit" the stub always exits 0 unless
-// editFail is true.
-func makeGHStub(t *testing.T, stubDir, viewJSON string, editFail bool) string {
+// missing PR (gh exits 1).  listJSON is written as the stdout for "gh pr list";
+// pass "" to return an empty array (no PRs, gh exits 0).  For "gh pr edit" the
+// stub always exits 0 unless editFail is true.
+func makeGHStub(t *testing.T, stubDir, viewJSON, listJSON string, editFail bool) string {
 	t.Helper()
 	callsFile := filepath.Join(stubDir, "gh-calls.txt")
 	responseFile := filepath.Join(stubDir, "gh-response.json")
+	listFile := filepath.Join(stubDir, "gh-list.json")
 	if viewJSON != "" {
 		if err := os.WriteFile(responseFile, []byte(viewJSON), 0o644); err != nil {
 			t.Fatal(err)
 		}
+	}
+	listOut := "[]"
+	if listJSON != "" {
+		listOut = listJSON
+	}
+	if err := os.WriteFile(listFile, []byte(listOut), 0o644); err != nil {
+		t.Fatal(err)
 	}
 
 	prViewExit := 0
@@ -1900,6 +1909,10 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
   if [ -f %s ]; then cat %s; fi
   exit %d
 fi
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  cat %s
+  exit 0
+fi
 if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
   exit %d
 fi
@@ -1907,6 +1920,7 @@ exit 0`,
 		callsFile,
 		responseFile, responseFile,
 		prViewExit,
+		listFile,
 		prEditExit,
 	)
 	ghPath := filepath.Join(stubDir, "gh")
@@ -1924,7 +1938,7 @@ func prependPath(t *testing.T, dir string) {
 
 func TestLinkPRToIssue_noPR(t *testing.T) {
 	stubDir := t.TempDir()
-	callsFile := makeGHStub(t, stubDir, "", false)
+	callsFile := makeGHStub(t, stubDir, "", "", false)
 	prependPath(t, stubDir)
 
 	if err := linkPRToIssue(t.TempDir(), "42-my-feature", "42"); err != nil {
@@ -1956,7 +1970,7 @@ func TestLinkPRToIssue_alreadyLinked(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			stubDir := t.TempDir()
 			viewJSON := fmt.Sprintf(`{"number":7,"body":%q}`, tc.body)
-			callsFile := makeGHStub(t, stubDir, viewJSON, false)
+			callsFile := makeGHStub(t, stubDir, viewJSON, "", false)
 			prependPath(t, stubDir)
 
 			if err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
@@ -1973,7 +1987,7 @@ func TestLinkPRToIssue_alreadyLinked(t *testing.T) {
 func TestLinkPRToIssue_addsLink(t *testing.T) {
 	stubDir := t.TempDir()
 	viewJSON := `{"number":7,"body":"some PR work"}`
-	callsFile := makeGHStub(t, stubDir, viewJSON, false)
+	callsFile := makeGHStub(t, stubDir, viewJSON, "", false)
 	prependPath(t, stubDir)
 
 	if err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
@@ -1993,7 +2007,7 @@ func TestLinkPRToIssue_addsLink(t *testing.T) {
 func TestLinkPRToIssue_addsLink_emptyBody(t *testing.T) {
 	stubDir := t.TempDir()
 	viewJSON := `{"number":3,"body":""}`
-	callsFile := makeGHStub(t, stubDir, viewJSON, false)
+	callsFile := makeGHStub(t, stubDir, viewJSON, "", false)
 	prependPath(t, stubDir)
 
 	if err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
@@ -2010,7 +2024,7 @@ func TestLinkPRToIssue_addsLink_emptyBody(t *testing.T) {
 func TestLinkPRToIssue_editError(t *testing.T) {
 	stubDir := t.TempDir()
 	viewJSON := `{"number":7,"body":"some work"}`
-	makeGHStub(t, stubDir, viewJSON, true) // editFail=true
+	makeGHStub(t, stubDir, viewJSON, "", true) // editFail=true
 	prependPath(t, stubDir)
 
 	err := linkPRToIssue(t.TempDir(), "42-feature", "42")
@@ -2081,5 +2095,138 @@ func TestIsAgentRunning_livePID(t *testing.T) {
 	}
 	if !isAgentRunning(dir) {
 		t.Error("expected isAgentRunning=true when AgentPID is the current process")
+	}
+}
+
+func TestIsAgentRunning_unreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	// Write an .agent file then make it unreadable.
+	agentFile := filepath.Join(dir, ".agent")
+	if err := os.WriteFile(agentFile, []byte("agent-pid=99999\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(agentFile, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(agentFile, 0o600) })
+	// Should return true conservatively when file is unreadable.
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permission checks")
+	}
+	if !isAgentRunning(dir) {
+		t.Error("expected isAgentRunning=true when .agent file is unreadable (conservative)")
+	}
+}
+
+// ─── ghHasPR ─────────────────────────────────────────────────────────────────
+
+func TestGhHasPR_noPR(t *testing.T) {
+	stubDir := t.TempDir()
+	makeGHStub(t, stubDir, "", "", false) // listJSON="" → returns []
+	prependPath(t, stubDir)
+
+	has, err := ghHasPR(t.TempDir(), "42-my-feature")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if has {
+		t.Error("expected ghHasPR=false when pr list returns []")
+	}
+}
+
+func TestGhHasPR_hasPR(t *testing.T) {
+	stubDir := t.TempDir()
+	listJSON := `[{"number":7}]`
+	makeGHStub(t, stubDir, "", listJSON, false)
+	prependPath(t, stubDir)
+
+	has, err := ghHasPR(t.TempDir(), "42-my-feature")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !has {
+		t.Error("expected ghHasPR=true when pr list returns a non-empty array")
+	}
+}
+
+func TestGhHasPR_ghError(t *testing.T) {
+	// Use a stub that exits non-zero for pr list to simulate auth/network failure.
+	stubDir := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  echo "error: not authenticated" >&2
+  exit 1
+fi
+exit 0`)
+	ghPath := filepath.Join(stubDir, "gh")
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prependPath(t, stubDir)
+
+	has, err := ghHasPR(t.TempDir(), "42-my-feature")
+	if err == nil {
+		t.Fatal("expected error when gh exits non-zero")
+	}
+	if has {
+		t.Error("expected ghHasPR=false on error")
+	}
+}
+
+// ─── isStaleWorktree ─────────────────────────────────────────────────────────
+
+func TestIsStaleWorktree_agentRunning(t *testing.T) {
+	dir := t.TempDir()
+	pid := strconv.Itoa(os.Getpid())
+	if err := state.Write(dir, state.AgentFile{Agent: "claude", AgentPID: pid}); err != nil {
+		t.Fatal(err)
+	}
+	// No gh stub needed; isAgentRunning short-circuits.
+	if isStaleWorktree(t.TempDir(), "42-my-feature", dir) {
+		t.Error("expected isStaleWorktree=false when agent is running")
+	}
+}
+
+func TestIsStaleWorktree_hasPR(t *testing.T) {
+	dir := t.TempDir() // no .agent file → agent not running
+	stubDir := t.TempDir()
+	listJSON := `[{"number":7}]`
+	makeGHStub(t, stubDir, "", listJSON, false)
+	prependPath(t, stubDir)
+
+	if isStaleWorktree(t.TempDir(), "42-my-feature", dir) {
+		t.Error("expected isStaleWorktree=false when a PR exists")
+	}
+}
+
+func TestIsStaleWorktree_noPRNoAgent(t *testing.T) {
+	dir := t.TempDir() // no .agent file → agent not running
+	stubDir := t.TempDir()
+	makeGHStub(t, stubDir, "", "", false) // listJSON="" → returns []
+	prependPath(t, stubDir)
+
+	if !isStaleWorktree(t.TempDir(), "42-my-feature", dir) {
+		t.Error("expected isStaleWorktree=true when no agent and no PR")
+	}
+}
+
+func TestIsStaleWorktree_ghError(t *testing.T) {
+	dir := t.TempDir() // no .agent file → agent not running
+	stubDir := t.TempDir()
+	script := `#!/bin/sh
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  echo "error: not authenticated" >&2
+  exit 1
+fi
+exit 0`
+	ghPath := filepath.Join(stubDir, "gh")
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prependPath(t, stubDir)
+
+	// On gh error, should return false conservatively.
+	if isStaleWorktree(t.TempDir(), "42-my-feature", dir) {
+		t.Error("expected isStaleWorktree=false when gh returns an error (conservative)")
 	}
 }

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2230,3 +2230,184 @@ exit 0`
 		t.Error("expected isStaleWorktree=false when gh returns an error (conservative)")
 	}
 }
+
+// ─── runDiscardStale integration ─────────────────────────────────────────────
+
+// initGitRepoForStale creates a temporary git repository with an initial
+// commit and returns its path. Tests that need this are skipped when git is
+// not available.
+func initGitRepoForStale(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	dir := t.TempDir()
+	gitRun := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	gitRun("init")
+	gitRun("config", "user.email", "test@example.com")
+	gitRun("config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(dir, "README"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun("add", ".")
+	gitRun("commit", "-m", "init")
+	return dir
+}
+
+// pipeStdin replaces os.Stdin with a pipe that delivers text for the duration
+// of the test, then restores the original os.Stdin via t.Cleanup.
+func pipeStdin(t *testing.T, text string) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = old
+		r.Close()
+	})
+	if _, err := fmt.Fprintln(w, text); err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+}
+
+// addWorktree creates a linked worktree at wtPath on branch branchName.
+func addWorktree(t *testing.T, repo, wtPath, branchName string) {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "worktree", "add", wtPath, "-b", branchName)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+}
+
+func TestRunDiscardStale_noStaleWorktrees_agentRunning(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	wtPath := filepath.Join(t.TempDir(), "42-my-feature")
+	addWorktree(t, repo, wtPath, "42-my-feature")
+
+	// Write .agent file with current PID so agent appears running.
+	pid := strconv.Itoa(os.Getpid())
+	if err := state.Write(wtPath, state.AgentFile{Agent: "claude", AgentPID: pid}); err != nil {
+		t.Fatal(err)
+	}
+
+	// gh stub: no PRs — but agent is running, so worktree is not stale.
+	stubDir := t.TempDir()
+	makeGHStub(t, stubDir, "", "", false)
+	prependPath(t, stubDir)
+
+	chdirTemp(t, repo)
+	if err := runDiscardStale(); err != nil {
+		t.Fatalf("expected nil, got: %v", err)
+	}
+
+	// Worktree must still exist.
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Errorf("worktree should still exist when agent is running: %v", err)
+	}
+}
+
+func TestRunDiscardStale_noStaleWorktrees_hasPR(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	wtPath := filepath.Join(t.TempDir(), "42-my-feature")
+	addWorktree(t, repo, wtPath, "42-my-feature")
+
+	// gh stub: pr list returns a PR → not stale.
+	stubDir := t.TempDir()
+	makeGHStub(t, stubDir, "", `[{"number":7}]`, false)
+	prependPath(t, stubDir)
+
+	chdirTemp(t, repo)
+	if err := runDiscardStale(); err != nil {
+		t.Fatalf("expected nil, got: %v", err)
+	}
+
+	// Worktree must still exist.
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Errorf("worktree should still exist when PR exists: %v", err)
+	}
+}
+
+func TestRunDiscardStale_confirmationAbort(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	wtPath := filepath.Join(t.TempDir(), "42-my-feature")
+	addWorktree(t, repo, wtPath, "42-my-feature")
+
+	// gh stub: no PRs → stale.
+	stubDir := t.TempDir()
+	makeGHStub(t, stubDir, "", "", false)
+	prependPath(t, stubDir)
+
+	chdirTemp(t, repo)
+	pipeStdin(t, "n")
+
+	err := runDiscardStale()
+	if err == nil {
+		t.Fatal("expected aborted error when user declines confirmation")
+	}
+	if !strings.Contains(err.Error(), "aborted") {
+		t.Errorf("expected 'aborted' in error, got: %v", err)
+	}
+
+	// Worktree must still exist — nothing should have been removed.
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Errorf("worktree should still exist after abort: %v", err)
+	}
+}
+
+func TestRunDiscardStale_confirmationYES_removesWorktreeAndBranch(t *testing.T) {
+	repo := initGitRepoForStale(t)
+
+	// Create a bare repo as origin. The branch has not been pushed, so
+	// git push origin --delete will report "remote ref does not exist",
+	// which discardStaleEntry treats as "already removed" (success).
+	originDir := filepath.Join(t.TempDir(), "origin.git")
+	if err := os.MkdirAll(originDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init", "--bare")
+	cmd.Dir = originDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v\n%s", err, out)
+	}
+	cmd = exec.Command("git", "-C", repo, "remote", "add", "origin", originDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+
+	wtPath := filepath.Join(t.TempDir(), "42-my-feature")
+	addWorktree(t, repo, wtPath, "42-my-feature")
+
+	// gh stub: no PRs → stale.
+	stubDir := t.TempDir()
+	makeGHStub(t, stubDir, "", "", false)
+	prependPath(t, stubDir)
+
+	chdirTemp(t, repo)
+	pipeStdin(t, "YES")
+
+	if err := runDiscardStale(); err != nil {
+		t.Fatalf("runDiscardStale: %v", err)
+	}
+
+	// Worktree directory must be gone.
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Error("worktree dir should be removed after YES confirmation")
+	}
+
+	// Local branch must be gone.
+	cmd = exec.Command("git", "-C", repo, "show-ref", "--verify", "--quiet", "refs/heads/42-my-feature")
+	if err := cmd.Run(); err == nil {
+		t.Error("local branch should be deleted after YES confirmation")
+	}
+}


### PR DESCRIPTION
## Summary

- `agentctl discard --stale` scans all linked worktrees, identifies stale ones (no running agent **and** no open PR), lists them, prompts `YES`, then removes each: worktree dir, local branch, and remote branch. Prints `Discarded N stale worktree(s)`.
- `agentctl cleanup --all` now detects stale worktrees among skipped-no-PR entries and prints: `Note: N stale worktree(s) found with no agent and no PR — run \`agentctl discard --stale\` to remove them.`
- `--stale` and a positional issue number are mutually exclusive (returns an error).
- `docs/cli.md` updated to document `--stale` and the staleness definition.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./internal/cmd/ -run "TestDiscard|TestIsAgentRunning" -v` — 6 new tests pass:
  - `TestDiscardCmd_staleFlagRegistered`
  - `TestDiscardCmd_staleMutuallyExclusiveWithIssue`
  - `TestIsAgentRunning_noAgentFile`
  - `TestIsAgentRunning_emptyPID`
  - `TestIsAgentRunning_deadPID`
  - `TestIsAgentRunning_livePID`
- [ ] Manual: `agentctl discard --stale` (with stale worktrees present) — lists, prompts YES, removes all
- [ ] Manual: `agentctl discard --stale` (no stale worktrees) — prints "No stale worktrees found."
- [ ] Manual: `agentctl discard --stale 42` — error "mutually exclusive"
- [ ] Manual: `agentctl cleanup --all` (with stale worktrees) — shows hint at bottom

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)