### PR TITLE
fix: agentctl resume streams to terminal by default; add --headless flag

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,14 +34,19 @@ Side effects:
 ### `agentctl resume`
 
 ```bash
-agentctl resume <issue-number>
-agentctl resume <issue-number> [feedback]
+agentctl resume [--headless] [--quiet] <issue-number>
+agentctl resume [--headless] [--quiet] <issue-number> [feedback]
 ```
 
-Resumes a paused headless agent after the spec-review checkpoint.
+Resumes a paused agent after the spec-review checkpoint.
 
 - Without feedback: approves the spec and the agent begins implementation.
 - With feedback: sends the revision text and the agent rewrites the spec.
+
+By default the resumed agent streams its output to the terminal (foreground mode), identical to `agentctl start` without `--headless`. Press Ctrl+C to detach without stopping the agent.
+
+- `--headless`: run the resumed agent in the background and write output to `agent.log`.
+- `--quiet`: suppress agent log output in the terminal; show only the spinner (TTY) or heartbeat lines (non-TTY/CI). Has no effect with `--headless`.
 
 The command requires:
 
@@ -216,11 +221,14 @@ agentctl logs 42
 # Attach and wait for the agent to finish
 agentctl attach 42
 
-# Approve the spec after review
+# Approve the spec after review (streams to terminal by default)
 agentctl resume 42
 
 # Or request revisions instead
 agentctl resume 42 "Narrow scope to the API layer; avoid UI changes."
+
+# To resume in background (matches original headless behaviour)
+agentctl resume --headless 42
 
 # Clean up after merge
 agentctl cleanup 42
@@ -234,9 +242,9 @@ for i in 210 211 212; do
   agentctl start --headless "$i"
 done
 
-# Review generated specs, then approve each one
+# Review generated specs, then approve each one in background (batch-friendly)
 for i in 210 211 212; do
-  agentctl resume "$i"
+  agentctl resume --headless "$i"
 done
 
 # Monitor all worktrees

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1859,12 +1859,89 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 		return err
 	}
 
+	mirrorResumeLogFromOffset := func(srcPath string, dst *os.File, offset int64, done <-chan struct{}) {
+		src, err := os.Open(srcPath)
+		if err != nil {
+			return
+		}
+		defer src.Close()
+
+		ticker := time.NewTicker(200 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+
+			info, err := src.Stat()
+			if err != nil {
+				return
+			}
+
+			size := info.Size()
+			if size < offset {
+				offset = size
+			}
+
+			if size > offset {
+				if _, err := src.Seek(offset, io.SeekStart); err != nil {
+					return
+				}
+				written, err := io.Copy(dst, io.LimitReader(src, size-offset))
+				offset += written
+				if err != nil {
+					return
+				}
+				if err := dst.Sync(); err != nil {
+					return
+				}
+			}
+
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+			}
+		}
+	}
+
+	followResumeLogFromEOF := func(srcPath string, out io.Writer, done <-chan struct{}, quiet bool, color bool) {
+		info, err := os.Stat(srcPath)
+		if err != nil {
+			followLog(srcPath, out, done, quiet, color)
+			return
+		}
+
+		tmp, err := os.CreateTemp("", "agentctl-resume-log-*")
+		if err != nil {
+			followLog(srcPath, out, done, quiet, color)
+			return
+		}
+		tmpPath := tmp.Name()
+		defer func() {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+		}()
+
+		mirrorDone := make(chan struct{})
+		go func() {
+			defer close(mirrorDone)
+			mirrorResumeLogFromOffset(srcPath, tmp, info.Size(), done)
+		}()
+
+		followLog(tmpPath, out, done, quiet, color)
+		<-mirrorDone
+	}
+
 	logDone := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		followLog(logPath, os.Stdout, logDone, quiet, true)
+		followResumeLogFromEOF(logPath, os.Stdout, logDone, quiet, true)
 	}()
 
 	sigCh := make(chan os.Signal, 1)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -151,13 +151,20 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 
 // NewResumeCmd creates the `resume` subcommand.
 func NewResumeCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		headless bool
+		quiet    bool
+	)
+	c := &cobra.Command{
 		Use:   "resume <issue> [feedback]",
 		Short: "Resume a paused spec review: approve or revise",
-		Long: `Resume a paused headless agent after the spec-review checkpoint.
+		Long: `Resume a paused agent after the spec-review checkpoint.
 
 Without feedback, sends approval ("proceed") and the agent begins implementation.
-With feedback, sends the revision text and the agent rewrites the spec.`,
+With feedback, sends the revision text and the agent rewrites the spec.
+
+By default the resumed agent streams its output to the terminal (foreground).
+Use --headless to run it in the background and write output to agent.log.`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prompt := "proceed"
@@ -167,12 +174,15 @@ With feedback, sends the revision text and the agent rewrites the spec.`,
 				}
 				prompt = args[1]
 			}
-			return runReleasePausedSession(args[0], prompt)
+			return runReleasePausedSession(args[0], prompt, headless, quiet)
 		},
 	}
+	c.Flags().BoolVar(&headless, "headless", false, "Run agent in background (log -> agent.log)")
+	c.Flags().BoolVar(&quiet, "quiet", false, "Suppress agent log output; show spinner/heartbeat only")
+	return c
 }
 
-func runReleasePausedSession(issue, prompt string) error {
+func runReleasePausedSession(issue, prompt string, headless, quiet bool) error {
 	repoRoot, err := git.RepoRoot()
 	if err != nil {
 		return fmt.Errorf("cannot determine repo root: %w", err)
@@ -199,12 +209,7 @@ func runReleasePausedSession(issue, prompt string) error {
 		return fmt.Errorf("spec not yet generated for issue %s; paused state not reached.\nTail %s/agent.log to confirm and retry once the pause is reported.", issue, wt.Path)
 	}
 
-	if err := agentResume(af.Agent, wt.Path, af.SessionID, prompt); err != nil {
-		return err
-	}
-	fmt.Printf("Released pause for issue %s; Stage 2 running in background.\n", issue)
-	fmt.Printf("Tail: %s/agent.log\n", wt.Path)
-	return nil
+	return agentResume(af.Agent, wt.Path, issue, af.SessionID, prompt, headless, quiet)
 }
 
 // specExists checks whether a spec.md file exists anywhere under
@@ -1742,30 +1747,150 @@ func writeClaudeSettings(wtPath string) error {
 }
 
 // agentResume starts the coding agent in resume mode using the named adapter.
-func agentResume(adapterName, wtPath, sessionID, prompt string) error {
+// When headless is false (default) it streams agent.log to the terminal and
+// blocks until the agent exits. When headless is true it detaches immediately
+// and writes output to agent.log.
+func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless, quiet bool) error {
 	ad, err := adapters.Get(adapterName)
 	if err != nil {
 		return err
 	}
 
+	if err := ad.CheckBinary(); err != nil {
+		return err
+	}
+
+	if headless && adapterName == "claude" {
+		if err := writeClaudeSettings(wtPath); err != nil {
+			return err
+		}
+	}
+
 	resumeCmd := ad.ResumeCmd(prompt, sessionID, wtPath)
 	resumeCmd.Dir = wtPath
 
-	logFile, err := os.OpenFile(filepath.Join(wtPath, "agent.log"),
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	logPath := filepath.Join(wtPath, "agent.log")
+	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("open agent.log for append: %w", err)
 	}
-	resumeCmd.Stdout = logFile
-	resumeCmd.Stderr = logFile
+
+	var pr, pw *os.File
+	if !headless {
+		pr, pw, err = os.Pipe()
+		if err != nil {
+			logFile.Close()
+			return fmt.Errorf("os.Pipe: %w", err)
+		}
+		if adapterName == "claude" {
+			resumeCmd.Args = append(resumeCmd.Args, "--output-format", "stream-json", "--verbose")
+		}
+		resumeCmd.Stdout = pw
+		resumeCmd.Stderr = pw
+	} else {
+		if adapterName == "claude" {
+			resumeCmd.Args = append(resumeCmd.Args, "--verbose")
+		}
+		resumeCmd.Stdout = logFile
+		resumeCmd.Stderr = logFile
+	}
+
 	detachProcess(resumeCmd)
 
 	if err := resumeCmd.Start(); err != nil {
+		if pw != nil {
+			pw.Close()
+			pr.Close()
+		}
 		logFile.Close()
 		return fmt.Errorf("agent resume failed to start: %w", err)
 	}
-	logFile.Close()
-	// Release our reference to the process handle; the agent runs independently.
-	_ = resumeCmd.Process.Release()
-	return nil
+
+	var convWg sync.WaitGroup
+	if headless {
+		logFile.Close()
+	} else {
+		pw.Close()
+		convWg.Add(1)
+		go func() {
+			defer convWg.Done()
+			defer pr.Close()
+			defer logFile.Close()
+
+			r := bufio.NewReader(pr)
+			for {
+				line, err := r.ReadString('\n')
+				if line != "" {
+					if text := extractStreamText(strings.TrimSuffix(line, "\n"), wtPath); text != "" {
+						fmt.Fprintln(logFile, text)
+					}
+				}
+				if err != nil {
+					if !errors.Is(err, io.EOF) {
+						fmt.Fprintf(logFile, "converter read error: %v\n", err)
+					}
+					break
+				}
+			}
+		}()
+	}
+
+	pid := resumeCmd.Process.Pid
+
+	exitCh := make(chan struct{})
+	go func() {
+		if err := resumeCmd.Wait(); err != nil {
+			fmt.Fprintf(os.Stderr, "agent exited: %v\n", err)
+		}
+		close(exitCh)
+	}()
+
+	if err := state.AppendKey(wtPath, "agent-pid", strconv.Itoa(pid)); err != nil {
+		return err
+	}
+
+	if headless {
+		fmt.Printf("Released pause for issue %s; Stage 2 running in background.\n", issue)
+		fmt.Printf("Tail: %s\n", logPath)
+		return nil
+	}
+
+	if err := waitForFile(logPath, 10*time.Second); err != nil {
+		return err
+	}
+
+	logDone := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		followLog(logPath, os.Stdout, logDone, quiet, true)
+	}()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	for {
+		select {
+		case <-exitCh:
+			signal.Stop(sigCh)
+			convWg.Wait()
+			close(logDone)
+			wg.Wait()
+			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
+				if linkErr := linkPRToIssue(wtPath, branch, issue); linkErr != nil {
+					fmt.Fprintf(os.Stderr, "note: could not link PR to issue: %v\n", linkErr)
+				}
+			}
+			return nil
+		case <-sigCh:
+			signal.Stop(sigCh)
+			close(logDone)
+			wg.Wait()
+			fmt.Fprintf(os.Stdout, "agent still running in background\n")
+			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", issue)
+			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", issue)
+			fmt.Fprintf(os.Stdout, "  agentctl discard %s  # permanently delete worktree and branches\n", issue)
+			return nil
+		}
+	}
 }

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -907,13 +907,19 @@ func TestAgentResume_headless_success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read .agent: %v", err)
 	}
-	if !strings.Contains(string(agentState), "agent-pid:") {
+	if !strings.Contains(string(agentState), "agent-pid=") {
 		t.Fatalf(".agent missing agent-pid entry:\n%s", string(agentState))
 	}
 
-	logData, err := os.ReadFile(filepath.Join(dir, "agent.log"))
-	if err != nil {
-		t.Fatalf("read agent.log: %v", err)
+	// The background echo process may not have written yet; poll briefly.
+	var logData []byte
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		logData, _ = os.ReadFile(filepath.Join(dir, "agent.log"))
+		if strings.Contains(string(logData), "sess-123") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 	if !strings.Contains(string(logData), "sess-123") {
 		t.Fatalf("agent.log missing resumed session output:\n%s", string(logData))

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -900,7 +900,23 @@ func TestAgentResume_headless_success(t *testing.T) {
 	chdirTemp(t, dir)
 
 	if err := agentResume("echoagent", dir, "42", "sess-123", "my feedback", true, false); err != nil {
-		t.Errorf("agentResume headless: %v", err)
+		t.Fatalf("agentResume headless: %v", err)
+	}
+
+	agentState, err := os.ReadFile(filepath.Join(dir, ".agent"))
+	if err != nil {
+		t.Fatalf("read .agent: %v", err)
+	}
+	if !strings.Contains(string(agentState), "agent-pid:") {
+		t.Fatalf(".agent missing agent-pid entry:\n%s", string(agentState))
+	}
+
+	logData, err := os.ReadFile(filepath.Join(dir, "agent.log"))
+	if err != nil {
+		t.Fatalf("read agent.log: %v", err)
+	}
+	if !strings.Contains(string(logData), "sess-123") {
+		t.Fatalf("agent.log missing resumed session output:\n%s", string(logData))
 	}
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -818,6 +818,30 @@ func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
 	}
 }
 
+// ─── resume command flags ─────────────────────────────────────────────────────
+
+func TestResumeCmd_headlessFlag(t *testing.T) {
+	c := NewResumeCmd()
+	f := c.Flags().Lookup("headless")
+	if f == nil {
+		t.Fatal("--headless flag must be registered on resume cmd")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--headless default should be false, got %q", f.DefValue)
+	}
+}
+
+func TestResumeCmd_quietFlag(t *testing.T) {
+	c := NewResumeCmd()
+	f := c.Flags().Lookup("quiet")
+	if f == nil {
+		t.Fatal("--quiet flag must be registered on resume cmd")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--quiet default should be false, got %q", f.DefValue)
+	}
+}
+
 // ─── agentResume ─────────────────────────────────────────────────────────────
 
 func TestLaunchAgent_nonZeroExitLogsToStderr(t *testing.T) {
@@ -862,21 +886,115 @@ func TestLaunchAgent_nonZeroExitLogsToStderr(t *testing.T) {
 
 func TestAgentResume_unknownAdapter(t *testing.T) {
 	dir := t.TempDir()
-	err := agentResume("nonexistent-xyz-abc", dir, "sess-123", "my feedback")
+	err := agentResume("nonexistent-xyz-abc", dir, "42", "sess-123", "my feedback", true, false)
 	if err == nil {
 		t.Error("expected error for unknown adapter")
 	}
 }
 
-func TestAgentResume_success(t *testing.T) {
+func TestAgentResume_headless_success(t *testing.T) {
 	dir := t.TempDir()
 	// Use `echo` as the resume binary — always on PATH, exits immediately.
 	writeLocalAdapter(t, dir, "echoagent",
 		"binary: echo\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := agentResume("echoagent", dir, "sess-123", "my feedback"); err != nil {
-		t.Errorf("agentResume: %v", err)
+	if err := agentResume("echoagent", dir, "42", "sess-123", "my feedback", true, false); err != nil {
+		t.Errorf("agentResume headless: %v", err)
+	}
+}
+
+func TestAgentResume_nonHeadless_exitsWhenAgentDone(t *testing.T) {
+	dir := t.TempDir()
+	// Use `echo` as the resume binary — always on PATH, exits immediately.
+	writeLocalAdapter(t, dir, "echoagent",
+		"binary: echo\nsession: --session\n")
+	chdirTemp(t, dir)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- agentResume("echoagent", dir, "42", "sess-123", "my feedback", false, false)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("agentResume non-headless: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		if p, err := os.FindProcess(os.Getpid()); err == nil {
+			_ = p.Signal(os.Interrupt)
+		}
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("agentResume did not return after agent exit and cleanup returned error: %v", err)
+			}
+			t.Fatal("agentResume did not return after agent process exited — required interrupt-driven cleanup before failing")
+		case <-time.After(2 * time.Second):
+			t.Fatal("agentResume hung even after interrupt")
+		}
+	}
+}
+
+func TestAgentResume_nonHeadless_sigintPrintsHints(t *testing.T) {
+	dir := t.TempDir()
+
+	scriptPath := filepath.Join(dir, "sleepagent")
+	script := "#!/bin/sh\nsleep 30\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeLocalAdapter(t, dir, "sleepagent", "binary: "+scriptPath+"\n")
+	chdirTemp(t, dir)
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- agentResume("sleepagent", dir, "42", "sess-123", "feedback", false, false)
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	if p, err := os.FindProcess(os.Getpid()); err == nil {
+		_ = p.Signal(os.Interrupt)
+	}
+
+	select {
+	case launchErr := <-done:
+		if launchErr != nil {
+			t.Fatalf("agentResume: %v", launchErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("agentResume did not return after SIGINT")
+	}
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("reading captured stdout: %v", err)
+	}
+	r.Close()
+
+	out := buf.String()
+	for _, want := range []string{
+		"agent still running in background",
+		"agentctl logs 42",
+		"agentctl attach 42",
+		"agentctl discard 42",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in stdout after Ctrl+C, got:\n%s", want, out)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- `agentctl resume` previously always ran in the background (outputting only to `agent.log`), inconsistent with `agentctl start` which streams to the terminal by default.
- Default behaviour is now **foreground**: output streams live to the terminal and the command blocks until the agent exits — matching `agentctl start`.
- New `--headless` flag detaches and writes to `agent.log` (preserving the old default for batch/background workflows).
- New `--quiet` flag suppresses log output, showing only the spinner/heartbeat (mirrors `agentctl start --quiet`).
- `agentResume` is refactored to reuse `launchAgent`'s pipe, stream-json conversion, `followLog`, and signal-handling logic instead of bypassing it entirely.

## Test plan

- [x] `TestResumeCmd_headlessFlag` — `--headless` flag registered with default `false`
- [x] `TestResumeCmd_quietFlag` — `--quiet` flag registered with default `false`
- [x] `TestAgentResume_unknownAdapter` — error on unknown adapter (updated signature)
- [x] `TestAgentResume_headless_success` — headless mode writes to log and returns immediately
- [x] `TestAgentResume_nonHeadless_exitsWhenAgentDone` — foreground mode auto-exits when agent finishes
- [x] `TestAgentResume_nonHeadless_sigintPrintsHints` — Ctrl+C in foreground prints `logs`/`attach`/`discard` hints
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)