### PR TITLE
fix: route headless output through io.Writer to prevent test stdout leaks

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -144,7 +144,7 @@ func runStart(issue, slug, agentName, sddName string, headless, quiet bool) erro
 		kickoff = m.KickoffPrompt(issueNum, portStr)
 	}
 
-	return launchAgent(agentName, wtPath, issueNum, portStr, sessionID, kickoff, headless, quiet)
+	return launchAgent(agentName, wtPath, issueNum, portStr, sessionID, kickoff, headless, quiet, os.Stdout)
 }
 
 // ─── resume ───────────────────────────────────────────────────────────────────
@@ -1278,7 +1278,7 @@ func findWorktreePath(issue string) (string, error) {
 // then either returns immediately (headless) or streams agent.log to stdout
 // until the agent exits (non-headless). quiet suppresses log lines, showing
 // only the spinner/heartbeat.
-func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, headless, quiet bool) error {
+func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, headless, quiet bool, out io.Writer) error {
 	ad, err := adapters.Get(adapterName)
 	if err != nil {
 		return err
@@ -1398,11 +1398,11 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 	}
 
 	if headless {
-		fmt.Printf("Agent PID %d — log: %s\n", pid, logPath)
-		fmt.Printf("Session ID: %s\n", sessionID)
-		fmt.Printf("Use \"agentctl resume %s [feedback]\" to continue the session.\n", issue)
-		fmt.Println("Without feedback, it sends approval (\"proceed\") and the agent begins implementation.")
-		fmt.Println("With feedback, it sends the revision text and the agent rewrites the spec.")
+		fmt.Fprintf(out, "Agent PID %d — log: %s\n", pid, logPath)
+		fmt.Fprintf(out, "Session ID: %s\n", sessionID)
+		fmt.Fprintf(out, "Use \"agentctl resume %s [feedback]\" to continue the session.\n", issue)
+		fmt.Fprintln(out, "Without feedback, it sends approval (\"proceed\") and the agent begins implementation.")
+		fmt.Fprintln(out, "With feedback, it sends the revision text and the agent rewrites the spec.")
 		return nil
 	}
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1415,7 +1415,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		followLog(logPath, os.Stdout, logDone, quiet, true)
+		followLog(logPath, out, logDone, quiet, true)
 	}()
 
 	sigCh := make(chan os.Signal, 1)
@@ -1437,10 +1437,10 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			signal.Stop(sigCh)
 			close(logDone)
 			wg.Wait()
-			fmt.Fprintf(os.Stdout, "agent still running in background\n")
-			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", issue)
-			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", issue)
-			fmt.Fprintf(os.Stdout, "  agentctl discard %s  # permanently delete worktree and branches\n", issue)
+			fmt.Fprintf(out, "agent still running in background\n")
+			fmt.Fprintf(out, "  agentctl logs %s     # follow log\n", issue)
+			fmt.Fprintf(out, "  agentctl attach %s   # stream live output\n", issue)
+			fmt.Fprintf(out, "  agentctl discard %s  # permanently delete worktree and branches\n", issue)
 			return nil
 		}
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -561,7 +561,7 @@ func writeLocalAdapter(t *testing.T, dir, name, content string) {
 
 func TestLaunchAgent_unknownAdapter(t *testing.T) {
 	dir := t.TempDir()
-	err := launchAgent("nonexistent-xyz-abc", dir, "42", "3010", "sess-123", "kickoff", true, false)
+	err := launchAgent("nonexistent-xyz-abc", dir, "42", "3010", "sess-123", "kickoff", true, false, &bytes.Buffer{})
 	if err == nil {
 		t.Error("expected error for unknown adapter")
 	}
@@ -572,7 +572,7 @@ func TestLaunchAgent_binaryNotFound(t *testing.T) {
 	writeLocalAdapter(t, dir, "fakebinary", "binary: __nonexistent_binary_xyz__\n")
 	chdirTemp(t, dir)
 
-	err := launchAgent("fakebinary", dir, "42", "3010", "sess-123", "kickoff", true, false)
+	err := launchAgent("fakebinary", dir, "42", "3010", "sess-123", "kickoff", true, false, &bytes.Buffer{})
 	if err == nil {
 		t.Fatal("expected error when binary not found")
 	}
@@ -588,7 +588,8 @@ func TestLaunchAgent_headless(t *testing.T) {
 		"binary: echo\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", true, false)
+	var out bytes.Buffer
+	err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", true, false, &out)
 	if err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
@@ -604,6 +605,18 @@ func TestLaunchAgent_headless(t *testing.T) {
 	if _, err := strconv.Atoi(af.AgentPID); err != nil {
 		t.Errorf("agent-pid %q is not a valid integer: %v", af.AgentPID, err)
 	}
+
+	// Verify headless status lines were written to the provided writer, not stdout.
+	outStr := out.String()
+	for _, want := range []string{
+		"Agent PID",
+		"Session ID: sess-abc",
+		"agentctl resume 42",
+	} {
+		if !strings.Contains(outStr, want) {
+			t.Errorf("missing %q in headless output:\n%s", want, outStr)
+		}
+	}
 }
 
 func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
@@ -618,7 +631,7 @@ func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 	// Ctrl+C or any other intervention.
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", false, false)
+		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", false, false, &bytes.Buffer{})
 	}()
 
 	select {
@@ -668,7 +681,7 @@ func TestLaunchAgent_claudeNonHeadlessInjectsStreamJsonAndVerbose(t *testing.T) 
 
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", false, false)
+		done <- launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", false, false, &bytes.Buffer{})
 	}()
 
 	select {
@@ -719,7 +732,7 @@ func TestLaunchAgent_claudeHeadlessInjectsVerboseOnly(t *testing.T) {
 	writeLocalAdapter(t, dir, "claude", "binary: "+scriptPath+"\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", true, false); err != nil {
+	if err := launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", true, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 
@@ -775,7 +788,7 @@ func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("sleepagent", dir, "42", "3010", "sess-abc", "do the thing", false, false)
+		done <- launchAgent("sleepagent", dir, "42", "3010", "sess-abc", "do the thing", false, false, &bytes.Buffer{})
 	}()
 
 	// Give launchAgent time to start the agent process and register its signal
@@ -839,7 +852,7 @@ func TestLaunchAgent_nonZeroExitLogsToStderr(t *testing.T) {
 	// closed, which happens after fmt.Fprintf(os.Stderr, ...) in the reaper
 	// goroutine — so by the time launchAgent returns, the message is already
 	// captured in the pipe.
-	launchErr := launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", false, false)
+	launchErr := launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", false, false, &bytes.Buffer{})
 
 	// Close the write end and restore stderr before reading.
 	w.Close()
@@ -1831,7 +1844,7 @@ func TestLaunchAgent_claudeHeadlessWritesSettingsJson(t *testing.T) {
 	writeLocalAdapter(t, dir, "claude", "binary: "+scriptPath+"\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", true, false); err != nil {
+	if err := launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", true, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 
@@ -1859,7 +1872,7 @@ func TestLaunchAgent_nonClaudeDoesNotWriteSettingsJson(t *testing.T) {
 	writeLocalAdapter(t, dir, "echoagent", "binary: echo\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", true, false); err != nil {
+	if err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", true, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -764,7 +764,7 @@ func TestLaunchAgent_claudeHeadlessInjectsVerboseOnly(t *testing.T) {
 
 // TestLaunchAgent_nonHeadless_sigintPrintsHints verifies that pressing Ctrl+C
 // while launchAgent is streaming output in non-headless mode prints the
-// expected reconnection hints (logs, attach, discard) to stdout.
+// expected reconnection hints (logs, attach, discard) to the provided writer.
 func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
 	dir := t.TempDir()
 
@@ -777,18 +777,10 @@ func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
 	writeLocalAdapter(t, dir, "sleepagent", "binary: "+scriptPath+"\n")
 	chdirTemp(t, dir)
 
-	// Redirect os.Stdout to a pipe so we can capture the hint output.
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stdout = w
-	t.Cleanup(func() { os.Stdout = oldStdout })
-
+	var outBuf bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("sleepagent", dir, "42", "3010", "sess-abc", "do the thing", false, false, &bytes.Buffer{})
+		done <- launchAgent("sleepagent", dir, "42", "3010", "sess-abc", "do the thing", false, false, &outBuf)
 	}()
 
 	// Give launchAgent time to start the agent process and register its signal
@@ -808,17 +800,7 @@ func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
 		t.Fatal("launchAgent did not return after SIGINT")
 	}
 
-	// Close the write end and restore stdout before reading captured output.
-	w.Close()
-	os.Stdout = oldStdout
-
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatalf("reading captured stdout: %v", err)
-	}
-	r.Close()
-
-	out := buf.String()
+	out := outBuf.String()
 	for _, want := range []string{
 		"agent still running in background",
 		"agentctl logs 42",
@@ -826,7 +808,7 @@ func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
 		"agentctl discard 42",
 	} {
 		if !strings.Contains(out, want) {
-			t.Errorf("missing %q in stdout after Ctrl+C, got:\n%s", want, out)
+			t.Errorf("missing %q in out after Ctrl+C, got:\n%s", want, out)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `launchAgent` now accepts an `io.Writer` parameter for the headless status lines (Agent PID, Session ID, resume hint) instead of hard-coding `fmt.Printf` / `fmt.Println` to stdout
- Production caller (`runStart`) passes `os.Stdout`, preserving existing CLI behaviour
- All test callers pass `&bytes.Buffer{}` so the 5 headless output lines are captured rather than leaking into `go test ./...` output
- `TestLaunchAgent_headless` gains content assertions on the captured buffer, verifying the PID line, session ID, and resume hint are present

## Test plan

- [ ] `go test ./internal/cmd/ -run TestLaunchAgent` — all 10 tests pass, no headless output printed to terminal
- [ ] `go test ./...` — no new failures introduced
- [ ] `go vet ./...` — clean
- [ ] `go build ./...` — clean

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)