### PR TITLE
feat: print PR link after agent exits

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -911,9 +911,7 @@ func attachLog(wtPath, issue string, w io.Writer, logWait time.Duration) error {
 		_ = tail.Run()
 		fmt.Fprintln(w, "agent has already finished")
 		if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
-			if linkErr := linkPRToIssue(wtPath, branch, issue); linkErr != nil {
-				fmt.Fprintf(w, "note: could not link PR to issue: %v\n", linkErr)
-			}
+			reportPRStatus(w, wtPath, branch, issue)
 		}
 		return nil
 	}
@@ -947,9 +945,7 @@ func attachLog(wtPath, issue string, w io.Writer, logWait time.Duration) error {
 	_ = tail.Process.Kill()
 	_ = tail.Wait()
 	if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
-		if linkErr := linkPRToIssue(wtPath, branch, issue); linkErr != nil {
-			fmt.Fprintf(w, "note: could not link PR to issue: %v\n", linkErr)
-		}
+		reportPRStatus(w, wtPath, branch, issue)
 	}
 	return nil
 }
@@ -1041,30 +1037,34 @@ func ghPRState(repoRoot, branch string) (string, error) {
 	return state, err
 }
 
+type prInfo struct {
+	Number int    `json:"number"`
+	Body   string `json:"body"`
+	URL    string `json:"url"`
+}
+
 // linkPRToIssue appends "Closes #<issueNum>" to the open PR for branch,
 // unless the body already contains a closing keyword (closes/fixes).
-// Silently returns nil when no PR exists.
-func linkPRToIssue(dir, branch, issueNum string) error {
-	cmd := exec.Command("gh", "pr", "view", branch, "--json", "number,body")
+// Returns the PR info (including URL) so callers can display it.
+// Silently returns nil, nil when no PR exists.
+func linkPRToIssue(dir, branch, issueNum string) (*prInfo, error) {
+	cmd := exec.Command("gh", "pr", "view", branch, "--json", "number,body,url")
 	cmd.Dir = dir
 	var out, errBuf bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &errBuf
 	if err := cmd.Run(); err != nil {
-		return nil // no PR — silently skip
+		return nil, nil // no PR — silently skip
 	}
 
-	var pr struct {
-		Number int    `json:"number"`
-		Body   string `json:"body"`
-	}
+	var pr prInfo
 	if err := json.Unmarshal(out.Bytes(), &pr); err != nil {
-		return nil
+		return nil, nil
 	}
 
 	lower := strings.ToLower(pr.Body)
 	if strings.Contains(lower, "closes #"+issueNum) || strings.Contains(lower, "fixes #"+issueNum) {
-		return nil
+		return &pr, nil
 	}
 
 	newBody := strings.TrimRight(pr.Body, "\n") + "\n\nCloses #" + issueNum
@@ -1073,9 +1073,21 @@ func linkPRToIssue(dir, branch, issueNum string) error {
 	var editErr bytes.Buffer
 	editCmd.Stderr = &editErr
 	if err := editCmd.Run(); err != nil {
-		return fmt.Errorf("gh pr edit: %w: %s", err, strings.TrimSpace(editErr.String()))
+		return &pr, fmt.Errorf("gh pr edit: %w: %s", err, strings.TrimSpace(editErr.String()))
 	}
-	return nil
+	return &pr, nil
+}
+
+// reportPRStatus links the PR to the issue and prints the PR URL to w.
+// Silent when no PR exists.
+func reportPRStatus(w io.Writer, dir, branch, issueNum string) {
+	pr, err := linkPRToIssue(dir, branch, issueNum)
+	if err != nil {
+		fmt.Fprintf(w, "note: could not link PR to issue: %v\n", err)
+	}
+	if pr != nil && pr.Number > 0 && pr.URL != "" {
+		fmt.Fprintf(w, "PR: #%d  %s\n", pr.Number, pr.URL)
+	}
 }
 
 // parseIssueURL checks whether arg is a full GitHub issue URL of the form
@@ -1585,9 +1597,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff string, he
 			close(logDone)
 			wg.Wait()
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
-				if linkErr := linkPRToIssue(wtPath, branch, issue); linkErr != nil {
-					fmt.Fprintf(os.Stderr, "note: could not link PR to issue: %v\n", linkErr)
-				}
+				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
 			return nil
 		case <-sigCh:
@@ -2106,9 +2116,7 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			close(logDone)
 			wg.Wait()
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
-				if linkErr := linkPRToIssue(wtPath, branch, issue); linkErr != nil {
-					fmt.Fprintf(os.Stderr, "note: could not link PR to issue: %v\n", linkErr)
-				}
+				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
 			return nil
 		case <-sigCh:

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2136,8 +2136,12 @@ func TestLinkPRToIssue_noPR(t *testing.T) {
 	callsFile := makeGHStub(t, stubDir, "", "", false)
 	prependPath(t, stubDir)
 
-	if err := linkPRToIssue(t.TempDir(), "42-my-feature", "42"); err != nil {
-		t.Errorf("expected nil for no-PR case, got: %v", err)
+	pr, err := linkPRToIssue(t.TempDir(), "42-my-feature", "42")
+	if err != nil {
+		t.Errorf("expected nil error for no-PR case, got: %v", err)
+	}
+	if pr != nil {
+		t.Errorf("expected nil prInfo for no-PR case, got: %+v", pr)
 	}
 
 	calls, _ := os.ReadFile(callsFile)
@@ -2168,7 +2172,7 @@ func TestLinkPRToIssue_alreadyLinked(t *testing.T) {
 			callsFile := makeGHStub(t, stubDir, viewJSON, "", false)
 			prependPath(t, stubDir)
 
-			if err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
+			if _, err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
 				t.Errorf("expected nil, got: %v", err)
 			}
 			calls, _ := os.ReadFile(callsFile)
@@ -2181,12 +2185,16 @@ func TestLinkPRToIssue_alreadyLinked(t *testing.T) {
 
 func TestLinkPRToIssue_addsLink(t *testing.T) {
 	stubDir := t.TempDir()
-	viewJSON := `{"number":7,"body":"some PR work"}`
+	viewJSON := `{"number":7,"body":"some PR work","url":"https://github.com/owner/repo/pull/7"}`
 	callsFile := makeGHStub(t, stubDir, viewJSON, "", false)
 	prependPath(t, stubDir)
 
-	if err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
+	pr, err := linkPRToIssue(t.TempDir(), "42-feature", "42")
+	if err != nil {
 		t.Fatalf("linkPRToIssue: %v", err)
+	}
+	if pr == nil || pr.URL != "https://github.com/owner/repo/pull/7" {
+		t.Errorf("expected PR URL to be returned, got: %+v", pr)
 	}
 
 	calls, _ := os.ReadFile(callsFile)
@@ -2201,11 +2209,11 @@ func TestLinkPRToIssue_addsLink(t *testing.T) {
 
 func TestLinkPRToIssue_addsLink_emptyBody(t *testing.T) {
 	stubDir := t.TempDir()
-	viewJSON := `{"number":3,"body":""}`
+	viewJSON := `{"number":3,"body":"","url":"https://github.com/owner/repo/pull/3"}`
 	callsFile := makeGHStub(t, stubDir, viewJSON, "", false)
 	prependPath(t, stubDir)
 
-	if err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
+	if _, err := linkPRToIssue(t.TempDir(), "42-feature", "42"); err != nil {
 		t.Fatalf("linkPRToIssue: %v", err)
 	}
 
@@ -2218,16 +2226,47 @@ func TestLinkPRToIssue_addsLink_emptyBody(t *testing.T) {
 
 func TestLinkPRToIssue_editError(t *testing.T) {
 	stubDir := t.TempDir()
-	viewJSON := `{"number":7,"body":"some work"}`
+	viewJSON := `{"number":7,"body":"some work","url":"https://github.com/owner/repo/pull/7"}`
 	makeGHStub(t, stubDir, viewJSON, "", true) // editFail=true
 	prependPath(t, stubDir)
 
-	err := linkPRToIssue(t.TempDir(), "42-feature", "42")
+	_, err := linkPRToIssue(t.TempDir(), "42-feature", "42")
 	if err == nil {
 		t.Error("expected error when gh pr edit fails")
 	}
 	if !strings.Contains(err.Error(), "gh pr edit") {
 		t.Errorf("expected 'gh pr edit' in error, got: %v", err)
+	}
+}
+
+func TestReportPRStatus_printsPRLink(t *testing.T) {
+	stubDir := t.TempDir()
+	viewJSON := `{"number":9,"body":"work","url":"https://github.com/owner/repo/pull/9"}`
+	makeGHStub(t, stubDir, viewJSON, "", false)
+	prependPath(t, stubDir)
+
+	var buf bytes.Buffer
+	reportPRStatus(&buf, t.TempDir(), "2-my-feature", "2")
+
+	out := buf.String()
+	if !strings.Contains(out, "PR: #9") {
+		t.Errorf("expected PR number in output, got: %q", out)
+	}
+	if !strings.Contains(out, "https://github.com/owner/repo/pull/9") {
+		t.Errorf("expected PR URL in output, got: %q", out)
+	}
+}
+
+func TestReportPRStatus_noPR_printsNothing(t *testing.T) {
+	stubDir := t.TempDir()
+	makeGHStub(t, stubDir, "", "", false) // no PR
+	prependPath(t, stubDir)
+
+	var buf bytes.Buffer
+	reportPRStatus(&buf, t.TempDir(), "2-my-feature", "2")
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no output when no PR exists, got: %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- print a single fixed `PR: #<n>  <url>` line after the agent exits in launch, attach, and resume flows
- reuse PR lookup data so agentctl can both append `Closes #157` and emit the PR URL consistently
- cover the new launch/attach/resume output paths with cmd tests

## Testing
- go test ./internal/cmd -run 'Test(LaunchAgent_nonHeadless_printsPRLinkAfterExit|AttachLog_agentAlreadyDead|AgentResume_printsPRLinkAfterExit|LinkPRToIssue_)'
- go build ./...
- go build -o agentctl ./cmd/agentctl
- go vet ./...
- go test ./... *(fails on pre-existing internal/adapters, internal/cmd, and internal/sdd baseline failures on this branch)*

Closes #157