### PR TITLE
fix: use agent-neutral convention-file guidance in generic kickoff prompt

### DIFF
--- a/internal/sdd/sdd.go
+++ b/internal/sdd/sdd.go
@@ -18,7 +18,7 @@ var builtinFS embed.FS
 
 // genericSkipPrompt is the hardcoded prompt used when --no-sdd is set.
 // It never varies by methodology.
-const genericSkipPrompt = `Work on GitHub issue #{issue}. Read CLAUDE.md for project conventions.
+const genericSkipPrompt = `Work on GitHub issue #{issue}. Read project conventions from AGENTS.md, CLAUDE.md, or README.md if present.
 Skip the SDD lifecycle — make the changes directly, push the branch,
 and open a PR. Do not merge.
 Dev server is running on port {port}.`

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -372,6 +372,16 @@ func TestSkipPrompt_noPort_omitsDevServerLine(t *testing.T) {
 	assertPromptWithoutPortKeepsGuidance(t, "SkipPrompt", prompt)
 }
 
+func TestSkipPrompt_doesNotReferExclusivelyToClaudeMD(t *testing.T) {
+	prompt := sdd.SkipPrompt("42", "3010")
+	// CLAUDE.md is a Claude Code-specific file. The generic skip prompt must be
+	// agent-neutral so that Codex and other agents find their own convention
+	// files without hunting for a file that may not exist in the target repo.
+	if strings.Contains(prompt, "Read CLAUDE.md") {
+		t.Errorf("SkipPrompt must not use a Claude-specific file reference; got:\n%s", prompt)
+	}
+}
+
 func TestKickoffPrompt_noPort_omitsDevServerLine(t *testing.T) {
 	m, err := sdd.Get("speckit")
 	if err != nil {

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -377,8 +377,12 @@ func TestSkipPrompt_doesNotReferExclusivelyToClaudeMD(t *testing.T) {
 	// CLAUDE.md is a Claude Code-specific file. The generic skip prompt must be
 	// agent-neutral so that Codex and other agents find their own convention
 	// files without hunting for a file that may not exist in the target repo.
-	if strings.Contains(prompt, "Read CLAUDE.md") {
-		t.Errorf("SkipPrompt must not use a Claude-specific file reference; got:\n%s", prompt)
+	hasAgentNeutralReference := strings.Contains(prompt, "AGENTS.md") || strings.Contains(prompt, "README.md")
+	if !hasAgentNeutralReference {
+		t.Errorf("SkipPrompt must mention an agent-neutral convention file such as AGENTS.md or README.md; got:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "CLAUDE.md") && !hasAgentNeutralReference {
+		t.Errorf("SkipPrompt must not rely on a Claude-specific file reference without agent-neutral guidance; got:\n%s", prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces `Read CLAUDE.md for project conventions.` in `genericSkipPrompt` with `Read project conventions from AGENTS.md, CLAUDE.md, or README.md if present.`
- Adds a test (`TestSkipPrompt_doesNotReferExclusivelyToClaudeMD`) that enforces the agent-neutral language going forward

## Why

`CLAUDE.md` is a Claude Code-specific file. When `agentctl start N --agent codex` runs on a repo that has no `CLAUDE.md`, Codex spends significant effort searching sibling directories for the file, producing extremely verbose and largely useless output before giving up and proceeding. The `if present` guard also signals to any agent that the file is optional, preventing the hunt.

The new instruction lists `AGENTS.md` first (Codex's convention), then `CLAUDE.md` (Claude Code's convention), then `README.md` as a universal fallback.

## Test plan

- [ ] `go test ./internal/sdd/...` passes for all `TestSkipPrompt_*` and `TestKickoffPrompt_*` cases
- [ ] New test `TestSkipPrompt_doesNotReferExclusivelyToClaudeMD` is present and green
- [ ] `go build ./...` and `go vet ./...` are clean

Note: `TestGet_userLevelOverridesBuiltin` and `TestList_userLevelShadowsBuiltin` fail on macOS due to `os.UserConfigDir()` ignoring `XDG_CONFIG_HOME` — pre-existing failures unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)