### PR TITLE
fix: recognise plain-style specs/spec.md in status and resume

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -272,18 +272,11 @@ func runReleasePausedSession(issue, prompt string, headless, quiet bool) error {
 	}
 
 	// Check that a spec exists (paused state reached).
-	if !specExists(wt.Path) {
+	if computeSpecState(wt.Path, issue) == "no-spec" {
 		return fmt.Errorf("spec not yet generated for issue %s; paused state not reached.\nTail %s/agent.log to confirm and retry once the pause is reported.", issue, wt.Path)
 	}
 
 	return agentResume(af.Agent, wt.Path, issue, af.SessionID, prompt, headless, quiet)
-}
-
-// specExists checks whether a spec.md file exists anywhere under
-// <worktreePath>/specs/*/spec.md.
-func specExists(wtPath string) bool {
-	matches, err := filepath.Glob(filepath.Join(wtPath, "specs", "*", "spec.md"))
-	return err == nil && len(matches) > 0
 }
 
 // ─── discard ──────────────────────────────────────────────────────────────────
@@ -1036,13 +1029,19 @@ func pidStatus(pid string) string {
 	return pid + "(dead)"
 }
 
-// computeSpecState derives the SpecKit lifecycle state from filesystem
-// artifacts under <wtPath>/specs/<issue>-*/.
-// Spec pause state from SpecKit-style artefacts on disk.
+// computeSpecState derives the spec lifecycle state from filesystem artifacts.
+// It recognises two layouts:
+//   - plain-style:   specs/spec.md (flat); always "paused" — no lifecycle files
+//   - speckit-style: specs/<issue>-*/spec.md with optional plan.md / tasks.md
 func computeSpecState(wtPath, issue string) string {
 	if issue == "" {
 		return "no-spec"
 	}
+	// Plain-style: flat specs/spec.md with no lifecycle subdirectory.
+	if _, err := os.Stat(filepath.Join(wtPath, "specs", "spec.md")); err == nil {
+		return "paused"
+	}
+	// Speckit-style: specs/<issue>-<slug>/ with lifecycle artefacts.
 	specGlob := filepath.Join(wtPath, "specs", issue+"-*", "spec.md")
 	specs, err := filepath.Glob(specGlob)
 	if err != nil || len(specs) == 0 {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -125,14 +125,14 @@ func TestComputeSpecState_done(t *testing.T) {
 	}
 }
 
-func TestSpecExists_absent(t *testing.T) {
+func TestComputeSpecState_speckitStyleAbsent(t *testing.T) {
 	dir := t.TempDir()
-	if specExists(dir) {
-		t.Error("expected specExists to return false for empty dir")
+	if got := computeSpecState(dir, "42"); got != "no-spec" {
+		t.Errorf("computeSpecState empty dir = %q, want %q", got, "no-spec")
 	}
 }
 
-func TestSpecExists_present(t *testing.T) {
+func TestComputeSpecState_speckitStylePresent(t *testing.T) {
 	dir := t.TempDir()
 	specDir := filepath.Join(dir, "specs", "42-feature")
 	if err := os.MkdirAll(specDir, 0o755); err != nil {
@@ -141,8 +141,23 @@ func TestSpecExists_present(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(specDir, "spec.md"), []byte("spec"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if !specExists(dir) {
-		t.Error("expected specExists to return true when spec.md exists")
+	if got := computeSpecState(dir, "42"); got != "paused" {
+		t.Errorf("computeSpecState speckit spec = %q, want %q", got, "paused")
+	}
+}
+
+func TestComputeSpecState_plainStyle(t *testing.T) {
+	// plain SDD writes specs/spec.md directly; status should show "paused".
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "specs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "specs", "spec.md"), []byte("spec"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := computeSpecState(dir, "15")
+	if got != "paused" {
+		t.Errorf("computeSpecState with plain-style spec = %q, want %q", got, "paused")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `agentctl status` showed `no-spec` for worktrees using `--sdd=plain` even after the agent wrote `specs/spec.md`
- `agentctl resume` refused with "spec not yet generated" for the same reason
- Root cause: both `specExists` and `computeSpecState` only matched speckit's subdirectory pattern (`specs/<issue>-<slug>/spec.md`), not the flat `specs/spec.md` that the `plain` methodology produces

**Fix:** `computeSpecState` now checks for `specs/spec.md` first (plain-style → `paused`), then falls through to the speckit glob. The standalone `specExists` helper is removed; `resume` calls `computeSpecState` directly, eliminating duplicated detection logic.

## Test plan

- [ ] `go test -run TestComputeSpecState ./internal/cmd/` — all 8 spec state tests pass (2 new: `plainStyle`, `speckitStyleAbsent/Present`)
- [ ] `go test ./...` — no regressions beyond pre-existing macOS symlink failures
- [ ] `agentctl status` shows `paused` (not `no-spec`) for issue #15 worktree that already has `specs/spec.md`
- [ ] `agentctl resume 15 "..."` succeeds and continues the conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)