### PR TITLE
fix: show no-spec when SDD not requested, even if specs/spec.md exists

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -154,6 +154,7 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet bool, out 
 		Agent:     agentName,
 		SessionID: sessionID,
 		DevPID:    devPID,
+		SDD:       sddName,
 	}
 	if err := state.Write(wtPath, af); err != nil {
 		return err
@@ -272,7 +273,7 @@ func runReleasePausedSession(issue, prompt string, headless, quiet bool) error {
 	}
 
 	// Check that a spec exists (paused state reached).
-	if computeSpecState(wt.Path, issue) == "no-spec" {
+	if computeSpecState(wt.Path, issue, af.SDD) == "no-spec" {
 		return fmt.Errorf("spec not yet generated for issue %s; paused state not reached.\nTail %s/agent.log to confirm and retry once the pause is reported.", issue, wt.Path)
 	}
 
@@ -817,7 +818,7 @@ func runStatus(verbose bool) error {
 
 		devPIDStr := pidStatus(af.DevPID)
 		agentPIDStr := pidStatus(af.AgentPID)
-		specState := computeSpecState(wt.Path, wt.Issue)
+		specState := computeSpecState(wt.Path, wt.Issue, af.SDD)
 
 		prState := "none"
 		if branch != "?" && branch != "HEAD" {
@@ -1030,11 +1031,12 @@ func pidStatus(pid string) string {
 }
 
 // computeSpecState derives the spec lifecycle state from filesystem artifacts.
+// sddName is the SDD methodology recorded in .agent (empty when no SDD was requested).
 // It recognises two layouts:
 //   - plain-style:   specs/spec.md (flat); always "paused" — no lifecycle files
 //   - speckit-style: specs/<issue>-*/spec.md with optional plan.md / tasks.md
-func computeSpecState(wtPath, issue string) string {
-	if issue == "" {
+func computeSpecState(wtPath, issue, sddName string) string {
+	if issue == "" || sddName == "" {
 		return "no-spec"
 	}
 	// Plain-style: flat specs/spec.md with no lifecycle subdirectory.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -273,7 +273,10 @@ func runReleasePausedSession(issue, prompt string, headless, quiet bool) error {
 	}
 
 	// Check that a spec exists (paused state reached).
-	if computeSpecState(wt.Path, issue, af.SDD) == "no-spec" {
+	if af.SDDSet && af.SDD == "" {
+		return fmt.Errorf("worktree for issue %s was started without --sdd; resume is not applicable", issue)
+	}
+	if computeSpecState(wt.Path, issue, af.SDD, af.SDDSet) == "no-spec" {
 		return fmt.Errorf("spec not yet generated for issue %s; paused state not reached.\nTail %s/agent.log to confirm and retry once the pause is reported.", issue, wt.Path)
 	}
 
@@ -818,7 +821,7 @@ func runStatus(verbose bool) error {
 
 		devPIDStr := pidStatus(af.DevPID)
 		agentPIDStr := pidStatus(af.AgentPID)
-		specState := computeSpecState(wt.Path, wt.Issue, af.SDD)
+		specState := computeSpecState(wt.Path, wt.Issue, af.SDD, af.SDDSet)
 
 		prState := "none"
 		if branch != "?" && branch != "HEAD" {
@@ -1032,11 +1035,21 @@ func pidStatus(pid string) string {
 
 // computeSpecState derives the spec lifecycle state from filesystem artifacts.
 // sddName is the SDD methodology recorded in .agent (empty when no SDD was requested).
+// sddSet is true when the sdd= key was explicitly present in the .agent file:
+//   - sddSet=false: legacy worktree written before the sdd key existed — fall back
+//     to filesystem heuristics (same as old behaviour).
+//   - sddSet=true, sddName="": worktree started without --sdd — return "no-spec".
+//   - sddSet=true, sddName!="": SDD was requested — use filesystem heuristics.
+//
 // It recognises two layouts:
 //   - plain-style:   specs/spec.md (flat); always "paused" — no lifecycle files
 //   - speckit-style: specs/<issue>-*/spec.md with optional plan.md / tasks.md
-func computeSpecState(wtPath, issue, sddName string) string {
-	if issue == "" || sddName == "" {
+func computeSpecState(wtPath, issue, sddName string, sddSet bool) string {
+	if issue == "" {
+		return "no-spec"
+	}
+	// New worktree explicitly created without --sdd.
+	if sddSet && sddName == "" {
 		return "no-spec"
 	}
 	// Plain-style: flat specs/spec.md with no lifecycle subdirectory.

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -62,7 +62,7 @@ func TestTitleToSlug(t *testing.T) {
 
 func TestComputeSpecState_noSpec(t *testing.T) {
 	dir := t.TempDir()
-	state := computeSpecState(dir, "42", "plain")
+	state := computeSpecState(dir, "42", "plain", true)
 	if state != "no-spec" {
 		t.Errorf("expected no-spec, got %q", state)
 	}
@@ -70,7 +70,7 @@ func TestComputeSpecState_noSpec(t *testing.T) {
 
 func TestComputeSpecState_emptyIssue(t *testing.T) {
 	dir := t.TempDir()
-	state := computeSpecState(dir, "", "plain")
+	state := computeSpecState(dir, "", "plain", true)
 	if state != "no-spec" {
 		t.Errorf("expected no-spec for empty issue, got %q", state)
 	}
@@ -85,7 +85,7 @@ func TestComputeSpecState_paused(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(specDir, "spec.md"), []byte("spec"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	state := computeSpecState(dir, "42", "speckit")
+	state := computeSpecState(dir, "42", "speckit", true)
 	if state != "paused" {
 		t.Errorf("expected paused, got %q", state)
 	}
@@ -102,7 +102,7 @@ func TestComputeSpecState_inProgress(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	state := computeSpecState(dir, "42", "speckit")
+	state := computeSpecState(dir, "42", "speckit", true)
 	if state != "in-progress" {
 		t.Errorf("expected in-progress, got %q", state)
 	}
@@ -119,7 +119,7 @@ func TestComputeSpecState_done(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	state := computeSpecState(dir, "42", "speckit")
+	state := computeSpecState(dir, "42", "speckit", true)
 	if state != "done" {
 		t.Errorf("expected done, got %q", state)
 	}
@@ -127,7 +127,7 @@ func TestComputeSpecState_done(t *testing.T) {
 
 func TestComputeSpecState_speckitStyleAbsent(t *testing.T) {
 	dir := t.TempDir()
-	if got := computeSpecState(dir, "42", "speckit"); got != "no-spec" {
+	if got := computeSpecState(dir, "42", "speckit", true); got != "no-spec" {
 		t.Errorf("computeSpecState empty dir = %q, want %q", got, "no-spec")
 	}
 }
@@ -141,7 +141,7 @@ func TestComputeSpecState_speckitStylePresent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(specDir, "spec.md"), []byte("spec"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := computeSpecState(dir, "42", "speckit"); got != "paused" {
+	if got := computeSpecState(dir, "42", "speckit", true); got != "paused" {
 		t.Errorf("computeSpecState speckit spec = %q, want %q", got, "paused")
 	}
 }
@@ -155,7 +155,7 @@ func TestComputeSpecState_plainStyle(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "specs", "spec.md"), []byte("spec"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := computeSpecState(dir, "15", "plain")
+	got := computeSpecState(dir, "15", "plain", true)
 	if got != "paused" {
 		t.Errorf("computeSpecState with plain-style spec = %q, want %q", got, "paused")
 	}
@@ -171,9 +171,26 @@ func TestComputeSpecState_plainSpecExistsNoSDD(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "specs", "spec.md"), []byte("spec"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := computeSpecState(dir, "11", "")
+	got := computeSpecState(dir, "11", "", true)
 	if got != "no-spec" {
 		t.Errorf("computeSpecState no SDD + specs/spec.md = %q, want %q", got, "no-spec")
+	}
+}
+
+func TestComputeSpecState_legacyWorktree(t *testing.T) {
+	// Legacy worktrees written before the sdd= key was introduced have sddSet=false.
+	// computeSpecState must fall back to filesystem heuristics so existing worktrees
+	// with spec artifacts continue to show their real lifecycle state.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "specs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "specs", "spec.md"), []byte("spec"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := computeSpecState(dir, "11", "", false)
+	if got != "paused" {
+		t.Errorf("computeSpecState legacy worktree + specs/spec.md = %q, want %q", got, "paused")
 	}
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -62,7 +62,7 @@ func TestTitleToSlug(t *testing.T) {
 
 func TestComputeSpecState_noSpec(t *testing.T) {
 	dir := t.TempDir()
-	state := computeSpecState(dir, "42")
+	state := computeSpecState(dir, "42", "plain")
 	if state != "no-spec" {
 		t.Errorf("expected no-spec, got %q", state)
 	}
@@ -70,7 +70,7 @@ func TestComputeSpecState_noSpec(t *testing.T) {
 
 func TestComputeSpecState_emptyIssue(t *testing.T) {
 	dir := t.TempDir()
-	state := computeSpecState(dir, "")
+	state := computeSpecState(dir, "", "plain")
 	if state != "no-spec" {
 		t.Errorf("expected no-spec for empty issue, got %q", state)
 	}
@@ -85,7 +85,7 @@ func TestComputeSpecState_paused(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(specDir, "spec.md"), []byte("spec"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	state := computeSpecState(dir, "42")
+	state := computeSpecState(dir, "42", "speckit")
 	if state != "paused" {
 		t.Errorf("expected paused, got %q", state)
 	}
@@ -102,7 +102,7 @@ func TestComputeSpecState_inProgress(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	state := computeSpecState(dir, "42")
+	state := computeSpecState(dir, "42", "speckit")
 	if state != "in-progress" {
 		t.Errorf("expected in-progress, got %q", state)
 	}
@@ -119,7 +119,7 @@ func TestComputeSpecState_done(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	state := computeSpecState(dir, "42")
+	state := computeSpecState(dir, "42", "speckit")
 	if state != "done" {
 		t.Errorf("expected done, got %q", state)
 	}
@@ -127,7 +127,7 @@ func TestComputeSpecState_done(t *testing.T) {
 
 func TestComputeSpecState_speckitStyleAbsent(t *testing.T) {
 	dir := t.TempDir()
-	if got := computeSpecState(dir, "42"); got != "no-spec" {
+	if got := computeSpecState(dir, "42", "speckit"); got != "no-spec" {
 		t.Errorf("computeSpecState empty dir = %q, want %q", got, "no-spec")
 	}
 }
@@ -141,7 +141,7 @@ func TestComputeSpecState_speckitStylePresent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(specDir, "spec.md"), []byte("spec"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := computeSpecState(dir, "42"); got != "paused" {
+	if got := computeSpecState(dir, "42", "speckit"); got != "paused" {
 		t.Errorf("computeSpecState speckit spec = %q, want %q", got, "paused")
 	}
 }
@@ -155,9 +155,25 @@ func TestComputeSpecState_plainStyle(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "specs", "spec.md"), []byte("spec"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got := computeSpecState(dir, "15")
+	got := computeSpecState(dir, "15", "plain")
 	if got != "paused" {
 		t.Errorf("computeSpecState with plain-style spec = %q, want %q", got, "paused")
+	}
+}
+
+func TestComputeSpecState_plainSpecExistsNoSDD(t *testing.T) {
+	// specs/spec.md exists in the repo (e.g. committed from a prior run) but no
+	// SDD was requested for this issue — status must show "no-spec", not "paused".
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "specs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "specs", "spec.md"), []byte("spec"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := computeSpecState(dir, "11", "")
+	if got != "no-spec" {
+		t.Errorf("computeSpecState no SDD + specs/spec.md = %q, want %q", got, "no-spec")
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -18,6 +18,7 @@ type AgentFile struct {
 	SessionID string // UUID assigned at spawn time
 	DevPID    string // PID of the dev server process
 	AgentPID  string // PID of the background agent process (headless only)
+	SDD       string // SDD methodology name, e.g. "plain", "speckit"; empty if none
 	// Extra holds any additional key=value pairs not explicitly modelled above.
 	Extra map[string]string
 }
@@ -54,6 +55,8 @@ func Read(worktreePath string) (AgentFile, error) {
 			af.DevPID = v
 		case "agent-pid":
 			af.AgentPID = v
+		case "sdd":
+			af.SDD = v
 		default:
 			af.Extra[k] = v
 		}
@@ -93,6 +96,9 @@ func Write(worktreePath string, af AgentFile) error {
 	}
 	if af.AgentPID != "" {
 		lines = append(lines, "agent-pid="+af.AgentPID)
+	}
+	if af.SDD != "" {
+		lines = append(lines, "sdd="+af.SDD)
 	}
 	for k, v := range af.Extra {
 		lines = append(lines, k+"="+v)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -19,6 +19,11 @@ type AgentFile struct {
 	DevPID    string // PID of the dev server process
 	AgentPID  string // PID of the background agent process (headless only)
 	SDD       string // SDD methodology name, e.g. "plain", "speckit"; empty if none
+	// SDDSet is true when the sdd= key was explicitly present in the .agent file,
+	// even if its value is empty. Use this to distinguish new worktrees created
+	// without --sdd (SDDSet=true, SDD="") from legacy worktrees written before the
+	// sdd key was introduced (SDDSet=false).
+	SDDSet bool
 	// Extra holds any additional key=value pairs not explicitly modelled above.
 	Extra map[string]string
 }
@@ -57,6 +62,7 @@ func Read(worktreePath string) (AgentFile, error) {
 			af.AgentPID = v
 		case "sdd":
 			af.SDD = v
+			af.SDDSet = true
 		default:
 			af.Extra[k] = v
 		}
@@ -80,6 +86,8 @@ func GetKey(worktreePath, key string) (string, error) {
 		return af.DevPID, nil
 	case "agent-pid":
 		return af.AgentPID, nil
+	case "sdd":
+		return af.SDD, nil
 	default:
 		return af.Extra[key], nil
 	}
@@ -97,9 +105,9 @@ func Write(worktreePath string, af AgentFile) error {
 	if af.AgentPID != "" {
 		lines = append(lines, "agent-pid="+af.AgentPID)
 	}
-	if af.SDD != "" {
-		lines = append(lines, "sdd="+af.SDD)
-	}
+	// Always write sdd= so readers can distinguish new worktrees created without
+	// --sdd (sdd= present but empty) from legacy worktrees that predate this key.
+	lines = append(lines, "sdd="+af.SDD)
 	for k, v := range af.Extra {
 		lines = append(lines, k+"="+v)
 	}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -93,6 +93,7 @@ func TestGetKey(t *testing.T) {
 		Agent:     "copilot",
 		SessionID: "sess-999",
 		DevPID:    "77",
+		SDD:       "plain",
 	}); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
@@ -103,6 +104,43 @@ func TestGetKey(t *testing.T) {
 	v, err = GetKey(dir, "session-id")
 	if err != nil || v != "sess-999" {
 		t.Errorf("GetKey session-id: got %q %v", v, err)
+	}
+	v, err = GetKey(dir, "sdd")
+	if err != nil || v != "plain" {
+		t.Errorf("GetKey sdd: got %q %v", v, err)
+	}
+}
+
+func TestWriteAlwaysIncludesSDD(t *testing.T) {
+	// Write must always emit the sdd= key, even when SDD is empty, so that
+	// Read can set SDDSet=true and callers can distinguish new worktrees
+	// created without --sdd from legacy worktrees that predate the sdd key.
+	dir := t.TempDir()
+	af := AgentFile{
+		Agent:     "codex",
+		SessionID: "xyz-789",
+		DevPID:    "1234",
+		// SDD intentionally empty (started without --sdd)
+	}
+	if err := Write(dir, af); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, FileName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !contains(string(raw), "sdd=") {
+		t.Error("expected sdd= line to be present even when SDD is empty")
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !got.SDDSet {
+		t.Error("expected SDDSet=true after reading a file written with empty SDD")
+	}
+	if got.SDD != "" {
+		t.Errorf("SDD: got %q, want %q", got.SDD, "")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `agentctl status` was showing `paused` for worktrees started without `--sdd`, whenever `specs/spec.md` existed in the repo (e.g. committed from a prior plain-SDD PR). Affected `agentctl-test` issues #11 and #12 in the repro.
- Root cause: `computeSpecState` checked for `specs/spec.md` on disk with no knowledge of whether SDD was actually requested for that worktree.
- Fix: store `sdd=<name>` in `.agent` at start time; `computeSpecState` now takes the SDD name as a parameter and returns `no-spec` immediately when it is empty.

## Changes

- `internal/state/state.go`: add `SDD string` field to `AgentFile`; parse/write `sdd=` key
- `internal/cmd/commands.go`: set `af.SDD = sddName` in `startOne`; add `sddName` parameter to `computeSpecState`; pass `af.SDD` at both call sites (`status`, `resume`)
- `internal/cmd/commands_test.go`: update all `computeSpecState` call sites; add `TestComputeSpecState_plainSpecExistsNoSDD`

## Test plan

- [ ] `go test ./internal/cmd/ -run TestComputeSpecState` — all 9 pass
- [ ] `go test ./internal/state/` — all pass
- [ ] `agentctl start 11,12` (no `--sdd`) → `agentctl status` shows `no-spec`
- [ ] `agentctl start 15 --sdd=plain` → `agentctl status` shows `paused` after spec is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)