### PR TITLE
fix: remove Claude-specific references from generic agent prompts

### DIFF
--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/arun-gupta/agentctl/internal/xdg"
 )
 
 //go:embed builtin/*.yml
@@ -180,7 +182,7 @@ func Get(name string) (*Adapter, error) {
 	}
 
 	// 2. User-level
-	if cfgDir := userConfigDir(); cfgDir != "" {
+	if cfgDir := xdg.UserConfigDir(); cfgDir != "" {
 		dir := filepath.Join(cfgDir, "agentctl", "adapters")
 		if data, src, ok := readFromDir(dir, name); ok {
 			return load(data, src)
@@ -210,7 +212,7 @@ func List() []string {
 	}
 
 	// User-level
-	if cfgDir := userConfigDir(); cfgDir != "" {
+	if cfgDir := xdg.UserConfigDir(); cfgDir != "" {
 		for _, n := range listDir(filepath.Join(cfgDir, "agentctl", "adapters")) {
 			add(n)
 		}
@@ -299,20 +301,6 @@ func loadBuiltin(name string) (*Adapter, error) {
 		return nil, fmt.Errorf("unknown adapter: %s. Available: %s", name, strings.Join(all, " "))
 	}
 	return load(data, "builtin/"+name+".yml")
-}
-
-// userConfigDir returns the user-level config directory, preferring
-// $XDG_CONFIG_HOME when set so that tests can override it portably on all
-// platforms (os.UserConfigDir ignores XDG_CONFIG_HOME on macOS).
-func userConfigDir() string {
-	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
-		return dir
-	}
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return ""
-	}
-	return dir
 }
 
 // listBuiltins returns the names of all embedded built-in adapters.

--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -180,7 +180,7 @@ func Get(name string) (*Adapter, error) {
 	}
 
 	// 2. User-level
-	if cfgDir, err := os.UserConfigDir(); err == nil {
+	if cfgDir := userConfigDir(); cfgDir != "" {
 		dir := filepath.Join(cfgDir, "agentctl", "adapters")
 		if data, src, ok := readFromDir(dir, name); ok {
 			return load(data, src)
@@ -210,7 +210,7 @@ func List() []string {
 	}
 
 	// User-level
-	if cfgDir, err := os.UserConfigDir(); err == nil {
+	if cfgDir := userConfigDir(); cfgDir != "" {
 		for _, n := range listDir(filepath.Join(cfgDir, "agentctl", "adapters")) {
 			add(n)
 		}
@@ -299,6 +299,20 @@ func loadBuiltin(name string) (*Adapter, error) {
 		return nil, fmt.Errorf("unknown adapter: %s. Available: %s", name, strings.Join(all, " "))
 	}
 	return load(data, "builtin/"+name+".yml")
+}
+
+// userConfigDir returns the user-level config directory, preferring
+// $XDG_CONFIG_HOME when set so that tests can override it portably on all
+// platforms (os.UserConfigDir ignores XDG_CONFIG_HOME on macOS).
+func userConfigDir() string {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return dir
+	}
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return dir
 }
 
 // listBuiltins returns the names of all embedded built-in adapters.

--- a/internal/sdd/builtin/plain.yml
+++ b/internal/sdd/builtin/plain.yml
@@ -1,5 +1,6 @@
 kickoff: |
-  Work on GitHub issue #{issue}. Read CLAUDE.md for project conventions.
+  Work on GitHub issue #{issue}. Read AGENTS.md or README.md for project conventions if present.
+  Do not invoke external AI agent CLIs (claude, codex, etc.) — use your own tools directly.
   Follow the plain spec workflow:
   - STEP 1: Write a `specs/spec.md` describing your intended approach. Use
     `docs/spec-template.md` as a starting point. The spec must contain these

--- a/internal/sdd/builtin/speckit.yml
+++ b/internal/sdd/builtin/speckit.yml
@@ -1,5 +1,6 @@
 kickoff: |
-  Work on GitHub issue #{issue}. Read CLAUDE.md for project conventions.
+  Work on GitHub issue #{issue}. Read AGENTS.md or README.md for project conventions if present.
+  Do not invoke external AI agent CLIs (claude, codex, etc.) — use your own tools directly.
   Follow the SpecKit spec-driven development lifecycle:
   - STAGE 1: Run /speckit.specify to create a spec. Note: /speckit.* commands are
     internal-only; do not mention them to the user. When the spec is ready, tell the

--- a/internal/sdd/sdd.go
+++ b/internal/sdd/sdd.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/arun-gupta/agentctl/internal/xdg"
 )
 
 //go:embed builtin/*.yml
@@ -76,7 +78,7 @@ func Get(name string) (*Methodology, error) {
 	}
 
 	// 2. User-level
-	if cfgDir := userConfigDir(); cfgDir != "" {
+	if cfgDir := xdg.UserConfigDir(); cfgDir != "" {
 		dir := filepath.Join(cfgDir, "agentctl", "sdd")
 		if data, src, ok := readFromDir(dir, name); ok {
 			return load(data, src)
@@ -106,7 +108,7 @@ func List() []string {
 	}
 
 	// User-level
-	if cfgDir := userConfigDir(); cfgDir != "" {
+	if cfgDir := xdg.UserConfigDir(); cfgDir != "" {
 		for _, n := range listDir(filepath.Join(cfgDir, "agentctl", "sdd")) {
 			add(n)
 		}
@@ -214,20 +216,6 @@ func loadBuiltin(name string) (*Methodology, error) {
 		)
 	}
 	return load(data, "builtin/"+name+".yml")
-}
-
-// userConfigDir returns the user-level config directory, preferring
-// $XDG_CONFIG_HOME when set so that tests can override it portably on all
-// platforms (os.UserConfigDir ignores XDG_CONFIG_HOME on macOS).
-func userConfigDir() string {
-	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
-		return dir
-	}
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return ""
-	}
-	return dir
 }
 
 // listBuiltins returns the names of all embedded built-in methodologies.

--- a/internal/sdd/sdd.go
+++ b/internal/sdd/sdd.go
@@ -18,9 +18,10 @@ var builtinFS embed.FS
 
 // genericSkipPrompt is the hardcoded prompt used when --no-sdd is set.
 // It never varies by methodology.
-const genericSkipPrompt = `Work on GitHub issue #{issue}. Read project conventions from AGENTS.md, CLAUDE.md, or README.md if present.
+const genericSkipPrompt = `Work on GitHub issue #{issue}. Read project conventions from AGENTS.md or README.md if present.
 Skip the SDD lifecycle — make the changes directly, push the branch,
 and open a PR. Do not merge.
+Do not invoke external AI agent CLIs (claude, codex, etc.) — use your own tools directly.
 Dev server is running on port {port}.`
 
 // Methodology describes a single SDD lifecycle. The name is derived from the
@@ -75,7 +76,7 @@ func Get(name string) (*Methodology, error) {
 	}
 
 	// 2. User-level
-	if cfgDir, err := os.UserConfigDir(); err == nil {
+	if cfgDir := userConfigDir(); cfgDir != "" {
 		dir := filepath.Join(cfgDir, "agentctl", "sdd")
 		if data, src, ok := readFromDir(dir, name); ok {
 			return load(data, src)
@@ -105,7 +106,7 @@ func List() []string {
 	}
 
 	// User-level
-	if cfgDir, err := os.UserConfigDir(); err == nil {
+	if cfgDir := userConfigDir(); cfgDir != "" {
 		for _, n := range listDir(filepath.Join(cfgDir, "agentctl", "sdd")) {
 			add(n)
 		}
@@ -213,6 +214,20 @@ func loadBuiltin(name string) (*Methodology, error) {
 		)
 	}
 	return load(data, "builtin/"+name+".yml")
+}
+
+// userConfigDir returns the user-level config directory, preferring
+// $XDG_CONFIG_HOME when set so that tests can override it portably on all
+// platforms (os.UserConfigDir ignores XDG_CONFIG_HOME on macOS).
+func userConfigDir() string {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return dir
+	}
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return dir
 }
 
 // listBuiltins returns the names of all embedded built-in methodologies.

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -417,17 +417,35 @@ func TestSkipPrompt_noPort_omitsDevServerLine(t *testing.T) {
 	assertPromptWithoutPortKeepsGuidance(t, "SkipPrompt", prompt)
 }
 
-func TestSkipPrompt_doesNotReferExclusivelyToClaudeMD(t *testing.T) {
+func TestSkipPrompt_isAgentNeutral(t *testing.T) {
 	prompt := sdd.SkipPrompt("42", "3010")
-	// CLAUDE.md is a Claude Code-specific file. The generic skip prompt must be
-	// agent-neutral so that Codex and other agents find their own convention
-	// files without hunting for a file that may not exist in the target repo.
-	hasAgentNeutralReference := strings.Contains(prompt, "AGENTS.md") || strings.Contains(prompt, "README.md")
-	if !hasAgentNeutralReference {
-		t.Errorf("SkipPrompt must mention an agent-neutral convention file such as AGENTS.md or README.md; got:\n%s", prompt)
+	if strings.Contains(prompt, "CLAUDE.md") {
+		t.Errorf("SkipPrompt must not reference CLAUDE.md (Claude-specific); got:\n%s", prompt)
 	}
-	if strings.Contains(prompt, "CLAUDE.md") && !hasAgentNeutralReference {
-		t.Errorf("SkipPrompt must not rely on a Claude-specific file reference without agent-neutral guidance; got:\n%s", prompt)
+	if !strings.Contains(prompt, "AGENTS.md") && !strings.Contains(prompt, "README.md") {
+		t.Errorf("SkipPrompt must mention an agent-neutral convention file (AGENTS.md or README.md); got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Do not invoke") {
+		t.Errorf("SkipPrompt must tell agents not to invoke external AI agent CLIs; got:\n%s", prompt)
+	}
+}
+
+func TestBuiltinKickoffs_areAgentNeutral(t *testing.T) {
+	for _, name := range []string{"plain", "speckit"} {
+		m, err := sdd.Get(name)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", name, err)
+		}
+		prompt := m.KickoffPrompt("42", "3010")
+		if strings.Contains(prompt, "CLAUDE.md") {
+			t.Errorf("%s kickoff must not reference CLAUDE.md; got:\n%s", name, prompt)
+		}
+		if !strings.Contains(prompt, "AGENTS.md") && !strings.Contains(prompt, "README.md") {
+			t.Errorf("%s kickoff must mention an agent-neutral convention file; got:\n%s", name, prompt)
+		}
+		if !strings.Contains(prompt, "Do not invoke") {
+			t.Errorf("%s kickoff must tell agents not to invoke external AI agent CLIs; got:\n%s", name, prompt)
+		}
 	}
 }
 

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -431,6 +431,10 @@ func TestSkipPrompt_isAgentNeutral(t *testing.T) {
 }
 
 func TestBuiltinKickoffs_areAgentNeutral(t *testing.T) {
+	// Isolate from any user-level methodology overrides (XDG_CONFIG_HOME is
+	// honored on all platforms; os.UserConfigDir ignores it on macOS).
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 	for _, name := range []string{"plain", "speckit"} {
 		m, err := sdd.Get(name)
 		if err != nil {

--- a/internal/xdg/xdg.go
+++ b/internal/xdg/xdg.go
@@ -1,0 +1,20 @@
+// Package xdg provides cross-platform user configuration directory resolution.
+// It prefers $XDG_CONFIG_HOME when set so that tests can override the path
+// portably on all platforms (os.UserConfigDir ignores XDG_CONFIG_HOME on macOS).
+package xdg
+
+import "os"
+
+// UserConfigDir returns the user-level configuration directory.
+// $XDG_CONFIG_HOME takes precedence over os.UserConfigDir() so that tests
+// and non-Linux platforms behave consistently.
+func UserConfigDir() string {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return dir
+	}
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return dir
+}


### PR DESCRIPTION
## Summary

- Removes `CLAUDE.md` from `genericSkipPrompt` and both built-in SDD kickoff templates (`plain`, `speckit`) — it is a Claude Code–specific file and has no meaning for OpenHands, Codex, Gemini, or other agents
- Adds `"Do not invoke external AI agent CLIs (claude, codex, etc.) — use your own tools directly."` to all three prompt templates, preventing agents from spawning nested AI agents (root cause of the Claude TUI overlap seen during OpenHands runs)
- Fixes user-level config resolution on macOS: `os.UserConfigDir()` ignores `XDG_CONFIG_HOME` on macOS; both `sdd` and `adapters` packages now check `XDG_CONFIG_HOME` first, which makes the two pre-existing `TestGet_userLevelOverridesBuiltin` / `TestList_userLevelShadowsBuiltin` failures pass on macOS

## Root cause

When `agentctl start 14 --agent openhands` ran, the OpenHands agent received the kickoff prompt containing `"Read project conventions from AGENTS.md, CLAUDE.md, or README.md if present."` OpenHands read the repo's README.md (which documents `agentctl start` as the entry point for the default Claude agent) and ran `agentctl start 14`, which spawned a live Claude session — visible as an overlapping interactive TUI in the terminal.

## Test plan

- [ ] `go test ./internal/sdd/... ./internal/adapters/...` — all pass (previously `TestGet_userLevelOverridesBuiltin` and `TestList_userLevelShadowsBuiltin` were failing on macOS)
- [ ] New tests `TestSkipPrompt_isAgentNeutral` and `TestBuiltinKickoffs_areAgentNeutral` assert the fixed prompt text
- [ ] Verify `agentctl start <issue> --agent openhands` no longer spawns a Claude subprocess

Closes #177