### PR TITLE
fix: strengthen agent-neutral prompt to explicitly exclude agentctl

### DIFF
--- a/internal/sdd/builtin/plain.yml
+++ b/internal/sdd/builtin/plain.yml
@@ -1,6 +1,7 @@
 kickoff: |
   Work on GitHub issue #{issue}. Read AGENTS.md or README.md for project conventions if present.
-  Do not invoke external AI agent CLIs (claude, codex, etc.) — use your own tools directly.
+  You are the coding agent — implement changes using your own file-editing and bash tools.
+  Do not run agentctl, claude, codex, or any other agent-launcher CLI.
   Follow the plain spec workflow:
   - STEP 1: Write a `specs/spec.md` describing your intended approach. Use
     `docs/spec-template.md` as a starting point. The spec must contain these

--- a/internal/sdd/builtin/speckit.yml
+++ b/internal/sdd/builtin/speckit.yml
@@ -1,6 +1,7 @@
 kickoff: |
   Work on GitHub issue #{issue}. Read AGENTS.md or README.md for project conventions if present.
-  Do not invoke external AI agent CLIs (claude, codex, etc.) — use your own tools directly.
+  You are the coding agent — implement changes using your own file-editing and bash tools.
+  Do not run agentctl, claude, codex, or any other agent-launcher CLI.
   Follow the SpecKit spec-driven development lifecycle:
   - STAGE 1: Run /speckit.specify to create a spec. Note: /speckit.* commands are
     internal-only; do not mention them to the user. When the spec is ready, tell the

--- a/internal/sdd/sdd.go
+++ b/internal/sdd/sdd.go
@@ -23,7 +23,8 @@ var builtinFS embed.FS
 const genericSkipPrompt = `Work on GitHub issue #{issue}. Read project conventions from AGENTS.md or README.md if present.
 Skip the SDD lifecycle — make the changes directly, push the branch,
 and open a PR. Do not merge.
-Do not invoke external AI agent CLIs (claude, codex, etc.) — use your own tools directly.
+You are the coding agent — implement changes using your own file-editing and bash tools.
+Do not run agentctl, claude, codex, or any other agent-launcher CLI.
 Dev server is running on port {port}.`
 
 // Methodology describes a single SDD lifecycle. The name is derived from the

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -425,7 +425,7 @@ func TestSkipPrompt_isAgentNeutral(t *testing.T) {
 	if !strings.Contains(prompt, "AGENTS.md") && !strings.Contains(prompt, "README.md") {
 		t.Errorf("SkipPrompt must mention an agent-neutral convention file (AGENTS.md or README.md); got:\n%s", prompt)
 	}
-	if !strings.Contains(prompt, "Do not invoke") {
+	if !strings.Contains(prompt, "Do not run agentctl") {
 		t.Errorf("SkipPrompt must tell agents not to invoke external AI agent CLIs; got:\n%s", prompt)
 	}
 }
@@ -447,7 +447,7 @@ func TestBuiltinKickoffs_areAgentNeutral(t *testing.T) {
 		if !strings.Contains(prompt, "AGENTS.md") && !strings.Contains(prompt, "README.md") {
 			t.Errorf("%s kickoff must mention an agent-neutral convention file; got:\n%s", name, prompt)
 		}
-		if !strings.Contains(prompt, "Do not invoke") {
+		if !strings.Contains(prompt, "Do not run agentctl") {
 			t.Errorf("%s kickoff must tell agents not to invoke external AI agent CLIs; got:\n%s", name, prompt)
 		}
 	}


### PR DESCRIPTION
## Summary

- Adds `agentctl` to the list of CLIs agents must not run
- Changes phrasing from "Do not invoke external AI agent CLIs (claude, codex, etc.)" to a clearer two-sentence form: "You are the coding agent — implement changes using your own file-editing and bash tools. Do not run agentctl, claude, codex, or any other agent-launcher CLI."
- Applied to all three prompt templates: `genericSkipPrompt`, `plain.yml`, `speckit.yml`

## Root cause

The previous prompt omitted `agentctl` from the exclusion list. OpenHands read the `agentctl-test` README.md, which documents `agentctl start` as the entry point for the default Claude agent, and ran it — spawning a nested Claude interactive session visible in the terminal.

## Test plan

- [ ] `go test ./internal/sdd/...` passes
- [ ] `agentctl start <issue> --agent openhands` no longer spawns a Claude subprocess or interactive TUI