### PR TITLE
refactor: move non-SDD kickoff prompt out of sdd package

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -95,6 +95,31 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 	return c
 }
 
+// kickoffTemplate is the default prompt sent to the agent when no --sdd
+// methodology is specified. {issue} and {port} are substituted at call time.
+const kickoffTemplate = `Work on GitHub issue #{issue}. Read AGENTS.md or README.md for project conventions if present.
+Make the changes directly, push the branch, and open a PR. Do not merge.
+You are the coding agent — implement changes using your own file-editing and bash tools.
+Do not run agentctl, claude, codex, or any other agent-launcher CLI.
+Dev server is running on port {port}.`
+
+// buildKickoff returns the default agent kickoff prompt for a plain
+// (non-SDD) run with {issue} and {port} substituted. When port is empty,
+// the dev-server line is omitted entirely.
+func buildKickoff(issue, port string) string {
+	s := strings.ReplaceAll(kickoffTemplate, "{issue}", issue)
+	if port == "" {
+		var lines []string
+		for _, line := range strings.Split(s, "\n") {
+			if !strings.Contains(line, "{port}") {
+				lines = append(lines, line)
+			}
+		}
+		return strings.TrimRight(strings.Join(lines, "\n"), "\n")
+	}
+	return strings.ReplaceAll(s, "{port}", port)
+}
+
 // startOne provisions a worktree for a single issue and launches the agent.
 // It is the per-issue unit used by both single-issue and batch invocations.
 func startOne(issue, slug, agentName, sddName string, headless, quiet bool, out io.Writer) error {
@@ -162,7 +187,7 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet bool, out 
 
 	var kickoff string
 	if sddName == "" {
-		kickoff = sdd.SkipPrompt(issueNum, portStr)
+		kickoff = buildKickoff(issueNum, portStr)
 	} else {
 		m, sddErr := sdd.Get(sddName)
 		if sddErr != nil {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -293,13 +293,45 @@ Initializing agent...
 	}
 }
 
-func TestSkipPrompt_noSDDFlag(t *testing.T) {
-	kickoff := sdd.SkipPrompt("42", "3010")
-	if !contains(kickoff, "Skip the SDD lifecycle") {
-		t.Error("no-sdd kickoff should mention skipping SDD")
+func TestBuildKickoff_substitution(t *testing.T) {
+	kickoff := buildKickoff("42", "3010")
+	if strings.Contains(kickoff, "{issue}") {
+		t.Error("buildKickoff did not substitute {issue}")
+	}
+	if strings.Contains(kickoff, "{port}") {
+		t.Error("buildKickoff did not substitute {port}")
+	}
+	if !strings.Contains(kickoff, "42") {
+		t.Error("buildKickoff missing issue number 42")
+	}
+	if !strings.Contains(kickoff, "3010") {
+		t.Error("buildKickoff missing port 3010")
+	}
+}
+
+func TestBuildKickoff_noPort_omitsDevServerLine(t *testing.T) {
+	kickoff := buildKickoff("42", "")
+	if strings.Contains(kickoff, "port") || strings.Contains(kickoff, "{port}") {
+		t.Errorf("buildKickoff with empty port must not mention port, got:\n%s", kickoff)
+	}
+	if !strings.Contains(kickoff, "open a PR") {
+		t.Errorf("buildKickoff with empty port must still instruct to open a PR, got:\n%s", kickoff)
+	}
+}
+
+func TestBuildKickoff_isAgentNeutral(t *testing.T) {
+	kickoff := buildKickoff("42", "3010")
+	if strings.Contains(kickoff, "CLAUDE.md") {
+		t.Errorf("buildKickoff must not reference CLAUDE.md; got:\n%s", kickoff)
+	}
+	if !strings.Contains(kickoff, "AGENTS.md") && !strings.Contains(kickoff, "README.md") {
+		t.Errorf("buildKickoff must mention an agent-neutral convention file; got:\n%s", kickoff)
+	}
+	if !strings.Contains(kickoff, "Do not run agentctl") {
+		t.Errorf("buildKickoff must tell agents not to run agent-launcher CLIs; got:\n%s", kickoff)
 	}
 	if contains(kickoff, "/speckit") {
-		t.Error("no-sdd kickoff should not contain speckit-specific commands")
+		t.Error("buildKickoff must not contain speckit-specific commands")
 	}
 }
 

--- a/internal/sdd/builtin/plain.yml
+++ b/internal/sdd/builtin/plain.yml
@@ -1,6 +1,7 @@
 kickoff: |
   Work on GitHub issue #{issue}. Read AGENTS.md or README.md for project conventions if present.
-  Do not invoke external AI agent CLIs (claude, codex, etc.) — use your own tools directly.
+  You are the coding agent — implement changes using your own file-editing and bash tools.
+  Do not run agentctl, claude, codex, or any other agent-launcher CLI.
   Follow the plain spec workflow:
   - STEP 1: Write a `specs/spec.md` describing your intended approach. Use
     `docs/spec-template.md` as a starting point. The spec must contain these

--- a/internal/sdd/builtin/speckit.yml
+++ b/internal/sdd/builtin/speckit.yml
@@ -1,6 +1,7 @@
 kickoff: |
   Work on GitHub issue #{issue}. Read AGENTS.md or README.md for project conventions if present.
-  Do not invoke external AI agent CLIs (claude, codex, etc.) — use your own tools directly.
+  You are the coding agent — implement changes using your own file-editing and bash tools.
+  Do not run agentctl, claude, codex, or any other agent-launcher CLI.
   Follow the SpecKit spec-driven development lifecycle:
   - STAGE 1: Run /speckit.specify to create a spec. Note: /speckit.* commands are
     internal-only; do not mention them to the user. When the spec is ready, tell the

--- a/internal/sdd/sdd.go
+++ b/internal/sdd/sdd.go
@@ -18,14 +18,6 @@ import (
 //go:embed builtin/*.yml
 var builtinFS embed.FS
 
-// genericSkipPrompt is the hardcoded prompt used when --no-sdd is set.
-// It never varies by methodology.
-const genericSkipPrompt = `Work on GitHub issue #{issue}. Read project conventions from AGENTS.md or README.md if present.
-Skip the SDD lifecycle — make the changes directly, push the branch,
-and open a PR. Do not merge.
-Do not invoke external AI agent CLIs (claude, codex, etc.) — use your own tools directly.
-Dev server is running on port {port}.`
-
 // Methodology describes a single SDD lifecycle. The name is derived from the
 // YAML filename stem (e.g. "speckit.yml" → "speckit"). There is no name: field.
 type Methodology struct {
@@ -39,13 +31,6 @@ type Methodology struct {
 // containing {port} is removed so the agent is not told about a dev server.
 func (m *Methodology) KickoffPrompt(issue, port string) string {
 	s := strings.ReplaceAll(m.Kickoff, "{issue}", issue)
-	return substitutePort(s, port)
-}
-
-// SkipPrompt returns the generic skip prompt with {issue} and {port} substituted.
-// This is always the same regardless of which methodology is active.
-func SkipPrompt(issue, port string) string {
-	s := strings.ReplaceAll(genericSkipPrompt, "{issue}", issue)
 	return substitutePort(s, port)
 }
 

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -184,36 +184,6 @@ func TestKickoffPrompt_plain_waitForApproval(t *testing.T) {
 	}
 }
 
-// ─── SkipPrompt ───────────────────────────────────────────────────────────────
-
-func TestSkipPrompt_substitution(t *testing.T) {
-	prompt := sdd.SkipPrompt("42", "3010")
-	if strings.Contains(prompt, "{issue}") {
-		t.Error("SkipPrompt did not substitute {issue}")
-	}
-	if strings.Contains(prompt, "{port}") {
-		t.Error("SkipPrompt did not substitute {port}")
-	}
-	if !strings.Contains(prompt, "42") {
-		t.Error("SkipPrompt missing issue number 42")
-	}
-	if !strings.Contains(prompt, "3010") {
-		t.Error("SkipPrompt missing port 3010")
-	}
-}
-
-func TestSkipPrompt_sameRegardlessOfMethodology(t *testing.T) {
-	// SkipPrompt is always the same generic text, not methodology-specific.
-	p1 := sdd.SkipPrompt("1", "3010")
-	p2 := sdd.SkipPrompt("1", "3010")
-	if p1 != p2 {
-		t.Errorf("SkipPrompt is not deterministic: %q vs %q", p1, p2)
-	}
-	if !strings.Contains(p1, "Skip the SDD lifecycle") {
-		t.Errorf("SkipPrompt missing generic skip text, got: %s", p1)
-	}
-}
-
 // ─── resolution chain ─────────────────────────────────────────────────────────
 
 func TestGet_userLevelOverridesBuiltin(t *testing.T) {
@@ -412,24 +382,6 @@ func assertPromptWithoutPortKeepsGuidance(t *testing.T, promptName, prompt strin
 	}
 }
 
-func TestSkipPrompt_noPort_omitsDevServerLine(t *testing.T) {
-	prompt := sdd.SkipPrompt("42", "")
-	assertPromptWithoutPortKeepsGuidance(t, "SkipPrompt", prompt)
-}
-
-func TestSkipPrompt_isAgentNeutral(t *testing.T) {
-	prompt := sdd.SkipPrompt("42", "3010")
-	if strings.Contains(prompt, "CLAUDE.md") {
-		t.Errorf("SkipPrompt must not reference CLAUDE.md (Claude-specific); got:\n%s", prompt)
-	}
-	if !strings.Contains(prompt, "AGENTS.md") && !strings.Contains(prompt, "README.md") {
-		t.Errorf("SkipPrompt must mention an agent-neutral convention file (AGENTS.md or README.md); got:\n%s", prompt)
-	}
-	if !strings.Contains(prompt, "Do not invoke") {
-		t.Errorf("SkipPrompt must tell agents not to invoke external AI agent CLIs; got:\n%s", prompt)
-	}
-}
-
 func TestBuiltinKickoffs_areAgentNeutral(t *testing.T) {
 	// Isolate from any user-level methodology overrides (XDG_CONFIG_HOME is
 	// honored on all platforms; os.UserConfigDir ignores it on macOS).
@@ -447,8 +399,8 @@ func TestBuiltinKickoffs_areAgentNeutral(t *testing.T) {
 		if !strings.Contains(prompt, "AGENTS.md") && !strings.Contains(prompt, "README.md") {
 			t.Errorf("%s kickoff must mention an agent-neutral convention file; got:\n%s", name, prompt)
 		}
-		if !strings.Contains(prompt, "Do not invoke") {
-			t.Errorf("%s kickoff must tell agents not to invoke external AI agent CLIs; got:\n%s", name, prompt)
+		if !strings.Contains(prompt, "Do not run agentctl") {
+			t.Errorf("%s kickoff must tell agents not to invoke agent-launcher CLIs; got:\n%s", name, prompt)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Removes `genericSkipPrompt` / `SkipPrompt` from `internal/sdd` — the `sdd` package is now only touched when `--sdd` is explicitly specified
- Adds `kickoffTemplate` constant and `buildKickoff()` to `internal/cmd`; plain `agentctl start` (no `--sdd`) now assembles its prompt entirely within the `cmd` layer
- Strengthens the kickoff prompt: drops the internal "Skip the SDD lifecycle" phrase, adds an explicit guard against running `agentctl`, `claude`, `codex`, or other agent-launcher CLIs
- Applies the same wording update to `plain.yml` and `speckit.yml` SDD templates
- Migrates `SkipPrompt` tests to `commands_test.go` as `TestBuildKickoff_*`; updates `TestBuiltinKickoffs_areAgentNeutral` in `sdd_test.go`

## Test plan

- [ ] `go test ./internal/sdd/... ./internal/cmd/...` — all tests pass (pre-existing macOS symlink failures in `TestLocateOrCloneRepo_cwdMatch` and two related tests are unaffected)
- [ ] `agentctl start <issue> --agent openhands` uses the new prompt (verify with `agentctl logs <issue>`)
- [ ] `agentctl start <issue> --sdd=plain` still uses the SDD kickoff from `plain.yml`