### PR TITLE
fix: isolate agent HOME to prevent session hijacking

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1512,7 +1512,11 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 
 	agentCmd := ad.LaunchCmd(kickoff, sessionID, wtPath)
 	agentCmd.Dir = wtPath
-	agentCmd.Env = agentEnv(wtPath)
+	agentEnv, err := agentEnv(wtPath)
+	if err != nil {
+		return fmt.Errorf("agentEnv: %w", err)
+	}
+	agentCmd.Env = agentEnv
 
 	logPath := filepath.Join(wtPath, "agent.log")
 	logFile, err := os.Create(logPath)
@@ -2210,19 +2214,53 @@ func isWriterTerminal(w io.Writer) bool {
 // HOME to a private directory inside the worktree so the agent gets a fresh
 // ~/.claude (no existing sessions to attach to) while every other tool keeps
 // working. Git and SSH stay functional via symlinks into the real home.
-func agentEnv(wtPath string) []string {
+// Returns an error if the private HOME directory cannot be created.
+func agentEnv(wtPath string) ([]string, error) {
 	agentHome := filepath.Join(wtPath, ".agent-home")
-	_ = os.MkdirAll(agentHome, 0o755)
+
+	// Guard against a pre-existing symlink at .agent-home: a malicious repo
+	// could plant one to redirect HOME outside the worktree and bypass isolation.
+	if fi, err := os.Lstat(agentHome); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("agentEnv: .agent-home is a symlink; refusing to use as HOME")
+	}
+
+	if err := os.MkdirAll(agentHome, 0o755); err != nil {
+		return nil, fmt.Errorf("agentEnv: create agent home dir: %w", err)
+	}
 
 	realHome, err := os.UserHomeDir()
 	if err == nil {
-		// Symlink .gitconfig and .ssh so git operations and SSH key auth work.
+		// Link .gitconfig and .ssh so git operations and SSH key auth work.
 		for _, name := range []string{".gitconfig", ".ssh"} {
 			src := filepath.Join(realHome, name)
 			dst := filepath.Join(agentHome, name)
-			if _, statErr := os.Lstat(dst); statErr != nil {
-				if _, srcErr := os.Lstat(src); srcErr == nil {
-					_ = os.Symlink(src, dst)
+
+			// Skip dst if already present; treat unexpected stat errors as a warning.
+			if _, statErr := os.Lstat(dst); statErr == nil {
+				continue
+			} else if !os.IsNotExist(statErr) {
+				fmt.Fprintf(os.Stderr, "agentctl: warning: stat %s: %v\n", dst, statErr)
+				continue
+			}
+
+			// Only proceed when src actually exists; warn on unexpected src errors.
+			if _, srcErr := os.Lstat(src); srcErr != nil {
+				if !os.IsNotExist(srcErr) {
+					fmt.Fprintf(os.Stderr, "agentctl: warning: stat %s: %v\n", src, srcErr)
+				}
+				continue
+			}
+
+			if symlinkErr := os.Symlink(src, dst); symlinkErr != nil {
+				// On Windows, symlinks require Developer Mode. Fall back to
+				// copying regular files (e.g. .gitconfig); for directories
+				// (.ssh) emit a warning so failures are diagnosable.
+				if name == ".gitconfig" {
+					if copyErr := copyFile(src, dst); copyErr != nil {
+						fmt.Fprintf(os.Stderr, "agentctl: warning: copy %s: %v\n", name, copyErr)
+					}
+				} else {
+					fmt.Fprintf(os.Stderr, "agentctl: warning: symlink %s: %v (git/SSH may not work)\n", name, symlinkErr)
 				}
 			}
 		}
@@ -2232,12 +2270,42 @@ func agentEnv(wtPath string) []string {
 	for i, kv := range env {
 		if strings.HasPrefix(kv, "HOME=") {
 			env[i] = "HOME=" + agentHome
-			return env
+			return env, nil
 		}
 	}
-	return append(env, "HOME="+agentHome)
+	return append(env, "HOME="+agentHome), nil
 }
 
+// copyFile copies the file at src to dst using regular file I/O.
+// It is used as a Windows fallback when os.Symlink is unavailable.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close() // read-only; Close error is safe to ignore
+
+	fi, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fi.Mode())
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// writeClaudeSettings creates .claude/settings.json in wtPath with a
+// wildcard allow-list so that sub-agents spawned by the top-level Claude
+// process inherit the same bypass-permissions mode. If the file already
+// exists (e.g. committed in the repo) it is left untouched.
 func writeClaudeSettings(wtPath string) error {
 	dir := filepath.Join(wtPath, ".claude")
 	// Reject symlinks to prevent writing outside the worktree.
@@ -2289,7 +2357,11 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 
 	resumeCmd := ad.ResumeCmd(prompt, sessionID, wtPath)
 	resumeCmd.Dir = wtPath
-	resumeCmd.Env = agentEnv(wtPath)
+	resumeEnv, err := agentEnv(wtPath)
+	if err != nil {
+		return fmt.Errorf("agentEnv: %w", err)
+	}
+	resumeCmd.Env = resumeEnv
 
 	logPath := filepath.Join(wtPath, "agent.log")
 	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1512,6 +1512,10 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 
 	agentCmd := ad.LaunchCmd(kickoff, sessionID, wtPath)
 	agentCmd.Dir = wtPath
+	// Remove agent-launcher binaries from the child's PATH so the agent
+	// cannot invoke agentctl, claude, or other agent CLIs even if its model
+	// decides to try — prompt instructions alone are not reliable guards.
+	agentCmd.Env = agentEnv()
 
 	logPath := filepath.Join(wtPath, "agent.log")
 	logFile, err := os.Create(logPath)
@@ -2209,6 +2213,37 @@ func isWriterTerminal(w io.Writer) bool {
 // wildcard allow-list so that sub-agents spawned by the top-level Claude
 // process inherit the same bypass-permissions mode. If the file already
 // exists (e.g. committed in the repo) it is left untouched.
+// agentEnv returns os.Environ() with directories that contain known
+// agent-launcher binaries (claude, agentctl) removed from PATH. This prevents
+// a spawned agent from invoking another AI agent CLI even when its model
+// decides to try — prompt instructions alone are not a reliable guard.
+func agentEnv() []string {
+	blocked := []string{"claude", "agentctl"}
+	rawPath := os.Getenv("PATH")
+	var kept []string
+	for _, dir := range filepath.SplitList(rawPath) {
+		exclude := false
+		for _, bin := range blocked {
+			if _, err := os.Stat(filepath.Join(dir, bin)); err == nil {
+				exclude = true
+				break
+			}
+		}
+		if !exclude {
+			kept = append(kept, dir)
+		}
+	}
+	filteredPath := strings.Join(kept, string(filepath.ListSeparator))
+	env := os.Environ()
+	for i, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			env[i] = "PATH=" + filteredPath
+			return env
+		}
+	}
+	return append(env, "PATH="+filteredPath)
+}
+
 func writeClaudeSettings(wtPath string) error {
 	dir := filepath.Join(wtPath, ".claude")
 	// Reject symlinks to prevent writing outside the worktree.
@@ -2260,6 +2295,7 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 
 	resumeCmd := ad.ResumeCmd(prompt, sessionID, wtPath)
 	resumeCmd.Dir = wtPath
+	resumeCmd.Env = agentEnv()
 
 	logPath := filepath.Join(wtPath, "agent.log")
 	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1512,10 +1512,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 
 	agentCmd := ad.LaunchCmd(kickoff, sessionID, wtPath)
 	agentCmd.Dir = wtPath
-	// Remove agent-launcher binaries from the child's PATH so the agent
-	// cannot invoke agentctl, claude, or other agent CLIs even if its model
-	// decides to try — prompt instructions alone are not reliable guards.
-	agentCmd.Env = agentEnv()
+	agentCmd.Env = agentEnv(wtPath)
 
 	logPath := filepath.Join(wtPath, "agent.log")
 	logFile, err := os.Create(logPath)
@@ -2209,39 +2206,36 @@ func isWriterTerminal(w io.Writer) bool {
 	return fi.Mode()&os.ModeCharDevice != 0
 }
 
-// writeClaudeSettings creates .claude/settings.json in wtPath with a
-// wildcard allow-list so that sub-agents spawned by the top-level Claude
-// process inherit the same bypass-permissions mode. If the file already
-// exists (e.g. committed in the repo) it is left untouched.
-// agentEnv returns os.Environ() with directories that contain known
-// agent-launcher binaries (claude, agentctl) removed from PATH. This prevents
-// a spawned agent from invoking another AI agent CLI even when its model
-// decides to try — prompt instructions alone are not a reliable guard.
-func agentEnv() []string {
-	blocked := []string{"claude", "agentctl"}
-	rawPath := os.Getenv("PATH")
-	var kept []string
-	for _, dir := range filepath.SplitList(rawPath) {
-		exclude := false
-		for _, bin := range blocked {
-			if _, err := os.Stat(filepath.Join(dir, bin)); err == nil {
-				exclude = true
-				break
+// agentEnv builds the environment for a spawned agent process. It overrides
+// HOME to a private directory inside the worktree so the agent gets a fresh
+// ~/.claude (no existing sessions to attach to) while every other tool keeps
+// working. Git and SSH stay functional via symlinks into the real home.
+func agentEnv(wtPath string) []string {
+	agentHome := filepath.Join(wtPath, ".agent-home")
+	_ = os.MkdirAll(agentHome, 0o755)
+
+	realHome, err := os.UserHomeDir()
+	if err == nil {
+		// Symlink .gitconfig and .ssh so git operations and SSH key auth work.
+		for _, name := range []string{".gitconfig", ".ssh"} {
+			src := filepath.Join(realHome, name)
+			dst := filepath.Join(agentHome, name)
+			if _, statErr := os.Lstat(dst); statErr != nil {
+				if _, srcErr := os.Lstat(src); srcErr == nil {
+					_ = os.Symlink(src, dst)
+				}
 			}
 		}
-		if !exclude {
-			kept = append(kept, dir)
-		}
 	}
-	filteredPath := strings.Join(kept, string(filepath.ListSeparator))
+
 	env := os.Environ()
 	for i, kv := range env {
-		if strings.HasPrefix(kv, "PATH=") {
-			env[i] = "PATH=" + filteredPath
+		if strings.HasPrefix(kv, "HOME=") {
+			env[i] = "HOME=" + agentHome
 			return env
 		}
 	}
-	return append(env, "PATH="+filteredPath)
+	return append(env, "HOME="+agentHome)
 }
 
 func writeClaudeSettings(wtPath string) error {
@@ -2295,7 +2289,7 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 
 	resumeCmd := ad.ResumeCmd(prompt, sessionID, wtPath)
 	resumeCmd.Dir = wtPath
-	resumeCmd.Env = agentEnv()
+	resumeCmd.Env = agentEnv(wtPath)
 
 	logPath := filepath.Join(wtPath, "agent.log")
 	logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1299,7 +1299,106 @@ func TestAgentResume_nonHeadless_sigintPrintsHints(t *testing.T) {
 	}
 }
 
-// ─── streamLog ────────────────────────────────────────────────────────────────
+// ─── HOME isolation ───────────────────────────────────────────────────────────
+
+// TestLaunchAgent_homeIsolation verifies that a process spawned by launchAgent
+// sees HOME set to $wtPath/.agent-home and not the user's real home directory.
+func TestLaunchAgent_homeIsolation(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "env.txt")
+
+	// Stub script: record the HOME env variable and exit.
+	scriptPath := filepath.Join(dir, "envagent")
+	script := "#!/bin/sh\necho \"HOME=$HOME\" > \"" + envFile + "\"\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeLocalAdapter(t, dir, "envagent", "binary: "+scriptPath+"\nsession: --session\n")
+	chdirTemp(t, dir)
+
+	if err := launchAgent("envagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, &bytes.Buffer{}); err != nil {
+		t.Fatalf("launchAgent headless: %v", err)
+	}
+
+	// Poll until the stub writes the env file.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(envFile); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("reading env file: %v", err)
+	}
+	want := "HOME=" + filepath.Join(dir, ".agent-home")
+	if !strings.Contains(string(data), want) {
+		t.Errorf("expected HOME to be %q; got: %q", want, strings.TrimSpace(string(data)))
+	}
+}
+
+// TestAgentResume_homeIsolation verifies that a process spawned by agentResume
+// sees HOME set to $wtPath/.agent-home and not the user's real home directory.
+func TestAgentResume_homeIsolation(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "env.txt")
+
+	// Stub script: record the HOME env variable and exit.
+	scriptPath := filepath.Join(dir, "envagent")
+	script := "#!/bin/sh\necho \"HOME=$HOME\" > \"" + envFile + "\"\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeLocalAdapter(t, dir, "envagent", "binary: "+scriptPath+"\nsession: --session\n")
+	chdirTemp(t, dir)
+
+	if err := agentResume("envagent", dir, "42", "sess-abc", "feedback", true, false); err != nil {
+		t.Fatalf("agentResume headless: %v", err)
+	}
+
+	// Poll until the stub writes the env file.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(envFile); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("reading env file: %v", err)
+	}
+	want := "HOME=" + filepath.Join(dir, ".agent-home")
+	if !strings.Contains(string(data), want) {
+		t.Errorf("expected HOME to be %q; got: %q", want, strings.TrimSpace(string(data)))
+	}
+}
+
+// TestAgentEnv_rejectsSymlink verifies that agentEnv returns an error when
+// .agent-home already exists as a symlink (prevents HOME redirection attacks).
+func TestAgentEnv_rejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := t.TempDir()
+	agentHome := filepath.Join(dir, ".agent-home")
+	if err := os.Symlink(target, agentHome); err != nil {
+		t.Skipf("cannot create symlink (requires elevated privileges on Windows): %v", err)
+	}
+
+	_, err := agentEnv(dir)
+	if err == nil {
+		t.Fatal("expected error when .agent-home is a symlink")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error should mention symlink; got: %v", err)
+	}
+}
+
+
 
 func TestStreamLog_fileExists(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- Replace PATH-stripping with HOME isolation: each spawned agent gets `$worktree/.agent-home` as its HOME
- The fresh HOME means `~/.claude/` is empty — no existing sessions for the agent to attach to
- `.gitconfig` and `.ssh` are symlinked from the real HOME so git operations and SSH key auth keep working
- Both `launchAgent` and `agentResume` pass the worktree path to `agentEnv(wtPath)`

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/cmd/...` — only the three pre-existing macOS symlink failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)