### PR TITLE
fix: add --headless flag to OpenHands adapter recipe

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -187,8 +187,8 @@ Ready-to-use YAML files for agents not included as built-ins. Save any of these 
 
 ```yaml
 binary: openhands
-launch: openhands --always-approve --json -t {kickoff}
-resume_cmd: openhands --always-approve --json --resume --last -t {prompt}
+launch: openhands --headless --always-approve --json -t {kickoff}
+resume_cmd: openhands --headless --always-approve --json --resume --last -t {prompt}
 session_type: directory
 install: uv tool install openhands --python 3.12
 ```


### PR DESCRIPTION
## Summary

- `--json` requires `--headless` to suppress the TUI — without it OpenHands shows its settings dialog instead of running non-interactively
- Added `--headless` to both `launch` and `resume_cmd` in the OpenHands recipe in `docs/adapters.md`

## Test plan

- [ ] Copy the updated recipe to `~/.config/agentctl/adapters/openhands.yml` and run `agentctl start` — no TUI should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)