### PR TITLE
fix: symlink .openhands into agent home so OpenHands headless mode works

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2230,7 +2230,7 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	realHome, err := os.UserHomeDir()
 	if err == nil {
-		// Link config dirs so git, SSH, and OpenHands work with real credentials/settings.
+		// Link config files/dirs so git, SSH, and OpenHands work with real credentials/settings.
 		for _, name := range []string{".gitconfig", ".ssh", ".openhands"} {
 			src := filepath.Join(realHome, name)
 			dst := filepath.Join(agentHome, name)
@@ -2260,7 +2260,7 @@ func agentEnv(wtPath string) ([]string, error) {
 						fmt.Fprintf(os.Stderr, "agentctl: warning: copy %s: %v\n", name, copyErr)
 					}
 				} else {
-					fmt.Fprintf(os.Stderr, "agentctl: warning: symlink %s: %v (git/SSH may not work)\n", name, symlinkErr)
+					fmt.Fprintf(os.Stderr, "agentctl: warning: symlink %s: %v (agent config may not work)\n", name, symlinkErr)
 				}
 			}
 		}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2230,8 +2230,8 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	realHome, err := os.UserHomeDir()
 	if err == nil {
-		// Link .gitconfig and .ssh so git operations and SSH key auth work.
-		for _, name := range []string{".gitconfig", ".ssh"} {
+		// Link config dirs so git, SSH, and OpenHands work with real credentials/settings.
+		for _, name := range []string{".gitconfig", ".ssh", ".openhands"} {
 			src := filepath.Join(realHome, name)
 			dst := filepath.Join(agentHome, name)
 


### PR DESCRIPTION
## Summary

- OpenHands stores its settings in `~/.openhands/agent_settings.json`
- With HOME isolation active that directory is absent in `.agent-home`, causing `"Headless mode requires existing settings. Goodbye!"` on every run
- Added `.openhands` to the symlink list alongside `.gitconfig` and `.ssh` so the agent sees real settings while `~/.claude` stays isolated

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/cmd/...` — only the three pre-existing macOS symlink failures
- [ ] `agentctl start <issue> --agent openhands` runs without the "Headless mode requires existing settings" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)