### PR TITLE
fix: symlink .config into agent home so gh CLI credentials work

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2230,8 +2230,8 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	realHome, err := os.UserHomeDir()
 	if err == nil {
-		// Link config files/dirs so git, SSH, OpenHands, and gh CLI work with real credentials.
-		for _, name := range []string{".gitconfig", ".ssh", ".openhands", ".config"} {
+		// Link config files/dirs so git, SSH, and OpenHands work with real credentials/settings.
+		for _, name := range []string{".gitconfig", ".ssh", ".openhands"} {
 			src := filepath.Join(realHome, name)
 			dst := filepath.Join(agentHome, name)
 
@@ -2263,6 +2263,26 @@ func agentEnv(wtPath string) ([]string, error) {
 					fmt.Fprintf(os.Stderr, "agentctl: warning: symlink %s: %v (agent config may not work)\n", name, symlinkErr)
 				}
 			}
+		}
+
+		// Expose only ~/.config/gh (the gh CLI credential store) rather than
+		// the entire ~/.config tree, to limit the host config surface accessible
+		// from the agent's isolated HOME.
+		ghConfigSrc := filepath.Join(realHome, ".config", "gh")
+		if _, srcErr := os.Lstat(ghConfigSrc); srcErr == nil {
+			agentConfigDir := filepath.Join(agentHome, ".config")
+			if mkdirErr := os.MkdirAll(agentConfigDir, 0o755); mkdirErr != nil {
+				fmt.Fprintf(os.Stderr, "agentctl: warning: mkdir %s: %v\n", agentConfigDir, mkdirErr)
+			} else {
+				ghConfigDst := filepath.Join(agentConfigDir, "gh")
+				if _, statErr := os.Lstat(ghConfigDst); os.IsNotExist(statErr) {
+					if symlinkErr := os.Symlink(ghConfigSrc, ghConfigDst); symlinkErr != nil {
+						fmt.Fprintf(os.Stderr, "agentctl: warning: symlink .config/gh: %v (gh credentials may not work)\n", symlinkErr)
+					}
+				}
+			}
+		} else if !os.IsNotExist(srcErr) {
+			fmt.Fprintf(os.Stderr, "agentctl: warning: stat %s: %v\n", ghConfigSrc, srcErr)
 		}
 	}
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2230,8 +2230,8 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	realHome, err := os.UserHomeDir()
 	if err == nil {
-		// Link config files/dirs so git, SSH, and OpenHands work with real credentials/settings.
-		for _, name := range []string{".gitconfig", ".ssh", ".openhands"} {
+		// Link config files/dirs so git, SSH, OpenHands, and gh CLI work with real credentials.
+		for _, name := range []string{".gitconfig", ".ssh", ".openhands", ".config"} {
 			src := filepath.Join(realHome, name)
 			dst := filepath.Join(agentHome, name)
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1398,7 +1398,58 @@ func TestAgentEnv_rejectsSymlink(t *testing.T) {
 	}
 }
 
+// TestAgentEnv_ghConfigSymlink verifies that agentEnv creates a real directory
+// at .agent-home/.config and a symlink .agent-home/.config/gh → <HOME>/.config/gh,
+// rather than symlinking the entire ~/.config tree.
+func TestAgentEnv_ghConfigSymlink(t *testing.T) {
+	// Build a fake HOME containing .config/gh
+	fakeHome := t.TempDir()
+	ghConfigSrc := filepath.Join(fakeHome, ".config", "gh")
+	if err := os.MkdirAll(ghConfigSrc, 0o755); err != nil {
+		t.Fatalf("setup fake HOME: %v", err)
+	}
 
+	// Point HOME at our fake directory so os.UserHomeDir picks it up.
+	t.Setenv("HOME", fakeHome)
+
+	dir := t.TempDir()
+	if _, err := agentEnv(dir); err != nil {
+		t.Fatalf("agentEnv: %v", err)
+	}
+
+	agentHome := filepath.Join(dir, ".agent-home")
+
+	// .agent-home/.config must be a real directory, not a symlink to the whole
+	// ~/.config tree (that would expose unrelated host application configs).
+	configDst := filepath.Join(agentHome, ".config")
+	fi, err := os.Lstat(configDst)
+	if err != nil {
+		t.Skipf("symlinks not supported on this platform: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Error(".agent-home/.config must be a real directory, not a symlink to the entire ~/.config")
+	}
+	if !fi.IsDir() {
+		t.Errorf(".agent-home/.config must be a directory; got mode %v", fi.Mode())
+	}
+
+	// .agent-home/.config/gh must be a symlink pointing to the real ~/.config/gh.
+	ghConfigDst := filepath.Join(agentHome, ".config", "gh")
+	ghFi, err := os.Lstat(ghConfigDst)
+	if err != nil {
+		t.Fatalf(".agent-home/.config/gh missing: %v", err)
+	}
+	if ghFi.Mode()&os.ModeSymlink == 0 {
+		t.Error(".agent-home/.config/gh must be a symlink")
+	}
+	target, err := os.Readlink(ghConfigDst)
+	if err != nil {
+		t.Fatalf("readlink .agent-home/.config/gh: %v", err)
+	}
+	if target != ghConfigSrc {
+		t.Errorf(".agent-home/.config/gh symlink target = %q; want %q", target, ghConfigSrc)
+	}
+}
 
 func TestStreamLog_fileExists(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- HTTPS `git push` requires `~/.config/gh/` for the GitHub CLI credential helper
- Without it the agent's isolated HOME has no token and `git push` fails with an auth error
- Symlinking `.config` alongside `.gitconfig`, `.ssh`, and `.openhands` gives the agent access to real gh credentials

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/cmd/...` — only the three pre-existing macOS symlink failures
- [ ] `agentctl start <issue> --agent openhands` completes and successfully pushes a branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)