### PR TITLE
fix: inject GITHUB_TOKEN from gh auth token into agent environment

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2267,6 +2267,25 @@ func agentEnv(wtPath string) ([]string, error) {
 	}
 
 	env := os.Environ()
+
+	// If GITHUB_TOKEN is absent, pull it from `gh auth token` so the agent
+	// can push to GitHub without needing keychain access (the agent process
+	// runs detached and cannot unlock the macOS keychain).
+	hasGHToken := false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GITHUB_TOKEN=") {
+			hasGHToken = true
+			break
+		}
+	}
+	if !hasGHToken {
+		if out, err := exec.Command("gh", "auth", "token").Output(); err == nil {
+			if token := strings.TrimSpace(string(out)); token != "" {
+				env = append(env, "GITHUB_TOKEN="+token)
+			}
+		}
+	}
+
 	for i, kv := range env {
 		if strings.HasPrefix(kv, "HOME=") {
 			env[i] = "HOME=" + agentHome

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2268,20 +2268,28 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	env := os.Environ()
 
-	// If GITHUB_TOKEN is absent, pull it from `gh auth token` so the agent
-	// can push to GitHub without needing keychain access (the agent process
-	// runs detached and cannot unlock the macOS keychain).
+	// If GITHUB_TOKEN is absent or empty, pull it from `gh auth token` so
+	// the agent can push to GitHub without needing keychain access (the agent
+	// process runs detached and cannot unlock the macOS keychain).
 	hasGHToken := false
-	for _, kv := range env {
+	ghTokenIdx := -1
+	for i, kv := range env {
 		if strings.HasPrefix(kv, "GITHUB_TOKEN=") {
-			hasGHToken = true
+			ghTokenIdx = i
+			if strings.TrimPrefix(kv, "GITHUB_TOKEN=") != "" {
+				hasGHToken = true
+			}
 			break
 		}
 	}
 	if !hasGHToken {
 		if out, err := exec.Command("gh", "auth", "token").Output(); err == nil {
 			if token := strings.TrimSpace(string(out)); token != "" {
-				env = append(env, "GITHUB_TOKEN="+token)
+				if ghTokenIdx >= 0 {
+					env[ghTokenIdx] = "GITHUB_TOKEN=" + token
+				} else {
+					env = append(env, "GITHUB_TOKEN="+token)
+				}
 			}
 		}
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1400,6 +1400,92 @@ func TestAgentEnv_rejectsSymlink(t *testing.T) {
 
 
 
+// fakeGHBin writes a small shell script to dir/gh that outputs token when
+// called as "gh auth token", and updates PATH so exec.Command("gh", …) finds it.
+func fakeGHBin(t *testing.T, token string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"token\" ]; then\n  echo " + token + "\n  exit 0\nfi\nexit 1\n"
+	bin := filepath.Join(dir, "gh")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("fakeGHBin: write script: %v", err)
+	}
+	orig := os.Getenv("PATH")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+orig)
+}
+
+// TestAgentEnv_injectsTokenWhenAbsent verifies that GITHUB_TOKEN is added to
+// the environment when it is not already present.
+func TestAgentEnv_injectsTokenWhenAbsent(t *testing.T) {
+	fakeGHBin(t, "test-token-injected")
+	// Truly unset GITHUB_TOKEN (not just set to empty) so it is absent.
+	orig, had := os.LookupEnv("GITHUB_TOKEN")
+	os.Unsetenv("GITHUB_TOKEN")
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("GITHUB_TOKEN", orig)
+		} else {
+			os.Unsetenv("GITHUB_TOKEN")
+		}
+	})
+
+	dir := t.TempDir()
+	env, err := agentEnv(dir)
+	if err != nil {
+		t.Fatalf("agentEnv: %v", err)
+	}
+	for _, kv := range env {
+		if kv == "GITHUB_TOKEN=test-token-injected" {
+			return // found — pass
+		}
+	}
+	t.Error("GITHUB_TOKEN=test-token-injected not found in env")
+}
+
+// TestAgentEnv_preservesExistingToken verifies that a non-empty GITHUB_TOKEN
+// already present in the environment is left unchanged.
+func TestAgentEnv_preservesExistingToken(t *testing.T) {
+	fakeGHBin(t, "should-not-be-used")
+	t.Setenv("GITHUB_TOKEN", "existing-token")
+
+	dir := t.TempDir()
+	env, err := agentEnv(dir)
+	if err != nil {
+		t.Fatalf("agentEnv: %v", err)
+	}
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GITHUB_TOKEN=") {
+			if kv != "GITHUB_TOKEN=existing-token" {
+				t.Errorf("GITHUB_TOKEN was overwritten; got %q", kv)
+			}
+			return
+		}
+	}
+	t.Error("GITHUB_TOKEN not found in env at all")
+}
+
+// TestAgentEnv_replacesEmptyToken verifies that an empty GITHUB_TOKEN is
+// treated as absent and replaced with the token from `gh auth token`.
+func TestAgentEnv_replacesEmptyToken(t *testing.T) {
+	fakeGHBin(t, "replacement-token")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	dir := t.TempDir()
+	env, err := agentEnv(dir)
+	if err != nil {
+		t.Fatalf("agentEnv: %v", err)
+	}
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GITHUB_TOKEN=") {
+			if kv != "GITHUB_TOKEN=replacement-token" {
+				t.Errorf("expected GITHUB_TOKEN=replacement-token, got %q", kv)
+			}
+			return
+		}
+	}
+	t.Error("GITHUB_TOKEN not found in env at all")
+}
+
 func TestStreamLog_fileExists(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "agent.log")


### PR DESCRIPTION
## Summary

- Agent processes run detached (new session via `Setsid: true`) and cannot access the macOS keychain
- `gh auth status` reports the token as invalid in the agent even though credentials exist locally
- If `GITHUB_TOKEN` is not already set in the environment, `agentEnv` now calls `gh auth token` and injects the result so `git push` succeeds without keychain access
- If `gh` is not installed or auth fails, the injection is silently skipped — no error

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/cmd/...` — only the three pre-existing macOS symlink failures
- [ ] `agentctl start <issue> --agent openhands` — agent successfully pushes branch and opens PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)