### PR TITLE
feat: print agentctl resume hint when agent exits

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -95,6 +95,10 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 	return c
 }
 
+// resumeHintFmt is printed after a foreground agent exits so users know how
+// to send follow-up feedback. %s is replaced with the issue number.
+const resumeHintFmt = "agentctl resume %s [feedback]   # no feedback approves; add feedback to request changes\n"
+
 // kickoffTemplate is the default prompt sent to the agent when no --sdd
 // methodology is specified. {issue} and {port} are substituted at call time.
 const kickoffTemplate = `Work on GitHub issue #{issue}. Read AGENTS.md or README.md for project conventions if present.
@@ -1706,7 +1710,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
 				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
-			fmt.Fprintf(out, "agentctl resume %s [feedback]   # no feedback approves; add feedback to request changes\n", issue)
+			fmt.Fprintf(out, resumeHintFmt, issue)
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)
@@ -2639,7 +2643,7 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
 				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
-			fmt.Fprintf(os.Stdout, "agentctl resume %s [feedback]   # send follow-up feedback; omit [feedback] to use the default proceed approval\n", issue)
+			fmt.Fprintf(os.Stdout, resumeHintFmt, issue)
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1706,7 +1706,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
 				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
-			fmt.Fprintf(out, "agentctl resume %s   # send a follow-up prompt\n", issue)
+			fmt.Fprintf(out, "agentctl resume %s [feedback]   # no feedback approves; add feedback to request changes\n", issue)
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)
@@ -2639,7 +2639,7 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
 				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
-			fmt.Fprintf(os.Stdout, "agentctl resume %s   # send a follow-up prompt\n", issue)
+			fmt.Fprintf(os.Stdout, "agentctl resume %s [feedback]   # send follow-up feedback; omit [feedback] to use the default proceed approval\n", issue)
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1706,6 +1706,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
 				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
+			fmt.Fprintf(out, "agentctl resume %s   # send a follow-up prompt\n", issue)
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)
@@ -2638,6 +2639,7 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
 				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
+			fmt.Fprintf(os.Stdout, "agentctl resume %s   # send a follow-up prompt\n", issue)
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -949,6 +949,50 @@ func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 	}
 }
 
+func TestLaunchAgent_nonHeadless_exitPrintsResumeHint(t *testing.T) {
+	dir := t.TempDir()
+	writeLocalAdapter(t, dir, "echoagent",
+		"binary: echo\nsession: --session\n")
+	chdirTemp(t, dir)
+
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, &out)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("launchAgent non-headless: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		if p, err := os.FindProcess(os.Getpid()); err == nil {
+			_ = p.Signal(os.Interrupt)
+		}
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("launchAgent did not return after agent process exited: %v", err)
+			}
+			t.Fatal("launchAgent did not return after agent process exited")
+		case <-time.After(2 * time.Second):
+			t.Fatal("launchAgent hung even after interrupt")
+		}
+	}
+
+	outStr := out.String()
+	want := "agentctl resume 42 [feedback]   # no feedback approves; add feedback to request changes"
+	if !strings.Contains(outStr, want) {
+		t.Errorf("missing resume hint %q in foreground-exit output:\n%s", want, outStr)
+	}
+	for _, unwanted := range []string{"agentctl logs", "agentctl attach", "agentctl discard"} {
+		if strings.Contains(outStr, unwanted) {
+			t.Errorf("foreground-exit output must not contain %q:\n%s", unwanted, outStr)
+		}
+	}
+}
+
 // TestLaunchAgent_claudeNonHeadlessInjectsStreamJsonAndVerbose verifies that
 // launchAgent appends --output-format, stream-json, and --verbose to the
 // command line when adapterName is "claude" and headless is false.
@@ -1318,6 +1362,66 @@ func TestAgentResume_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 			t.Fatal("agentResume did not return after agent process exited — required interrupt-driven cleanup before failing")
 		case <-time.After(2 * time.Second):
 			t.Fatal("agentResume hung even after interrupt")
+		}
+	}
+}
+
+func TestAgentResume_nonHeadless_exitPrintsResumeHint(t *testing.T) {
+	dir := t.TempDir()
+	writeLocalAdapter(t, dir, "echoagent",
+		"binary: echo\nsession: --session\n")
+	chdirTemp(t, dir)
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- agentResume("echoagent", dir, "42", "sess-123", "my feedback", false, false)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("agentResume non-headless: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		if p, err := os.FindProcess(os.Getpid()); err == nil {
+			_ = p.Signal(os.Interrupt)
+		}
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("agentResume did not return after agent exit: %v", err)
+			}
+			t.Fatal("agentResume did not return after agent process exited")
+		case <-time.After(2 * time.Second):
+			t.Fatal("agentResume hung even after interrupt")
+		}
+	}
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("reading captured stdout: %v", err)
+	}
+	r.Close()
+
+	out := buf.String()
+	want := "agentctl resume 42 [feedback]   # send follow-up feedback; omit [feedback] to use the default proceed approval"
+	if !strings.Contains(out, want) {
+		t.Errorf("missing resume hint %q in foreground-exit output:\n%s", want, out)
+	}
+	for _, unwanted := range []string{"agentctl logs", "agentctl attach", "agentctl discard"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("foreground-exit output must not contain %q:\n%s", unwanted, out)
 		}
 	}
 }

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -982,7 +982,7 @@ func TestLaunchAgent_nonHeadless_exitPrintsResumeHint(t *testing.T) {
 	}
 
 	outStr := out.String()
-	want := "agentctl resume 42 [feedback]   # no feedback approves; add feedback to request changes"
+	want := fmt.Sprintf(resumeHintFmt, "42")
 	if !strings.Contains(outStr, want) {
 		t.Errorf("missing resume hint %q in foreground-exit output:\n%s", want, outStr)
 	}
@@ -1415,7 +1415,7 @@ func TestAgentResume_nonHeadless_exitPrintsResumeHint(t *testing.T) {
 	r.Close()
 
 	out := buf.String()
-	want := "agentctl resume 42 [feedback]   # send follow-up feedback; omit [feedback] to use the default proceed approval"
+	want := fmt.Sprintf(resumeHintFmt, "42")
 	if !strings.Contains(out, want) {
 		t.Errorf("missing resume hint %q in foreground-exit output:\n%s", want, out)
 	}


### PR DESCRIPTION
## Summary

- After an agent finishes in foreground mode, the terminal now shows:
  ```
  agentctl resume <issue>   # send a follow-up prompt
  ```
- Added to both `launchAgent` and `agentResume` exit paths so the hint appears whether it's the first run or a resumed run

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/cmd/...` — only the three pre-existing macOS symlink failures
- [ ] `agentctl start <issue> --agent openhands` — hint appears after agent exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)