### PR TITLE
fix: symlink .codex into agent home so codex CLI credentials work

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,7 @@ Run `agentctl --help` or `agentctl <command> --help` for generated help from the
 ### `agentctl start`
 
 ```bash
-agentctl start [--agent <name>] [--headless] [--quiet] <issue-number-or-url> [slug] [--sdd=<name>]
+agentctl start [--agent <name>] [--headless] [--notify] [--quiet] <issue-number-or-url> [slug] [--sdd=<name>]
 ```
 
 Creates a linked worktree for a GitHub issue and launches the selected coding agent inside it.
@@ -36,8 +36,8 @@ Side effects:
 ### `agentctl resume`
 
 ```bash
-agentctl resume [--headless] [--quiet] <issue-number>
-agentctl resume [--headless] [--quiet] <issue-number> [feedback]
+agentctl resume [--headless] [--notify] [--quiet] <issue-number>
+agentctl resume [--headless] [--notify] [--quiet] <issue-number> [feedback]
 ```
 
 Resumes a paused agent after the spec-review checkpoint.
@@ -324,8 +324,9 @@ Place `.agentctl.yml` in the root of your application repository to set per-repo
 # reserved port. If omitted, no dev server is started and a warning is printed.
 dev_server: "uvicorn main:app --port {port}"
 
-# Port to reserve for the dev server. If omitted, agentctl picks a free port
-# in the 3010–3100 range. Written back by agentctl after allocation.
+# Port last allocated by agentctl for the dev server. This field is written
+# back by agentctl after it picks a free port in the 3010–3100 range.
+# It is managed by agentctl and should not be set manually.
 port: 3010
 
 # Send a native desktop notification when a headless agent finishes.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2282,8 +2282,8 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	realHome, err := os.UserHomeDir()
 	if err == nil {
-		// Link config files/dirs so git, SSH, and OpenHands work with real credentials/settings.
-		for _, name := range []string{".gitconfig", ".ssh", ".openhands"} {
+		// Link config files/dirs so git, SSH, OpenHands, and Codex work with real credentials/settings.
+		for _, name := range []string{".gitconfig", ".ssh", ".openhands", ".codex"} {
 			src := filepath.Join(realHome, name)
 			dst := filepath.Join(agentHome, name)
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1718,6 +1718,45 @@ func TestAgentEnv_ghConfigSymlink(t *testing.T) {
 	}
 }
 
+// TestAgentEnv_codexSymlink verifies that agentEnv creates a symlink
+// .agent-home/.codex → <HOME>/.codex when ~/.codex exists, giving the codex
+// CLI access to its credentials under HOME isolation.
+func TestAgentEnv_codexSymlink(t *testing.T) {
+	// Build a fake HOME containing .codex
+	fakeHome := t.TempDir()
+	codexSrc := filepath.Join(fakeHome, ".codex")
+	if err := os.MkdirAll(codexSrc, 0o755); err != nil {
+		t.Fatalf("setup fake HOME: %v", err)
+	}
+
+	// Point HOME at our fake directory so os.UserHomeDir picks it up.
+	t.Setenv("HOME", fakeHome)
+
+	dir := t.TempDir()
+	if _, err := agentEnv(dir); err != nil {
+		t.Fatalf("agentEnv: %v", err)
+	}
+
+	agentHome := filepath.Join(dir, ".agent-home")
+
+	// .agent-home/.codex must be a symlink pointing to the real ~/.codex.
+	codexDst := filepath.Join(agentHome, ".codex")
+	fi, err := os.Lstat(codexDst)
+	if err != nil {
+		t.Skipf("symlinks not supported on this platform: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Error(".agent-home/.codex must be a symlink")
+	}
+	target, err := os.Readlink(codexDst)
+	if err != nil {
+		t.Fatalf("readlink .agent-home/.codex: %v", err)
+	}
+	if target != codexSrc {
+		t.Errorf(".agent-home/.codex symlink target = %q; want %q", target, codexSrc)
+	}
+}
+
 // fakeGHBin writes a small shell script to dir/gh that outputs token when
 // called as "gh auth token", and updates PATH so exec.Command("gh", …) finds it.
 func fakeGHBin(t *testing.T, token string) {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1000,7 +1000,7 @@ func TestLaunchAgent_nonHeadless_exitPrintsResumeHint(t *testing.T) {
 	var out bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, &out)
+		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
 	}()
 
 	select {
@@ -1461,7 +1461,7 @@ func TestAgentResume_nonHeadless_exitPrintsResumeHint(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- agentResume("echoagent", dir, "42", "sess-123", "my feedback", false, false)
+		done <- agentResume("echoagent", dir, "42", "sess-123", "my feedback", false, false, false)
 	}()
 
 	select {


### PR DESCRIPTION
## Summary

- Codex stores its auth token in `~/.codex/auth.json`
- With HOME isolation active the directory is absent, so codex exits immediately with status 1 and writes nothing to `agent.log`
- Symlinking `.codex` alongside `.openhands` gives the agent access to real credentials

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/cmd/...` — only the three pre-existing macOS symlink failures
- [ ] `agentctl start <issue> --agent codex` runs without immediate exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)