### PR TITLE
fix: non-claude output streaming, cleanup hint, silent dev-server skip

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,7 +29,7 @@ Side effects:
 - Reserves a dev-server port in the `3010-3100` range.
 - Writes `.agent` metadata in the worktree.
 - Seeds `.env.local` from the primary worktree when present, stripping any existing `PORT=` lines (does not inject `PORT=<port>` itself).
-- Starts the dev server: if `.agentctl.yml` defines a `dev_server` command it is used (with `{port}` substituted); otherwise a warning is printed and the step is skipped. Any project that needs a dev server must set `dev_server` explicitly in `.agentctl.yml`.
+- Starts the dev server: if `.agentctl.yml` defines a `dev_server` command it is used (with `{port}` substituted); otherwise the step is silently skipped. Any project that needs a dev server must set `dev_server` explicitly in `.agentctl.yml`.
 - Launches the selected adapter.
 - When the agent exits, appends `Closes #<issue>` to the PR body retrieved via `gh pr view <branch>`, unless the body already contains `closes #<issue>` or `fixes #<issue>` (case-insensitive). Other closing keywords such as `resolves #<issue>` do not suppress the append.
 
@@ -321,7 +321,7 @@ Place `.agentctl.yml` in the root of your application repository to set per-repo
 
 ```yaml
 # Shell command to start the dev server. {port} is substituted with the
-# reserved port. If omitted, no dev server is started and a warning is printed.
+# reserved port. If omitted, no dev server is started (silently skipped).
 dev_server: "uvicorn main:app --port {port}"
 
 # Port agentctl allocated for the dev server (3010–3100 range). This value is

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1651,6 +1651,13 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 				convertOpenHandsStream(pr, logFile)
 				return
 			}
+			if adapterName != "claude" {
+				// Non-Claude adapters emit plain text; copy it directly to the log.
+				if _, err := io.Copy(logFile, pr); err != nil && !errors.Is(err, io.ErrClosedPipe) {
+					fmt.Fprintf(logFile, "converter read error: %v\n", err)
+				}
+				return
+			}
 			r := bufio.NewReader(pr)
 			for {
 				line, err := r.ReadString('\n')
@@ -1742,7 +1749,11 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
 				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
-			fmt.Fprintf(out, resumeHintFmt, issue)
+			if sddName != "" {
+				fmt.Fprintf(out, resumeHintFmt, issue)
+			} else {
+				fmt.Fprintf(out, "agentctl cleanup %s   # after PR is merged\n", issue)
+			}
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)
@@ -2702,7 +2713,7 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
 				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
-			fmt.Fprintf(os.Stdout, resumeHintFmt, issue)
+			fmt.Fprintf(os.Stdout, "agentctl cleanup %s   # after PR is merged\n", issue)
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1410,8 +1410,6 @@ func startDevServer(dir string, out io.Writer) (devPID, portStr string, err erro
 		return startCustomDevServer(dir, cfg, out)
 	}
 
-	// No dev server configured — warn and skip
-	fmt.Fprintf(out, "warning: no dev_server configured in .agentctl.yml, skipping dev server startup\n")
 	return "", "", nil
 }
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1395,7 +1395,7 @@ func seedEnvLocal(src, dst string) error {
 
 // startDevServer starts a dev server for the project in dir. Detection order:
 //  1. .agentctl.yml with dev_server field  → run that command with {port} substituted
-//  2. otherwise                            → print a warning and skip, return ("","",nil)
+//  2. otherwise                            → silently skip, return ("","",nil)
 //
 // On success the allocated port is written back to .agentctl.yml so it serves
 // as the single source of truth for all agentctl repo config.
@@ -2557,6 +2557,13 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 
 			if adapterName == "openhands" {
 				convertOpenHandsStream(pr, logFile)
+				return
+			}
+			if adapterName != "claude" {
+				// Non-Claude adapters emit plain text; copy it directly to the log.
+				if _, err := io.Copy(logFile, pr); err != nil && !errors.Is(err, io.ErrClosedPipe) {
+					fmt.Fprintf(logFile, "converter read error: %v\n", err)
+				}
 				return
 			}
 			r := bufio.NewReader(pr)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1706,15 +1706,11 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 
 	if headless {
 		fmt.Fprintf(out, "Agent PID %d — log: %s\n", pid, logPath)
+		fmt.Fprintf(out, "agentctl logs %s      # follow log\n", issue)
+		fmt.Fprintf(out, "agentctl attach %s    # stream live and wait\n", issue)
+		fmt.Fprintf(out, "agentctl discard %s   # abandon\n", issue)
 		if sddName != "" {
-			fmt.Fprintf(out, "Session ID: %s\n", sessionID)
-			fmt.Fprintf(out, "Use \"agentctl resume %s [feedback]\" to continue the session.\n", issue)
-			fmt.Fprintln(out, "Without feedback, it sends approval (\"proceed\") and the agent begins implementation.")
-			fmt.Fprintln(out, "With feedback, it sends the revision text and the agent rewrites the spec.")
-		} else {
-			fmt.Fprintf(out, "agentctl logs %s      # follow log\n", issue)
-			fmt.Fprintf(out, "agentctl attach %s    # stream live and wait\n", issue)
-			fmt.Fprintf(out, "agentctl discard %s   # abandon\n", issue)
+			fmt.Fprintf(out, "agentctl resume %s [feedback]   # approve spec or send revisions\n", issue)
 		}
 		if sendNotify {
 			go func() {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -896,14 +896,16 @@ func TestLaunchAgent_headless_withSDD_showsResumeHint(t *testing.T) {
 	}
 
 	outStr := out.String()
-	for _, want := range []string{"Session ID: sess-abc", "agentctl resume 42", "sends approval"} {
+	// SDD headless: must show logs/attach/discard so user can follow progress,
+	// plus the resume hint for the spec-review checkpoint.
+	for _, want := range []string{
+		"agentctl logs 42",
+		"agentctl attach 42",
+		"agentctl discard 42",
+		"agentctl resume 42",
+	} {
 		if !strings.Contains(outStr, want) {
 			t.Errorf("SDD headless output missing %q:\n%s", want, outStr)
-		}
-	}
-	for _, unwanted := range []string{"agentctl logs", "agentctl attach", "agentctl discard"} {
-		if strings.Contains(outStr, unwanted) {
-			t.Errorf("SDD headless output must not contain %q:\n%s", unwanted, outStr)
 		}
 	}
 }

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1024,14 +1024,49 @@ func TestLaunchAgent_nonHeadless_exitPrintsResumeHint(t *testing.T) {
 	}
 
 	outStr := out.String()
-	want := fmt.Sprintf(resumeHintFmt, "42")
+	// Non-SDD run: expect cleanup hint, not resume hint.
+	want := "agentctl cleanup 42"
 	if !strings.Contains(outStr, want) {
-		t.Errorf("missing resume hint %q in foreground-exit output:\n%s", want, outStr)
+		t.Errorf("missing cleanup hint %q in foreground-exit output:\n%s", want, outStr)
 	}
-	for _, unwanted := range []string{"agentctl logs", "agentctl attach", "agentctl discard"} {
+	for _, unwanted := range []string{"agentctl logs", "agentctl attach", "agentctl discard", resumeHintFmt[:20]} {
 		if strings.Contains(outStr, unwanted) {
 			t.Errorf("foreground-exit output must not contain %q:\n%s", unwanted, outStr)
 		}
+	}
+}
+
+// TestLaunchAgent_nonClaudeNonHeadless_outputStreamed verifies that plain-text
+// output from non-claude adapters is written to agent.log in non-headless mode.
+func TestLaunchAgent_nonClaudeNonHeadless_outputStreamed(t *testing.T) {
+	dir := t.TempDir()
+	// Use echo with an explicit launch command that emits a known plain-text
+	// line — simulates codex/copilot output (no JSON events).
+	writeLocalAdapter(t, dir, "echoagent2",
+		"binary: echo\nlaunch: echo hello from codex\n")
+	chdirTemp(t, dir)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- launchAgent("echoagent2", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("launchAgent: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("launchAgent did not return")
+	}
+
+	logPath := filepath.Join(dir, "agent.log")
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read agent.log: %v", err)
+	}
+	if !strings.Contains(string(content), "hello from codex") {
+		t.Errorf("agent.log missing plain-text output; got:\n%s", content)
 	}
 }
 
@@ -1494,9 +1529,10 @@ func TestAgentResume_nonHeadless_exitPrintsResumeHint(t *testing.T) {
 	r.Close()
 
 	out := buf.String()
-	want := fmt.Sprintf(resumeHintFmt, "42")
+	// After resume exit, the agent is done — expect cleanup hint, not resume hint.
+	want := "agentctl cleanup 42"
 	if !strings.Contains(out, want) {
-		t.Errorf("missing resume hint %q in foreground-exit output:\n%s", want, out)
+		t.Errorf("missing cleanup hint %q in foreground-exit output:\n%s", want, out)
 	}
 	for _, unwanted := range []string{"agentctl logs", "agentctl attach", "agentctl discard"} {
 		if strings.Contains(out, unwanted) {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1002,7 +1002,7 @@ func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 	}
 }
 
-func TestLaunchAgent_nonHeadless_exitPrintsResumeHint(t *testing.T) {
+func TestLaunchAgent_nonHeadless_exitPrintsCleanupHint(t *testing.T) {
 	dir := t.TempDir()
 	writeLocalAdapter(t, dir, "echoagent",
 		"binary: echo\nsession: --session\n")
@@ -1040,7 +1040,7 @@ func TestLaunchAgent_nonHeadless_exitPrintsResumeHint(t *testing.T) {
 	if !strings.Contains(outStr, want) {
 		t.Errorf("missing cleanup hint %q in foreground-exit output:\n%s", want, outStr)
 	}
-	for _, unwanted := range []string{"agentctl logs", "agentctl attach", "agentctl discard", resumeHintFmt[:20]} {
+	for _, unwanted := range []string{"agentctl logs", "agentctl attach", "agentctl discard", "agentctl resume"} {
 		if strings.Contains(outStr, unwanted) {
 			t.Errorf("foreground-exit output must not contain %q:\n%s", unwanted, outStr)
 		}
@@ -1491,7 +1491,7 @@ func TestAgentResume_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 	}
 }
 
-func TestAgentResume_nonHeadless_exitPrintsResumeHint(t *testing.T) {
+func TestAgentResume_nonHeadless_exitPrintsCleanupHint(t *testing.T) {
 	dir := t.TempDir()
 	writeLocalAdapter(t, dir, "echoagent",
 		"binary: echo\nsession: --session\n")
@@ -2527,7 +2527,6 @@ func TestStartDevServer_noPackageJSON_returnsEmptyPort(t *testing.T) {
 	if port != "" {
 		t.Errorf("expected empty port when no dev server started, got %q", port)
 	}
-	// No dev_server configured — silently skipped, no output expected.
 	if buf.String() != "" {
 		t.Errorf("expected no output when dev_server is not configured, got %q", buf.String())
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -544,7 +544,10 @@ func TestLocateOrCloneRepo_cwdMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got != dir {
+	// Resolve symlinks: on macOS t.TempDir() is under /var which symlinks to /private/var.
+	wantResolved, _ := filepath.EvalSymlinks(dir)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != wantResolved {
 		t.Errorf("got %q, want %q", got, dir)
 	}
 }
@@ -630,7 +633,10 @@ func TestRepoRootForIssue_bareNumber(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if root != dir {
+	// Resolve symlinks: on macOS t.TempDir() is under /var which symlinks to /private/var.
+	wantResolved, _ := filepath.EvalSymlinks(dir)
+	gotResolved, _ := filepath.EvalSymlinks(root)
+	if gotResolved != wantResolved {
 		t.Errorf("root = %q, want %q", root, dir)
 	}
 	if issueNum != "42" {
@@ -650,7 +656,10 @@ func TestRepoRootForIssue_urlCwdMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if root != dir {
+	// Resolve symlinks: on macOS t.TempDir() is under /var which symlinks to /private/var.
+	wantResolved, _ := filepath.EvalSymlinks(dir)
+	gotResolved, _ := filepath.EvalSymlinks(root)
+	if gotResolved != wantResolved {
 		t.Errorf("root = %q, want %q", root, dir)
 	}
 	if issueNum != "99" {
@@ -2518,8 +2527,9 @@ func TestStartDevServer_noPackageJSON_returnsEmptyPort(t *testing.T) {
 	if port != "" {
 		t.Errorf("expected empty port when no dev server started, got %q", port)
 	}
-	if !strings.Contains(buf.String(), "warning") {
-		t.Errorf("expected a warning message when dev_server is not configured, got %q", buf.String())
+	// No dev_server configured — silently skipped, no output expected.
+	if buf.String() != "" {
+		t.Errorf("expected no output when dev_server is not configured, got %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Codex/copilot output now shown**: non-claude adapters emit plain text, not Claude's stream-json events. The foreground converter was silently dropping everything. Now `io.Copy` is used for plain-text adapters so output reaches `agent.log` and the terminal.
- **Cleanup hint instead of resume hint**: after a non-SDD foreground run, `agentctl resume <issue> [feedback]` was printed even though the agent already opened a PR. Changed to `agentctl cleanup <issue> # after PR is merged`. Same fix for `agentctl resume` exits. The resume hint is retained for SDD flows where the spec-pause checkpoint may follow.
- **Silent dev-server skip**: removed the `warning: no dev_server configured` message — projects that don't need a dev server (CLI tools, libraries) were getting spurious noise. Now silently skipped. Docs updated.

## Test plan
- [ ] `agentctl start <issue> --agent codex` — codex output streams to terminal
- [ ] `agentctl start <issue>` (non-SDD) — `agentctl cleanup <issue>` shown after PR opens, not `agentctl resume`
- [ ] `agentctl start <issue>` in repo without `dev_server` in `.agentctl.yml` — no warning printed
- [ ] `agentctl start <issue> --sdd=plain` — `agentctl resume <issue>` hint still shown after spec phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)