### PR TITLE
fix: symlink .claude into agent home so Claude Code credentials work

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2288,7 +2288,7 @@ func agentEnv(wtPath string) ([]string, error) {
 	realHome, err := os.UserHomeDir()
 	if err == nil {
 		// Link config files/dirs so git, SSH, OpenHands, and Codex work with real credentials/settings.
-		for _, name := range []string{".gitconfig", ".ssh", ".openhands", ".codex"} {
+		for _, name := range []string{".gitconfig", ".ssh", ".claude", ".openhands", ".codex"} {
 			src := filepath.Join(realHome, name)
 			dst := filepath.Join(agentHome, name)
 


### PR DESCRIPTION
## Summary
- `.claude` was missing from the agent home symlink list — Claude Code looks for auth in `~/.claude/` which under HOME isolation resolves to `$worktree/.agent-home/.claude/`, an empty directory
- Adds `.claude` to the list alongside `.gitconfig`, `.ssh`, `.openhands`, `.codex`
- `writeClaudeSettings` writes to `$worktree/.claude/settings.json` (the worktree, not the agent home) so there is no conflict

## Test plan
- [ ] `agentctl start <issue> --headless --sdd=speckit` — no "Not logged in" error; agent runs and writes spec
- [ ] `agentctl logs <issue>` — shows agent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)