### PR TITLE
fix: exit early when --sdd=speckit but speckit skills are not installed

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -152,6 +152,11 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 		}
 	}
 
+	// Validate methodology-specific prerequisites before any side effects.
+	if err := validateSDD(sddName, repoRoot); err != nil {
+		return err
+	}
+
 	// Derive slug from GitHub issue title if not supplied.
 	if slug == "" {
 		slug, err = slugFromIssue(ghIssueArg)
@@ -1493,6 +1498,26 @@ func resolveIssueArg(flag string, args []string) (string, error) {
 func validateAdapter(name string) error {
 	_, err := adapters.Get(name)
 	return err
+}
+
+// validateSDD checks that methodology-specific prerequisites are present in
+// the repo before any worktree is created. Currently only "speckit" requires
+// external skills (.claude/commands/speckit.*.md files).
+func validateSDD(sddName, repoRoot string) error {
+	if sddName != "speckit" {
+		return nil
+	}
+	pattern := filepath.Join(repoRoot, ".claude", "commands", "speckit.*.md")
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return fmt.Errorf(
+			"speckit skills not found in %s\n"+
+				"Expected .claude/commands/speckit.*.md files — install the SpecKit skill pack first.\n"+
+				"See https://github.com/arun-gupta/agentctl/blob/main/docs/sdd.md for setup instructions.",
+			filepath.Join(repoRoot, ".claude", "commands"),
+		)
+	}
+	return nil
 }
 
 // findWorktreePath resolves the linked worktree path for the given issue number.

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -709,6 +709,46 @@ func TestValidateAdapter_unknown(t *testing.T) {
 	}
 }
 
+// ─── validateSDD ─────────────────────────────────────────────────────────────
+
+func TestValidateSDD_nonSpeckit_noCheck(t *testing.T) {
+	// Non-speckit methodologies require no filesystem check.
+	if err := validateSDD("plain", t.TempDir()); err != nil {
+		t.Errorf("validateSDD(plain) = %v; want nil", err)
+	}
+	if err := validateSDD("", t.TempDir()); err != nil {
+		t.Errorf("validateSDD(\"\") = %v; want nil", err)
+	}
+}
+
+func TestValidateSDD_speckit_missingSkills(t *testing.T) {
+	dir := t.TempDir() // no .claude/commands/ directory
+	err := validateSDD("speckit", dir)
+	if err == nil {
+		t.Fatal("validateSDD(speckit) expected error when skills missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "speckit skills not found") {
+		t.Errorf("error should mention 'speckit skills not found', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), ".claude/commands") {
+		t.Errorf("error should mention .claude/commands path, got: %v", err)
+	}
+}
+
+func TestValidateSDD_speckit_skillsPresent(t *testing.T) {
+	dir := t.TempDir()
+	cmdDir := filepath.Join(dir, ".claude", "commands")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cmdDir, "speckit.specify.md"), []byte("# speckit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSDD("speckit", dir); err != nil {
+		t.Errorf("validateSDD(speckit) with skills present = %v; want nil", err)
+	}
+}
+
 // ─── waitForFile ─────────────────────────────────────────────────────────────
 
 func TestWaitForFile_exists(t *testing.T) {


### PR DESCRIPTION
Fixes #202

## Summary
- Adds `validateSDD()` which checks for `.claude/commands/speckit.*.md` before creating any worktree
- If skills are missing, exits immediately with an actionable error pointing to the expected location
- Non-speckit methodologies (`plain`, custom) are unaffected — no filesystem check

## Error output
```
Error: speckit skills not found in <repo>/.claude/commands
Expected .claude/commands/speckit.*.md files — install the SpecKit skill pack first.
See https://github.com/arun-gupta/agentctl/blob/main/docs/sdd.md for setup instructions.
```

## Test plan
- [ ] `agentctl start <issue> --sdd=speckit` in a repo without speckit skills — exits with error before creating worktree
- [ ] `agentctl start <issue> --sdd=speckit` in a repo with `.claude/commands/speckit.*.md` — proceeds normally
- [ ] `agentctl start <issue> --sdd=plain` — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)