### PR TITLE
fix: improve SpecKit missing-skills error with install steps and plain alternative

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1512,9 +1512,12 @@ func validateSDD(sddName, repoRoot string) error {
 	if err != nil || len(matches) == 0 {
 		return fmt.Errorf(
 			"SpecKit skills not found in this repo.\n\n" +
-				"To install SpecKit (requires Python 3.11+ and uv or pipx):\n" +
-				"  uvx --from git+https://github.com/github/spec-kit.git@vX.Y.Z specify init <PROJECT_NAME> --integration claude\n\n" +
-				"Replace vX.Y.Z with the latest release from https://github.com/github/spec-kit/releases\n\n" +
+				"--sdd=speckit requires SpecKit slash commands installed as Claude Code command files:\n" +
+				"  .claude/commands/speckit.specify.md\n" +
+				"  .claude/commands/speckit.plan.md\n" +
+				"  .claude/commands/speckit.tasks.md\n" +
+				"  .claude/commands/speckit.implement.md\n\n" +
+				"To install: copy the SpecKit skill files into .claude/commands/ in this repo.\n\n" +
 				"Alternatively, use --sdd=plain which works without any additional setup:\n" +
 				"  agentctl start <issue> --sdd=plain",
 		)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1512,12 +1512,9 @@ func validateSDD(sddName, repoRoot string) error {
 	if err != nil || len(matches) == 0 {
 		return fmt.Errorf(
 			"SpecKit skills not found in this repo.\n\n" +
-				"--sdd=speckit requires SpecKit slash commands installed as Claude Code command files:\n" +
-				"  .claude/commands/speckit.specify.md\n" +
-				"  .claude/commands/speckit.plan.md\n" +
-				"  .claude/commands/speckit.tasks.md\n" +
-				"  .claude/commands/speckit.implement.md\n\n" +
-				"To install: copy the SpecKit skill files into .claude/commands/ in this repo.\n\n" +
+				"To install SpecKit (requires Python 3.11+ and uv or pipx):\n" +
+				"  uvx --from git+https://github.com/github/spec-kit.git@vX.Y.Z specify init <PROJECT_NAME> --integration claude\n\n" +
+				"Replace vX.Y.Z with the latest release from https://github.com/github/spec-kit/releases\n\n" +
 				"Alternatively, use --sdd=plain which works without any additional setup:\n" +
 				"  agentctl start <issue> --sdd=plain",
 		)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1511,10 +1511,15 @@ func validateSDD(sddName, repoRoot string) error {
 	matches, err := filepath.Glob(pattern)
 	if err != nil || len(matches) == 0 {
 		return fmt.Errorf(
-			"speckit skills not found in %s\n"+
-				"Expected .claude/commands/speckit.*.md files — install the SpecKit skill pack first.\n"+
-				"See https://github.com/arun-gupta/agentctl/blob/main/docs/sdd.md for setup instructions.",
-			filepath.Join(repoRoot, ".claude", "commands"),
+			"SpecKit skills not found in this repo.\n\n" +
+				"--sdd=speckit requires SpecKit slash commands installed as Claude Code command files:\n" +
+				"  .claude/commands/speckit.specify.md\n" +
+				"  .claude/commands/speckit.plan.md\n" +
+				"  .claude/commands/speckit.tasks.md\n" +
+				"  .claude/commands/speckit.implement.md\n\n" +
+				"To install: copy the SpecKit skill files into .claude/commands/ in this repo.\n\n" +
+				"Alternatively, use --sdd=plain which works without any additional setup:\n" +
+				"  agentctl start <issue> --sdd=plain",
 		)
 	}
 	return nil

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -727,11 +727,14 @@ func TestValidateSDD_speckit_missingSkills(t *testing.T) {
 	if err == nil {
 		t.Fatal("validateSDD(speckit) expected error when skills missing, got nil")
 	}
-	if !strings.Contains(err.Error(), "speckit skills not found") {
-		t.Errorf("error should mention 'speckit skills not found', got: %v", err)
+	if !strings.Contains(err.Error(), "SpecKit skills not found") {
+		t.Errorf("error should mention 'SpecKit skills not found', got: %v", err)
 	}
 	if !strings.Contains(err.Error(), ".claude/commands") {
 		t.Errorf("error should mention .claude/commands path, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--sdd=plain") {
+		t.Errorf("error should suggest --sdd=plain alternative, got: %v", err)
 	}
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -730,8 +730,8 @@ func TestValidateSDD_speckit_missingSkills(t *testing.T) {
 	if !strings.Contains(err.Error(), "SpecKit skills not found") {
 		t.Errorf("error should mention 'SpecKit skills not found', got: %v", err)
 	}
-	if !strings.Contains(err.Error(), ".claude/commands") {
-		t.Errorf("error should mention .claude/commands path, got: %v", err)
+	if !strings.Contains(err.Error(), "spec-kit") {
+		t.Errorf("error should mention spec-kit install source, got: %v", err)
 	}
 	if !strings.Contains(err.Error(), "--sdd=plain") {
 		t.Errorf("error should suggest --sdd=plain alternative, got: %v", err)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -730,8 +730,11 @@ func TestValidateSDD_speckit_missingSkills(t *testing.T) {
 	if !strings.Contains(err.Error(), "SpecKit skills not found") {
 		t.Errorf("error should mention 'SpecKit skills not found', got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "spec-kit") {
-		t.Errorf("error should mention spec-kit install source, got: %v", err)
+	if !strings.Contains(err.Error(), ".claude/commands") {
+		t.Errorf("error should mention .claude/commands install path, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "speckit.specify.md") {
+		t.Errorf("error should mention required speckit skill files, got: %v", err)
 	}
 	if !strings.Contains(err.Error(), "--sdd=plain") {
 		t.Errorf("error should suggest --sdd=plain alternative, got: %v", err)


### PR DESCRIPTION
## Summary
Improves the error message when `--sdd=speckit` is used but the SpecKit skills are not installed.

**Before:**
```
Error: speckit skills not found in <repo>/.claude/commands
Expected .claude/commands/speckit.*.md files — install the SpecKit skill pack first.
```

**After:**
```
Error: SpecKit skills not found in this repo.

--sdd=speckit requires SpecKit slash commands installed as Claude Code command files:
  .claude/commands/speckit.specify.md
  .claude/commands/speckit.plan.md
  .claude/commands/speckit.tasks.md
  .claude/commands/speckit.implement.md

To install: copy the SpecKit skill files into .claude/commands/ in this repo.

Alternatively, use --sdd=plain which works without any additional setup:
  agentctl start <issue> --sdd=plain
```

## Test plan
- [ ] `agentctl start <issue> --sdd=speckit` in a repo without SpecKit skills — shows new error with install steps and `--sdd=plain` suggestion
- [ ] `agentctl start <issue> --sdd=plain` — proceeds normally (no check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)