### PR TITLE
fix: agentctl logs exits with message when agent process dies

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -969,13 +969,33 @@ func streamLog(wtPath string, lines int, noFollow bool, w io.Writer, logWait tim
 		return fmt.Errorf("tail agent.log: %w", err)
 	}
 
+	// Read agent PID so we can detect process death and notify the user
+	// rather than hanging silently when the agent crashes or exits.
+	agentPID := ""
+	if af, err := state.Read(wtPath); err == nil {
+		agentPID = af.AgentPID
+	}
+
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	<-sigCh
-	signal.Stop(sigCh)
-	_ = tail.Process.Kill()
-	_ = tail.Wait()
-	return nil
+	for {
+		select {
+		case <-sigCh:
+			signal.Stop(sigCh)
+			_ = tail.Process.Kill()
+			_ = tail.Wait()
+			return nil
+		case <-time.After(500 * time.Millisecond):
+			if agentPID != "" && !process.IsAlive(agentPID) {
+				signal.Stop(sigCh)
+				time.Sleep(200 * time.Millisecond) // drain any final log writes
+				_ = tail.Process.Kill()
+				_ = tail.Wait()
+				fmt.Fprintln(w, "\nagent process has exited — use `agentctl attach <issue>` to see the full log or `agentctl resume <issue>` to continue")
+				return nil
+			}
+		}
+	}
 }
 
 // ─── attach ───────────────────────────────────────────────────────────────────

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -978,6 +978,8 @@ func streamLog(wtPath string, lines int, noFollow bool, w io.Writer, logWait tim
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-sigCh:
@@ -985,7 +987,15 @@ func streamLog(wtPath string, lines int, noFollow bool, w io.Writer, logWait tim
 			_ = tail.Process.Kill()
 			_ = tail.Wait()
 			return nil
-		case <-time.After(500 * time.Millisecond):
+		case <-ticker.C:
+			// Re-read the PID if we don't have it yet; the agent writes it
+			// to .agent after the core fields, so it may not be present when
+			// agentctl logs starts.
+			if agentPID == "" {
+				if af, err := state.Read(wtPath); err == nil {
+					agentPID = af.AgentPID
+				}
+			}
 			if agentPID != "" && !process.IsAlive(agentPID) {
 				signal.Stop(sigCh)
 				time.Sleep(200 * time.Millisecond) // drain any final log writes

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1972,6 +1972,94 @@ func TestStreamLog_fileMissing(t *testing.T) {
 	}
 }
 
+// TestStreamLog_followExitsOnProcessDeath verifies that streamLog exits with the
+// guidance message when the agent process dies while following the log.
+func TestStreamLog_followExitsOnProcessDeath(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.log")
+	if err := os.WriteFile(logPath, []byte("agent started\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start a short-lived helper process and wait for it to exit so IsAlive
+	// will return false before streamLog's first poll fires.
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not start helper process: %v", err)
+	}
+	pid := strconv.Itoa(cmd.Process.Pid)
+	_ = cmd.Wait()
+
+	// Write the (now-dead) PID to .agent so streamLog can pick it up.
+	if err := state.AppendKey(dir, "agent-pid", pid); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- streamLog(dir, 50, false, &buf, 100*time.Millisecond)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("streamLog: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "agent process has exited") {
+			t.Errorf("expected exit message; got: %q", out)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("streamLog did not return within 5s after agent process exited")
+	}
+}
+
+// TestStreamLog_followExitsWhenPIDAppearsLate verifies that streamLog detects
+// process death even when agent-pid is appended to .agent after streamLog starts.
+func TestStreamLog_followExitsWhenPIDAppearsLate(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.log")
+	if err := os.WriteFile(logPath, []byte("agent started\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start a short-lived process, capture its PID, then let it die before
+	// we write it to .agent.
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not start helper process: %v", err)
+	}
+	pid := strconv.Itoa(cmd.Process.Pid)
+	_ = cmd.Wait()
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- streamLog(dir, 50, false, &buf, 100*time.Millisecond)
+	}()
+
+	// Write the dead PID after streamLog has started so the re-read logic
+	// inside the polling loop is exercised.
+	time.Sleep(200 * time.Millisecond)
+	if err := state.AppendKey(dir, "agent-pid", pid); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("streamLog: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "agent process has exited") {
+			t.Errorf("expected exit message; got: %q", out)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("streamLog did not return within 5s after agent-pid was written")
+	}
+}
+
 func TestRunLogs_unknownIssue(t *testing.T) {
 	var buf bytes.Buffer
 	err := runLogs("99999", 50, true, &buf)


### PR DESCRIPTION
Fixes #206

## Summary

When an agent crashes or exits mid-run, `agentctl logs` was hanging silently at the last log line — the user had no way to know the process was gone without running a separate check.

Now `agentctl logs` polls the agent PID (read from `.agent`) every 500ms while following. When the process is no longer alive it drains any final log writes (200ms grace period), stops the tail, and prints:

```
agent process has exited — use `agentctl attach <issue>` to see the full log or `agentctl resume <issue>` to continue
```

Found via a Claude Code crash mid-edit: https://github.com/arun-gupta/agentctl-test/issues/7

## Test plan
- [ ] Start an agent, run `agentctl logs <issue>`, kill the agent process manually — logs exits with message instead of hanging
- [ ] Normal run: `agentctl logs <issue>` still follows until Ctrl+C

🤖 Generated with [Claude Code](https://claude.com/claude-code)