### PR TITLE
fix: print distinct error hint when agent crashes in foreground mode

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1772,6 +1772,10 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			convWg.Wait() // drain remaining pipe → log before the final read
 			close(logDone)
 			wg.Wait()
+			if agentExitErr != nil {
+				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", issue)
+				return nil
+			}
 			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
 				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1425,6 +1425,36 @@ func TestLaunchAgent_nonZeroExitLogsToStderr(t *testing.T) {
 	}
 }
 
+func TestLaunchAgent_nonHeadless_nonZeroExitPrintsErrorHint(t *testing.T) {
+	dir := t.TempDir()
+	writeLocalAdapter(t, dir, "falseagent", "binary: false\n")
+	chdirTemp(t, dir)
+
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("launchAgent did not return")
+	}
+
+	outStr := out.String()
+	if !strings.Contains(outStr, "agent exited with error") {
+		t.Errorf("expected 'agent exited with error' in output, got: %q", outStr)
+	}
+	if !strings.Contains(outStr, "agentctl logs 42") {
+		t.Errorf("expected 'agentctl logs 42' hint in output, got: %q", outStr)
+	}
+	// Must not show the normal cleanup/resume hint on error.
+	if strings.Contains(outStr, "agentctl cleanup") {
+		t.Errorf("must not show cleanup hint on error exit, got: %q", outStr)
+	}
+}
+
 func TestAgentResume_unknownAdapter(t *testing.T) {
 	dir := t.TempDir()
 	err := agentResume("nonexistent-xyz-abc", dir, "42", "sess-123", "my feedback", true, false, false)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1437,7 +1437,10 @@ func TestLaunchAgent_nonHeadless_nonZeroExitPrintsErrorHint(t *testing.T) {
 	}()
 
 	select {
-	case <-done:
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("launchAgent: unexpected error: %v", err)
+		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("launchAgent did not return")
 	}


### PR DESCRIPTION
## Summary

- When the agent exits with a non-zero status in foreground (non-headless) mode, print `agent exited with error — check the log: agentctl logs <issue>` instead of the normal cleanup/resume hint.
- This covers both `--quiet` mode and interactive foreground mode: the user now gets an actionable pointer to the log rather than a misleading "all done" cleanup hint.

Closes #207

## Test plan

- [ ] `TestLaunchAgent_nonHeadless_nonZeroExitPrintsErrorHint` — new test verifies error hint appears and cleanup hint is suppressed on non-zero agent exit
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)