### PR TITLE
fix: prevent spinner from overwriting partial log lines on TTY

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1126,6 +1126,21 @@ func computeSpecState(wtPath, issue, sddName string, sddSet bool) string {
 	return "paused"
 }
 
+// findSpecPath returns the absolute path to spec.md for the given issue inside
+// wtPath, or "" if none is found. It checks the plain layout first
+// (specs/spec.md), then the speckit layout (specs/<issue>-*/spec.md).
+func findSpecPath(wtPath, issue string) string {
+	plain := filepath.Join(wtPath, "specs", "spec.md")
+	if _, err := os.Stat(plain); err == nil {
+		return plain
+	}
+	matches, _ := filepath.Glob(filepath.Join(wtPath, "specs", issue+"-*", "spec.md"))
+	if len(matches) > 0 {
+		return matches[0]
+	}
+	return ""
+}
+
 // ghPRInfo calls `gh pr view <branch>` in repoRoot and returns the PR state
 // (e.g. "MERGED") and number (e.g. 42). Both are zero-values on error.
 func ghPRInfo(repoRoot, branch string) (state string, number int, err error) {
@@ -1776,6 +1791,9 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 				reportPRStatus(os.Stdout, wtPath, branch, issue)
 			}
 			if sddName != "" {
+				if specPath := findSpecPath(wtPath, issue); specPath != "" {
+					fmt.Fprintf(out, "Spec: %s\n", specPath)
+				}
 				fmt.Fprintf(out, resumeHintFmt, issue)
 			} else {
 				fmt.Fprintf(out, "agentctl cleanup %s   # after PR is merged\n", issue)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2246,7 +2246,15 @@ func followLog(logPath string, out io.Writer, done <-chan struct{}, quiet bool, 
 			if line != "" && !quiet {
 				if !filterNoise || !isStderrNoise(strings.TrimRight(line, "\r\n")) {
 					clearSpinner()
-					fmt.Fprint(out, line)
+					// On a TTY, partial lines (no trailing \n) leave the cursor
+					// mid-line. The next spinner tick then uses \r to reposition
+					// to column 0 and overwrites the log text. Force a newline so
+					// the cursor always lands at a clean line start.
+					if isTTY && !strings.HasSuffix(line, "\n") {
+						fmt.Fprintln(out, line)
+					} else {
+						fmt.Fprint(out, line)
+					}
 				}
 			}
 			if errors.Is(err, io.EOF) {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1093,6 +1093,49 @@ func TestLaunchAgent_nonHeadless_exitPrintsCleanupHint(t *testing.T) {
 	}
 }
 
+// TestLaunchAgent_nonHeadless_withSDD_showsSpecPath verifies that when a
+// foreground SDD run completes, the output includes the spec file path and the
+// resume hint.
+func TestLaunchAgent_nonHeadless_withSDD_showsSpecPath(t *testing.T) {
+	dir := t.TempDir()
+	writeLocalAdapter(t, dir, "echoagent",
+		"binary: echo\nsession: --session\n")
+	chdirTemp(t, dir)
+
+	// Write a spec file so findSpecPath can locate it.
+	specsDir := filepath.Join(dir, "specs")
+	if err := os.MkdirAll(specsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	specFile := filepath.Join(specsDir, "spec.md")
+	if err := os.WriteFile(specFile, []byte("# spec\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "plain", false, false, false, &out)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("launchAgent SDD foreground: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("launchAgent timed out")
+	}
+
+	outStr := out.String()
+	if !strings.Contains(outStr, specFile) {
+		t.Errorf("output missing spec path %q:\n%s", specFile, outStr)
+	}
+	if !strings.Contains(outStr, "agentctl resume 42") {
+		t.Errorf("output missing resume hint:\n%s", outStr)
+	}
+}
+
 // TestLaunchAgent_nonClaudeNonHeadless_outputStreamed verifies that plain-text
 // output from non-claude adapters is written to agent.log in non-headless mode.
 func TestLaunchAgent_nonClaudeNonHeadless_outputStreamed(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Spinner overwrite fix**: When a log line has no trailing newline (e.g. mid-stream text from copilot/codex), the spinner's next `\r` moves to column 0 of that same line and overwrites the beginning of the log text, producing garbled output like `⠿ agent running... 1m13splace. I'm running the full suite...`. Fix: on TTY, force a `\n` after partial lines so the cursor always lands at a clean line start before the next 100ms tick.

- **Spec path shown after pause**: After a foreground SDD agent pauses at the spec checkpoint, print `Spec: /path/to/specs/spec.md` so users can open and review the spec without hunting for it. Works for both plain-style (`specs/spec.md`) and speckit-style (`specs/<issue>-*/spec.md`) layouts.

Affects all foreground modes (`agentctl start`, `agentctl start --quiet`, `agentctl resume`). Spinner overwrite reproduces clearly with copilot/codex adapters whose output is plain text (not line-buffered JSON events like claude).

## Test plan

- [ ] `go test ./...` passes
- [ ] Manual: `agentctl start <issue> --agent copilot` — verify no merged spinner+log lines in terminal output
- [ ] Manual: `agentctl start <issue> --sdd=plain` — verify `Spec: <path>` is printed before resume hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)