### PR TITLE
fix: clarify plain spec sections and require all sections filled

### DIFF
--- a/docs/spec-template.md
+++ b/docs/spec-template.md
@@ -10,10 +10,12 @@ Include new function signatures, CLI flags, HTTP endpoints, or data structure
 snippets inline here if applicable. -->
 
 ## Test Cases
-<!-- Bulleted list of scenarios the new or updated tests will validate — one
-bullet per case, describe what is asserted, not which file changes. Also list
-which test files are added or updated.
-If there are no new tests, write "None". -->
+<!--
+Bulleted list of scenarios the new or updated tests will validate — one bullet
+per case. Describe what is asserted for each scenario, not which files changed.
+Separately list which test files are added or updated.
+If there are no new or updated tests, write "None".
+-->
 
 ## Risks / Open Questions
 <!-- What you are uncertain about, assumptions made, or areas where human judgment

--- a/docs/spec-template.md
+++ b/docs/spec-template.md
@@ -5,14 +5,19 @@
 <!-- How you plan to solve it. -->
 
 ## Changes
-<!-- Files/modules to add, modify, or delete. Include new function signatures,
-CLI flags, HTTP endpoints, or data structure snippets inline here if applicable. -->
+<!-- Implementation files/modules to add, modify, or delete (excluding test files).
+Include new function signatures, CLI flags, HTTP endpoints, or data structure
+snippets inline here if applicable. -->
 
 ## Test Cases
-<!-- Bulleted list of scenarios that will be validated (not code — just what will be tested). -->
+<!-- Bulleted list of scenarios the new or updated tests will validate — one
+bullet per case, describe what is asserted, not which file changes. Also list
+which test files are added or updated.
+If there are no new tests, write "None". -->
 
 ## Risks / Open Questions
-<!-- What you are uncertain about, assumptions made, or areas where human judgment is needed. -->
+<!-- What you are uncertain about, assumptions made, or areas where human judgment
+is needed. Write "None" if there are no risks. -->
 
 ## Out of Scope
-<!-- What will not be done in this PR. -->
+<!-- What will not be done in this PR. Write "None" if nothing is excluded. -->

--- a/internal/sdd/builtin/plain.yml
+++ b/internal/sdd/builtin/plain.yml
@@ -4,8 +4,8 @@ kickoff: |
   Do not run agentctl, claude, codex, or any other agent-launcher CLI.
   Follow the plain spec workflow:
   - STEP 1: Write a `specs/spec.md` describing your intended approach. Use
-    `docs/spec-template.md` as a starting point. The spec must contain these
-    sections:
+    `docs/spec-template.md` as a starting point. The spec must contain ALL of
+    these sections — write every section even if the answer is "None" or "N/A":
 
       ## Problem
       What the issue asks for and why.
@@ -14,17 +14,21 @@ kickoff: |
       How you plan to solve it.
 
       ## Changes
-      Files/modules to add, modify, or delete. Include new function signatures,
-      CLI flags, HTTP endpoints, or data structure snippets inline here if applicable.
+      Implementation files/modules to add, modify, or delete (excluding test
+      files). Include new function signatures, CLI flags, HTTP endpoints, or
+      data structure snippets inline here if applicable.
 
       ## Test Cases
-      Bulleted list of scenarios that will be validated (not code — just what will be tested).
+      Bulleted list of scenarios that the new or updated tests will validate —
+      one bullet per case, describe what is asserted, not which file changes.
+      Also list which test files are added or updated.
 
       ## Risks / Open Questions
-      What you are uncertain about, assumptions made, or areas where human judgment is needed.
+      What you are uncertain about, assumptions made, or areas where human
+      judgment is needed. Write "None" if there are no risks.
 
       ## Out of Scope
-      What will not be done in this PR.
+      What will not be done in this PR. Write "None" if nothing is excluded.
 
     Stop and wait for human approval before proceeding.
   - STEP 2: After approval, implement the changes directly, push the branch, and open a PR. Do not merge.

--- a/internal/sdd/builtin/plain.yml
+++ b/internal/sdd/builtin/plain.yml
@@ -20,8 +20,9 @@ kickoff: |
 
       ## Test Cases
       Bulleted list of scenarios that the new or updated tests will validate —
-      one bullet per case, describe what is asserted, not which file changes.
-      Also list which test files are added or updated.
+      one bullet per case, describing what behavior or assertion is tested
+      rather than which files changed. After the bullets, add a separate note
+      listing any test files added or updated.
 
       ## Risks / Open Questions
       What you are uncertain about, assumptions made, or areas where human


### PR DESCRIPTION
## Summary

- **Changes vs Test Cases confusion**: `## Changes` now says "implementation files only (excluding test files)"; `## Test Cases` now says to describe what is *asserted* per scenario plus which test files are added/updated. Keeps the two sections distinct.
- **Missing sections**: Added explicit instructions to write "None" for `## Risks / Open Questions` and `## Out of Scope` rather than omitting them. Added "ALL of these sections" + "even if the answer is None" to the spec step.
- **spec-template.md**: Updated HTML comments to match the revised guidance.

## Test plan

- [ ] `go test ./internal/sdd/...` passes (all plain/speckit section tests)
- [ ] Manual: `agentctl start <issue> --sdd=plain` — verify generated spec has all 6 sections filled, Changes contains only implementation files, Test Cases contains behavioral scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)