### PR TITLE
feat: fire test notification on first --notify use

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1825,7 +1825,7 @@ func maybeFireTestNotification(issue string, out io.Writer) {
 	notify.Send("agentctl", fmt.Sprintf("Notifications enabled — you'll be notified when issue #%s finishes.", issue))
 	_ = os.MkdirAll(filepath.Dir(sentinel), 0o755)
 	_ = os.WriteFile(sentinel, []byte(""), 0o644)
-	fmt.Fprintln(out, "Note: a test notification was sent — if you didn't see it, check System Settings → Notifications → Terminal.")
+	fmt.Fprintln(out, "Note: a test notification was sent — if you didn't see it, or want it to stay until dismissed, go to System Settings → Notifications → Terminal → set style to \"Alerts\".")
 }
 
 // sendCompletionNotification fires a native desktop notification reporting

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1810,8 +1811,13 @@ func waitForFile(path string, timeout time.Duration) error {
 
 // notifyTestSentinelPath returns the path of the one-time sentinel file that
 // records whether the first-run notification test has already been done.
+// Returns "" when the user config directory cannot be resolved.
 func notifyTestSentinelPath() string {
-	return filepath.Join(xdg.UserConfigDir(), "agentctl", "notify-tested")
+	cfgDir := xdg.UserConfigDir()
+	if cfgDir == "" {
+		return ""
+	}
+	return filepath.Join(cfgDir, "agentctl", "notify-tested")
 }
 
 // maybeFireTestNotification sends a single test notification the very first
@@ -1819,7 +1825,13 @@ func notifyTestSentinelPath() string {
 // A one-line hint is printed to out so the user knows to look for it.
 func maybeFireTestNotification(issue string, out io.Writer) {
 	sentinel := notifyTestSentinelPath()
-	_ = os.MkdirAll(filepath.Dir(sentinel), 0o755)
+	if sentinel == "" {
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(sentinel), 0o755); err != nil {
+		return
+	}
 
 	f, err := os.OpenFile(sentinel, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 	if err != nil {
@@ -1831,7 +1843,17 @@ func maybeFireTestNotification(issue string, out io.Writer) {
 	_ = f.Close()
 
 	notify.Send("agentctl", fmt.Sprintf("Notifications enabled — you'll be notified when issue #%s finishes.", issue))
-	fmt.Fprintln(out, "Note: a test notification was sent — if you didn't see it, or want it to stay until dismissed, go to System Settings → Notifications → Terminal → set style to \"Alerts\".")
+
+	var hint string
+	switch runtime.GOOS {
+	case "darwin":
+		hint = "Note: a test notification was sent — if you didn't see it, go to System Settings → Notifications → Terminal and set the style to \"Alerts\"."
+	case "linux":
+		hint = "Note: a test notification was sent — if you didn't see it, ensure notify-send (libnotify-bin) is installed."
+	default:
+		hint = "Note: a test notification was sent — if you didn't see it, check your system's notification settings."
+	}
+	fmt.Fprintln(out, hint)
 }
 
 // sendCompletionNotification fires a native desktop notification reporting

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -29,6 +29,7 @@ import (
 	"github.com/arun-gupta/agentctl/internal/process"
 	"github.com/arun-gupta/agentctl/internal/sdd"
 	"github.com/arun-gupta/agentctl/internal/state"
+	"github.com/arun-gupta/agentctl/internal/xdg"
 )
 
 // ─── start ────────────────────────────────────────────────────────────────────
@@ -1743,6 +1744,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			fmt.Fprintf(out, "agentctl resume %s [feedback]   # approve spec or send revisions\n", issue)
 		}
 		if sendNotify {
+			maybeFireTestNotification(issue, out)
 			go func() {
 				<-exitCh
 				sendCompletionNotification(issue, wtPath, agentExitErr)
@@ -1804,6 +1806,26 @@ func waitForFile(path string, timeout time.Duration) error {
 		time.Sleep(100 * time.Millisecond)
 	}
 	return fmt.Errorf("%s did not appear within %s", path, timeout)
+}
+
+// notifyTestSentinelPath returns the path of the one-time sentinel file that
+// records whether the first-run notification test has already been done.
+func notifyTestSentinelPath() string {
+	return filepath.Join(xdg.UserConfigDir(), "agentctl", "notify-tested")
+}
+
+// maybeFireTestNotification sends a single test notification the very first
+// time --notify is used, then creates a sentinel so it never fires again.
+// A one-line hint is printed to out so the user knows to look for it.
+func maybeFireTestNotification(issue string, out io.Writer) {
+	sentinel := notifyTestSentinelPath()
+	if _, err := os.Stat(sentinel); err == nil {
+		return // already tested
+	}
+	notify.Send("agentctl", fmt.Sprintf("Notifications enabled — you'll be notified when issue #%s finishes.", issue))
+	_ = os.MkdirAll(filepath.Dir(sentinel), 0o755)
+	_ = os.WriteFile(sentinel, []byte(""), 0o644)
+	fmt.Fprintln(out, "Note: a test notification was sent — if you didn't see it, check System Settings → Notifications → Terminal.")
 }
 
 // sendCompletionNotification fires a native desktop notification reporting
@@ -2637,6 +2659,7 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 		fmt.Printf("Released pause for issue %s; Stage 2 running in background.\n", issue)
 		fmt.Printf("Tail: %s\n", logPath)
 		if sendNotify {
+			maybeFireTestNotification(issue, os.Stdout)
 			go func() {
 				<-exitCh
 				sendCompletionNotification(issue, wtPath, resumeExitErr)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1819,12 +1819,18 @@ func notifyTestSentinelPath() string {
 // A one-line hint is printed to out so the user knows to look for it.
 func maybeFireTestNotification(issue string, out io.Writer) {
 	sentinel := notifyTestSentinelPath()
-	if _, err := os.Stat(sentinel); err == nil {
-		return // already tested
-	}
-	notify.Send("agentctl", fmt.Sprintf("Notifications enabled — you'll be notified when issue #%s finishes.", issue))
 	_ = os.MkdirAll(filepath.Dir(sentinel), 0o755)
-	_ = os.WriteFile(sentinel, []byte(""), 0o644)
+
+	f, err := os.OpenFile(sentinel, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return // already tested
+		}
+		return
+	}
+	_ = f.Close()
+
+	notify.Send("agentctl", fmt.Sprintf("Notifications enabled — you'll be notified when issue #%s finishes.", issue))
 	fmt.Fprintln(out, "Note: a test notification was sent — if you didn't see it, or want it to stay until dismissed, go to System Settings → Notifications → Terminal → set style to \"Alerts\".")
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1030,7 +1030,7 @@ func TestMaybeFireTestNotification_firstRun(t *testing.T) {
 	if !strings.Contains(notified[0][1], "42") {
 		t.Errorf("notification message %q does not mention issue 42", notified[0][1])
 	}
-	if !strings.Contains(out.String(), "test notification was sent") || !strings.Contains(out.String(), "Alerts") {
+	if !strings.Contains(out.String(), "test notification was sent") {
 		t.Errorf("hint line missing from output: %q", out.String())
 	}
 	sentinel := filepath.Join(cfgDir, "agentctl", "notify-tested")

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1030,7 +1030,7 @@ func TestMaybeFireTestNotification_firstRun(t *testing.T) {
 	if !strings.Contains(notifed[0][1], "42") {
 		t.Errorf("notification message %q does not mention issue 42", notifed[0][1])
 	}
-	if !strings.Contains(out.String(), "test notification was sent") {
+	if !strings.Contains(out.String(), "test notification was sent") || !strings.Contains(out.String(), "Alerts") {
 		t.Errorf("hint line missing from output: %q", out.String())
 	}
 	sentinel := filepath.Join(cfgDir, "agentctl", "notify-tested")

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1006,6 +1006,71 @@ func TestLaunchAgent_headless_notify(t *testing.T) {
 	}
 }
 
+// TestMaybeFireTestNotification_firstRun verifies that a notification is sent
+// and the sentinel is created on the first --notify use, and that a hint line
+// is printed to out.
+func TestMaybeFireTestNotification_firstRun(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	origFn := notify.SendFn
+	t.Cleanup(func() { notify.SendFn = origFn })
+
+	var notifed [][2]string
+	notify.SendFn = func(title, message string) {
+		notifed = append(notifed, [2]string{title, message})
+	}
+
+	var out bytes.Buffer
+	maybeFireTestNotification("42", &out)
+
+	if len(notifed) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(notifed))
+	}
+	if !strings.Contains(notifed[0][1], "42") {
+		t.Errorf("notification message %q does not mention issue 42", notifed[0][1])
+	}
+	if !strings.Contains(out.String(), "test notification was sent") {
+		t.Errorf("hint line missing from output: %q", out.String())
+	}
+	sentinel := filepath.Join(cfgDir, "agentctl", "notify-tested")
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("sentinel file not created: %v", err)
+	}
+}
+
+// TestMaybeFireTestNotification_subsequentRun verifies that the notification
+// is not sent again once the sentinel exists.
+func TestMaybeFireTestNotification_subsequentRun(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+
+	// Pre-create the sentinel.
+	sentinelDir := filepath.Join(cfgDir, "agentctl")
+	if err := os.MkdirAll(sentinelDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sentinelDir, "notify-tested"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origFn := notify.SendFn
+	t.Cleanup(func() { notify.SendFn = origFn })
+
+	called := false
+	notify.SendFn = func(title, message string) { called = true }
+
+	var out bytes.Buffer
+	maybeFireTestNotification("42", &out)
+
+	if called {
+		t.Error("notification must not fire on subsequent runs (sentinel present)")
+	}
+	if out.Len() != 0 {
+		t.Errorf("no hint expected on subsequent run, got: %q", out.String())
+	}
+}
+
 func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 	dir := t.TempDir()
 	// Use `echo` as the agent binary — always on PATH, exits immediately.

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1016,19 +1016,19 @@ func TestMaybeFireTestNotification_firstRun(t *testing.T) {
 	origFn := notify.SendFn
 	t.Cleanup(func() { notify.SendFn = origFn })
 
-	var notifed [][2]string
+	var notified [][2]string
 	notify.SendFn = func(title, message string) {
-		notifed = append(notifed, [2]string{title, message})
+		notified = append(notified, [2]string{title, message})
 	}
 
 	var out bytes.Buffer
 	maybeFireTestNotification("42", &out)
 
-	if len(notifed) != 1 {
-		t.Fatalf("expected 1 notification, got %d", len(notifed))
+	if len(notified) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(notified))
 	}
-	if !strings.Contains(notifed[0][1], "42") {
-		t.Errorf("notification message %q does not mention issue 42", notifed[0][1])
+	if !strings.Contains(notified[0][1], "42") {
+		t.Errorf("notification message %q does not mention issue 42", notified[0][1])
 	}
 	if !strings.Contains(out.String(), "test notification was sent") || !strings.Contains(out.String(), "Alerts") {
 		t.Errorf("hint line missing from output: %q", out.String())


### PR DESCRIPTION
## Summary

On the very first `--headless --notify` invocation, agentctl now fires an immediate test notification:

```
agentctl
Notifications enabled — you'll be notified when issue #35 finishes.
```

And prints a one-line hint to the terminal:

```
Note: a test notification was sent — if you didn't see it, check System Settings → Notifications → Terminal.
```

A sentinel file at `~/.config/agentctl/notify-tested` is created so the test fires exactly once. Subsequent `--notify` runs skip straight to waiting for the agent to finish.

Works for both `agentctl start --headless --notify` and `agentctl resume --headless --notify`.

## Test plan

- [ ] `TestMaybeFireTestNotification_firstRun` — notification fires, sentinel created, hint printed
- [ ] `TestMaybeFireTestNotification_subsequentRun` — notification suppressed when sentinel exists
- [ ] `go test ./...` passes
- [ ] Manual: delete `~/.config/agentctl/notify-tested`, run `agentctl start <issue> --headless --notify`, verify macOS banner appears immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)