### PR TITLE
fix: always show PR status after agent exits; cleanup hint only when PR exists

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1233,7 +1233,13 @@ func linkPRToIssue(dir, branch, issueNum string) (*prInfo, error) {
 	cmd.Stdout = &out
 	cmd.Stderr = &errBuf
 	if err := cmd.Run(); err != nil {
-		return nil, nil // no PR — silently skip
+		// "no pull request(s) found" means the branch exists but has no PR — not an error.
+		// Any other failure (auth, gh not installed, etc.) is a real error.
+		errMsg := strings.ToLower(errBuf.String())
+		if strings.Contains(errMsg, "no pull request") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(errBuf.String()))
 	}
 
 	var pr prInfo
@@ -1258,12 +1264,19 @@ func linkPRToIssue(dir, branch, issueNum string) (*prInfo, error) {
 }
 
 // reportPRStatus links the PR to the issue and prints the PR URL to w.
-// Returns true when a PR was found. Prints "PR: none" when no PR exists so
-// callers can always tell the user what happened.
+// Returns true when a PR was found. Prints "PR: none" when no PR exists,
+// "PR: unknown (<reason>)" when the check could not be performed, so callers
+// can always tell the user what happened.
 func reportPRStatus(w io.Writer, dir, branch, issueNum string) bool {
+	// An empty branch means no branch was found or created, so no PR can exist.
+	if branch == "" {
+		fmt.Fprintln(w, "PR: none")
+		return false
+	}
 	pr, err := linkPRToIssue(dir, branch, issueNum)
 	if err != nil {
-		fmt.Fprintf(w, "note: could not link PR to issue: %v\n", err)
+		fmt.Fprintf(w, "PR: unknown (%v)\n", err)
+		return false
 	}
 	if pr != nil && pr.Number > 0 && pr.URL != "" {
 		fmt.Fprintf(w, "PR: #%d  %s\n", pr.Number, pr.URL)
@@ -1825,7 +1838,10 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", issue)
 				return nil
 			}
-			branch, _ := git.CurrentBranch(wtPath)
+			branch, branchErr := git.CurrentBranch(wtPath)
+			if branchErr != nil {
+				branch = ""
+			}
 			hasPR := reportPRStatus(out, wtPath, branch, issue)
 			if sddName != "" {
 				if specPath := findSpecPath(wtPath, issue); specPath != "" {
@@ -2806,7 +2822,10 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			convWg.Wait()
 			close(logDone)
 			wg.Wait()
-			branch, _ := git.CurrentBranch(wtPath)
+			branch, branchErr := git.CurrentBranch(wtPath)
+			if branchErr != nil {
+				branch = ""
+			}
 			hasPR := reportPRStatus(os.Stdout, wtPath, branch, issue)
 			if hasPR {
 				fmt.Fprintf(os.Stdout, "agentctl cleanup %s   # after PR is merged\n", issue)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1258,15 +1258,19 @@ func linkPRToIssue(dir, branch, issueNum string) (*prInfo, error) {
 }
 
 // reportPRStatus links the PR to the issue and prints the PR URL to w.
-// Silent when no PR exists.
-func reportPRStatus(w io.Writer, dir, branch, issueNum string) {
+// Returns true when a PR was found. Prints "PR: none" when no PR exists so
+// callers can always tell the user what happened.
+func reportPRStatus(w io.Writer, dir, branch, issueNum string) bool {
 	pr, err := linkPRToIssue(dir, branch, issueNum)
 	if err != nil {
 		fmt.Fprintf(w, "note: could not link PR to issue: %v\n", err)
 	}
 	if pr != nil && pr.Number > 0 && pr.URL != "" {
 		fmt.Fprintf(w, "PR: #%d  %s\n", pr.Number, pr.URL)
+		return true
 	}
+	fmt.Fprintln(w, "PR: none")
+	return false
 }
 
 // parseIssueURL checks whether arg is a full GitHub issue URL of the form
@@ -1821,15 +1825,14 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", issue)
 				return nil
 			}
-			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
-				reportPRStatus(os.Stdout, wtPath, branch, issue)
-			}
+			branch, _ := git.CurrentBranch(wtPath)
+			hasPR := reportPRStatus(out, wtPath, branch, issue)
 			if sddName != "" {
 				if specPath := findSpecPath(wtPath, issue); specPath != "" {
 					fmt.Fprintf(out, "Spec: %s\n", specPath)
 				}
 				fmt.Fprintf(out, resumeHintFmt, issue)
-			} else {
+			} else if hasPR {
 				fmt.Fprintf(out, "agentctl cleanup %s   # after PR is merged\n", issue)
 			}
 			return nil
@@ -2803,10 +2806,11 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			convWg.Wait()
 			close(logDone)
 			wg.Wait()
-			if branch, branchErr := git.CurrentBranch(wtPath); branchErr == nil && branch != "" {
-				reportPRStatus(os.Stdout, wtPath, branch, issue)
+			branch, _ := git.CurrentBranch(wtPath)
+			hasPR := reportPRStatus(os.Stdout, wtPath, branch, issue)
+			if hasPR {
+				fmt.Fprintf(os.Stdout, "agentctl cleanup %s   # after PR is merged\n", issue)
 			}
-			fmt.Fprintf(os.Stdout, "agentctl cleanup %s   # after PR is merged\n", issue)
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1081,10 +1081,10 @@ func TestLaunchAgent_nonHeadless_exitPrintsCleanupHint(t *testing.T) {
 	}
 
 	outStr := out.String()
-	// Non-SDD run: expect cleanup hint, not resume hint.
-	want := "agentctl cleanup 42"
-	if !strings.Contains(outStr, want) {
-		t.Errorf("missing cleanup hint %q in foreground-exit output:\n%s", want, outStr)
+	// Non-SDD run with no PR: expect "PR: none", no cleanup hint (no PR yet),
+	// and no headless hints.
+	if !strings.Contains(outStr, "PR: none") {
+		t.Errorf("missing 'PR: none' in foreground-exit output:\n%s", outStr)
 	}
 	for _, unwanted := range []string{"agentctl logs", "agentctl attach", "agentctl discard", "agentctl resume"} {
 		if strings.Contains(outStr, unwanted) {
@@ -1662,10 +1662,10 @@ func TestAgentResume_nonHeadless_exitPrintsCleanupHint(t *testing.T) {
 	r.Close()
 
 	out := buf.String()
-	// After resume exit, the agent is done — expect cleanup hint, not resume hint.
-	want := "agentctl cleanup 42"
-	if !strings.Contains(out, want) {
-		t.Errorf("missing cleanup hint %q in foreground-exit output:\n%s", want, out)
+	// After resume exit with no PR: expect "PR: none". Cleanup hint only appears
+	// when a PR exists. No headless hints.
+	if !strings.Contains(out, "PR: none") {
+		t.Errorf("missing 'PR: none' in foreground-exit output:\n%s", out)
 	}
 	for _, unwanted := range []string{"agentctl logs", "agentctl attach", "agentctl discard"} {
 		if strings.Contains(out, unwanted) {
@@ -3284,16 +3284,19 @@ func TestReportPRStatus_printsPRLink(t *testing.T) {
 	}
 }
 
-func TestReportPRStatus_noPR_printsNothing(t *testing.T) {
+func TestReportPRStatus_noPR_printsNone(t *testing.T) {
 	stubDir := t.TempDir()
 	makeGHStub(t, stubDir, "", "", false) // no PR
 	prependPath(t, stubDir)
 
 	var buf bytes.Buffer
-	reportPRStatus(&buf, t.TempDir(), "2-my-feature", "2")
+	hasPR := reportPRStatus(&buf, t.TempDir(), "2-my-feature", "2")
 
-	if buf.Len() > 0 {
-		t.Errorf("expected no output when no PR exists, got: %q", buf.String())
+	if hasPR {
+		t.Error("expected hasPR=false when no PR exists")
+	}
+	if !strings.Contains(buf.String(), "PR: none") {
+		t.Errorf("expected 'PR: none' when no PR exists, got: %q", buf.String())
 	}
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1048,7 +1048,7 @@ func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 	}
 }
 
-func TestLaunchAgent_nonHeadless_exitPrintsCleanupHint(t *testing.T) {
+func TestLaunchAgent_nonHeadless_exitNoPR_printsNoPR(t *testing.T) {
 	dir := t.TempDir()
 	writeLocalAdapter(t, dir, "echoagent",
 		"binary: echo\nsession: --session\n")
@@ -1613,7 +1613,7 @@ func TestAgentResume_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 	}
 }
 
-func TestAgentResume_nonHeadless_exitPrintsCleanupHint(t *testing.T) {
+func TestAgentResume_nonHeadless_exitNoPR_printsNoPR(t *testing.T) {
 	dir := t.TempDir()
 	writeLocalAdapter(t, dir, "echoagent",
 		"binary: echo\nsession: --session\n")
@@ -3129,6 +3129,7 @@ func makeGHStub(t *testing.T, stubDir, viewJSON, listJSON string, editFail bool)
 printf '%%s\n' "$@" >> %s
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
   if [ -f %s ]; then cat %s; fi
+  if [ %d -ne 0 ]; then printf 'no pull requests found for branch\n' >&2; fi
   exit %d
 fi
 if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
@@ -3141,6 +3142,7 @@ fi
 exit 0`,
 		callsFile,
 		responseFile, responseFile,
+		prViewExit,
 		prViewExit,
 		listFile,
 		prEditExit,


### PR DESCRIPTION
## Summary

- `reportPRStatus` was silent when no PR was found, so users saw `agentctl cleanup N # after PR is merged` even when the agent never opened a PR (e.g. blocked by sandbox, crashed before push).
- Now prints `PR: none` when no PR is found, `PR: #N  <url>` when one exists.
- Cleanup hint (`agentctl cleanup N`) only prints when a PR actually exists.
- Applies to both `agentctl start` foreground exit and `agentctl resume` foreground exit.

## Test plan

- [ ] `TestReportPRStatus_noPR_printsNone` — asserts `PR: none` when no PR
- [ ] `TestLaunchAgent_nonHeadless_exitPrintsCleanupHint` — asserts `PR: none`, no cleanup hint when no PR
- [ ] `TestAgentResume_nonHeadless_exitPrintsCleanupHint` — same
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)