### PR TITLE
fix: authorise agent to run bash commands without asking in SDD plain mode

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -283,12 +283,13 @@ By default the resumed agent streams its output to the terminal (foreground).
 Use --headless to run it in the background and write output to agent.log.`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			prompt := "proceed"
+			const authorisation = "You are authorised to run bash commands (tests, linters, builds) directly without asking for human approval."
+			prompt := "The spec is approved. Proceed with implementation. " + authorisation
 			if len(args) == 2 {
 				if strings.TrimSpace(args[1]) == "" {
 					return fmt.Errorf("feedback must be non-empty; omit it entirely to approve")
 				}
-				prompt = args[1]
+				prompt = args[1] + " " + authorisation
 			}
 			return runReleasePausedSession(args[0], prompt, headless, quiet, sendNotify)
 		},

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -264,6 +264,21 @@ func runBatch(issues []string, agentName, sddName string, quiet, sendNotify bool
 
 // ─── resume ───────────────────────────────────────────────────────────────────
 
+// resumeAuthorisation is the sentence appended to every resume prompt so the
+// agent knows it may execute bash commands without additional human approval.
+const resumeAuthorisation = "You are authorised to run bash commands (tests, linters, builds) directly without asking for human approval."
+
+// buildResumePrompt returns the prompt sent to the agent on resume.
+// When feedback is empty the spec is approved and the agent begins
+// implementation; when feedback is non-empty the agent revises the spec.
+// Either way, the authorisation to run bash commands is appended.
+func buildResumePrompt(feedback string) string {
+	if feedback == "" {
+		return "The spec is approved. Proceed with implementation. " + resumeAuthorisation
+	}
+	return feedback + " " + resumeAuthorisation
+}
+
 // NewResumeCmd creates the `resume` subcommand.
 func NewResumeCmd() *cobra.Command {
 	var (
@@ -276,22 +291,23 @@ func NewResumeCmd() *cobra.Command {
 		Short: "Resume a paused spec review: approve or revise",
 		Long: `Resume a paused agent after the spec-review checkpoint.
 
-Without feedback, sends approval ("proceed") and the agent begins implementation.
-With feedback, sends the revision text and the agent rewrites the spec.
+Without feedback, sends "The spec is approved. Proceed with implementation." plus
+an authorisation to run bash commands, and the agent begins implementation.
+With feedback, sends the revision text (plus the same bash authorisation) and
+the agent rewrites the spec.
 
 By default the resumed agent streams its output to the terminal (foreground).
 Use --headless to run it in the background and write output to agent.log.`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			const authorisation = "You are authorised to run bash commands (tests, linters, builds) directly without asking for human approval."
-			prompt := "The spec is approved. Proceed with implementation. " + authorisation
-			if len(args) == 2 {
-				if strings.TrimSpace(args[1]) == "" {
-					return fmt.Errorf("feedback must be non-empty; omit it entirely to approve")
-				}
-				prompt = args[1] + " " + authorisation
+			if len(args) == 2 && strings.TrimSpace(args[1]) == "" {
+				return fmt.Errorf("feedback must be non-empty; omit it entirely to approve")
 			}
-			return runReleasePausedSession(args[0], prompt, headless, quiet, sendNotify)
+			feedback := ""
+			if len(args) == 2 {
+				feedback = args[1]
+			}
+			return runReleasePausedSession(args[0], buildResumePrompt(feedback), headless, quiet, sendNotify)
 		},
 	}
 	c.Flags().BoolVar(&headless, "headless", false, "Run agent in background (log -> agent.log)")

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1383,6 +1383,36 @@ func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
 	}
 }
 
+// ─── buildResumePrompt ────────────────────────────────────────────────────────
+
+func TestBuildResumePrompt_approval(t *testing.T) {
+	prompt := buildResumePrompt("")
+	if !strings.Contains(prompt, "The spec is approved") {
+		t.Errorf("approval prompt must say 'The spec is approved', got: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Proceed with implementation") {
+		t.Errorf("approval prompt must say 'Proceed with implementation', got: %q", prompt)
+	}
+	if !strings.Contains(prompt, resumeAuthorisation) {
+		t.Errorf("approval prompt must include authorisation sentence, got: %q", prompt)
+	}
+}
+
+func TestBuildResumePrompt_revision(t *testing.T) {
+	feedback := "Please add error handling"
+	prompt := buildResumePrompt(feedback)
+	if !strings.HasPrefix(prompt, feedback) {
+		t.Errorf("revision prompt must start with feedback, got: %q", prompt)
+	}
+	if !strings.Contains(prompt, resumeAuthorisation) {
+		t.Errorf("revision prompt must include authorisation sentence, got: %q", prompt)
+	}
+	// Approval text must NOT appear in a revision prompt.
+	if strings.Contains(prompt, "The spec is approved") {
+		t.Errorf("revision prompt must not contain approval text, got: %q", prompt)
+	}
+}
+
 // ─── resume command flags ─────────────────────────────────────────────────────
 
 func TestResumeCmd_headlessFlag(t *testing.T) {

--- a/internal/sdd/builtin/plain.yml
+++ b/internal/sdd/builtin/plain.yml
@@ -32,5 +32,8 @@ kickoff: |
       What will not be done in this PR. Write "None" if nothing is excluded.
 
     Stop and wait for human approval before proceeding.
-  - STEP 2: After approval, implement the changes directly, push the branch, and open a PR. Do not merge.
+  - STEP 2: After approval, implement the changes, run tests, push the branch,
+    and open a PR. Do not merge. Run bash commands (tests, linters, builds)
+    directly without asking for human approval — you are authorised to execute
+    any command needed to complete the implementation.
   Dev server is running on port {port}.

--- a/internal/sdd/sdd_test.go
+++ b/internal/sdd/sdd_test.go
@@ -184,6 +184,17 @@ func TestKickoffPrompt_plain_waitForApproval(t *testing.T) {
 	}
 }
 
+func TestKickoffPrompt_plain_authorisedBashCommands(t *testing.T) {
+	m, err := sdd.Get("plain")
+	if err != nil {
+		t.Fatalf("Get(plain) unexpected error: %v", err)
+	}
+	prompt := m.KickoffPrompt("42", "3010")
+	if !strings.Contains(prompt, "you are authorised to execute") {
+		t.Errorf("plain prompt must authorise agent to run bash commands, got:\n%s", prompt)
+	}
+}
+
 // ─── resolution chain ─────────────────────────────────────────────────────────
 
 func TestGet_userLevelOverridesBuiltin(t *testing.T) {


### PR DESCRIPTION
## Summary

The agent was stopping to ask "please approve the pytest run" even though `--permission-mode bypassPermissions` is set, because the SDD prompts never explicitly told the agent it could run bash commands autonomously.

Two fixes:

- **`plain.yml` STEP 2**: add "Run bash commands (tests, linters, builds) directly without asking for human approval — you are authorised to execute any command needed to complete the implementation."
- **`agentctl resume` approve prompt**: expand the bare `"proceed"` to `"The spec is approved. Proceed with implementation. You are authorised to run bash commands directly without asking for human approval."`
- **revision prompt**: appends the same authorisation sentence so the agent also doesn't ask after receiving feedback.

## Test plan

- [ ] `go test ./...` passes
- [ ] Manual: `agentctl start <issue> --sdd=plain` → `agentctl resume <issue>` — agent runs tests without pausing to ask

🤖 Generated with [Claude Code](https://claude.com/claude-code)