### PR TITLE
fix: add --permission-mode bypassPermissions to claude adapter resume_cmd

### DIFF
--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -81,6 +81,8 @@ func TestResumeCmd_claude(t *testing.T) {
 	assertContains(t, args, "my feedback")
 	assertContains(t, args, "sess-123")
 	assertContains(t, args, "--resume")
+	assertContains(t, args, "--permission-mode")
+	assertContains(t, args, "bypassPermissions")
 }
 
 func TestLaunchCmd_gemini_noSessionFlag(t *testing.T) {

--- a/internal/adapters/builtin/claude.yml
+++ b/internal/adapters/builtin/claude.yml
@@ -1,4 +1,4 @@
 binary: claude
 launch: claude --permission-mode bypassPermissions -p {kickoff} --session-id {session_id}
-resume_cmd: claude -p {prompt} --resume {session_id}
+resume_cmd: claude --permission-mode bypassPermissions -p {prompt} --resume {session_id}
 install: npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary

The `claude` adapter's `launch` command had `--permission-mode bypassPermissions` but `resume_cmd` did not:

```yaml
# before
resume_cmd: claude -p {prompt} --resume {session_id}

# after
resume_cmd: claude --permission-mode bypassPermissions -p {prompt} --resume {session_id}
```

This caused every `agentctl resume` to run Claude Code in the default restricted permission mode. The agent was blocked from running `pytest` and spent significant time trying to work around the restriction (reading transcripts, writing `.claude/settings.json`, etc.) instead of just running the tests.

## Test plan

- [ ] `go test ./...` passes
- [ ] Manual: `agentctl resume <issue>` — agent runs `pytest` without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)