### PR TITLE
fix: store allocated dev port in .agent instead of .agentctl.yml

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -201,6 +201,7 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 		Agent:     agentName,
 		SessionID: sessionID,
 		DevPID:    devPID,
+		DevPort:   portStr,
 		SDD:       sddName,
 	}
 	if err := state.Write(wtPath, af); err != nil {
@@ -1552,10 +1553,6 @@ func startCustomDevServer(dir string, cfg *config.AgentctlConfig, out io.Writer)
 	}
 	fmt.Fprintf(out, "Dev server: http://localhost:%s (log: %s/dev.log)\n", portStr, dir)
 
-	cfg.Port = port
-	if err := config.Write(dir, cfg); err != nil {
-		fmt.Fprintf(out, "warning: could not persist port to .agentctl.yml: %v\n", err)
-	}
 	return fmt.Sprintf("%d", devCmd.Process.Pid), portStr, nil
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/arun-gupta/agentctl/internal/config"
 	"github.com/arun-gupta/agentctl/internal/notify"
 	"github.com/arun-gupta/agentctl/internal/sdd"
 	"github.com/arun-gupta/agentctl/internal/state"
@@ -3142,10 +3141,11 @@ func TestFollowLog_filterNoise_false_passesEverything(t *testing.T) {
 	}
 }
 
-func TestStartDevServer_agentctlYml_writesPortBack(t *testing.T) {
+func TestStartDevServer_doesNotDirtyAgentctlYml(t *testing.T) {
 	dir := t.TempDir()
+	original := "dev_server: \"echo ok\"\n"
 	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),
-		[]byte("dev_server: \"echo ok\"\n"), 0o644); err != nil {
+		[]byte(original), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	pidStr, portStr, err := startDevServer(dir, io.Discard)
@@ -3171,13 +3171,13 @@ func TestStartDevServer_agentctlYml_writesPortBack(t *testing.T) {
 	if portStr == "" {
 		t.Fatal("expected non-empty port when dev_server is set")
 	}
-	// Verify port was written back to .agentctl.yml.
-	cfg, err := config.Read(dir)
-	if err != nil {
-		t.Fatal(err)
+	// Verify .agentctl.yml was NOT modified (port belongs in .agent, not here).
+	content, readErr := os.ReadFile(filepath.Join(dir, ".agentctl.yml"))
+	if readErr != nil {
+		t.Fatal(readErr)
 	}
-	if fmt.Sprintf("%d", cfg.Port) != portStr {
-		t.Errorf("port in .agentctl.yml = %d, want %s", cfg.Port, portStr)
+	if string(content) != original {
+		t.Errorf(".agentctl.yml was modified by startDevServer:\ngot:  %q\nwant: %q", string(content), original)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,4 @@
 // Package config handles reading and writing the per-repo .agentctl.yml file.
-// This file is the single source of truth for all agentctl repo-level config:
-// developers write the dev_server field; agentctl writes back the allocated port.
 package config
 
 import (
@@ -18,10 +16,6 @@ type AgentctlConfig struct {
 	// Use {port} as a placeholder; agentctl substitutes the allocated port.
 	// Example: "uvicorn main:app --port {port}"
 	DevServer string `yaml:"dev_server,omitempty"`
-
-	// Port is written back by agentctl after it allocates a port for the dev
-	// server. Read-only for the developer.
-	Port int `yaml:"port,omitempty"`
 
 	// Notify enables native desktop notifications when a headless agent
 	// finishes. Only meaningful in headless mode; ignored for foreground runs.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,7 +14,7 @@ func TestRead_missingFile_returnsEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.DevServer != "" || cfg.Port != 0 {
+	if cfg.DevServer != "" || cfg.Notify {
 		t.Errorf("expected empty config for missing file, got %+v", cfg)
 	}
 }
@@ -33,7 +33,7 @@ func TestRead_parsesDevServer(t *testing.T) {
 	}
 }
 
-func TestWrite_persistsPort(t *testing.T) {
+func TestWrite_preservesDevServer(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"uvicorn main:app --port {port}\"\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -42,7 +42,6 @@ func TestWrite_persistsPort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cfg.Port = 3042
 	if err := config.Write(dir, cfg); err != nil {
 		t.Fatalf("Write error: %v", err)
 	}
@@ -50,9 +49,6 @@ func TestWrite_persistsPort(t *testing.T) {
 	got, err := config.Read(dir)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if got.Port != 3042 {
-		t.Errorf("Port = %d, want 3042", got.Port)
 	}
 	if got.DevServer != "uvicorn main:app --port {port}" {
 		t.Errorf("DevServer lost after Write: %q", got.DevServer)
@@ -61,7 +57,7 @@ func TestWrite_persistsPort(t *testing.T) {
 
 func TestWrite_createsFileWhenAbsent(t *testing.T) {
 	dir := t.TempDir()
-	cfg := &config.AgentctlConfig{Port: 3010}
+	cfg := &config.AgentctlConfig{DevServer: "npm start"}
 	if err := config.Write(dir, cfg); err != nil {
 		t.Fatalf("Write error: %v", err)
 	}
@@ -69,8 +65,8 @@ func TestWrite_createsFileWhenAbsent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Port != 3010 {
-		t.Errorf("Port = %d, want 3010", got.Port)
+	if got.DevServer != "npm start" {
+		t.Errorf("DevServer = %q, want %q", got.DevServer, "npm start")
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -17,6 +17,7 @@ type AgentFile struct {
 	Agent     string // adapter name, e.g. "claude"
 	SessionID string // UUID assigned at spawn time
 	DevPID    string // PID of the dev server process
+	DevPort   string // port allocated for the dev server; empty when no dev server
 	AgentPID  string // PID of the background agent process (headless only)
 	SDD       string // SDD methodology name, e.g. "plain", "speckit"; empty if none
 	// SDDSet is true when the sdd= key was explicitly present in the .agent file,
@@ -58,6 +59,8 @@ func Read(worktreePath string) (AgentFile, error) {
 			af.SessionID = v
 		case "dev-pid":
 			af.DevPID = v
+		case "dev-port":
+			af.DevPort = v
 		case "agent-pid":
 			af.AgentPID = v
 		case "sdd":
@@ -84,6 +87,8 @@ func GetKey(worktreePath, key string) (string, error) {
 		return af.SessionID, nil
 	case "dev-pid":
 		return af.DevPID, nil
+	case "dev-port":
+		return af.DevPort, nil
 	case "agent-pid":
 		return af.AgentPID, nil
 	case "sdd":
@@ -101,6 +106,9 @@ func Write(worktreePath string, af AgentFile) error {
 		"agent=" + af.Agent,
 		"session-id=" + af.SessionID,
 		"dev-pid=" + af.DevPID,
+	}
+	if af.DevPort != "" {
+		lines = append(lines, "dev-port="+af.DevPort)
 	}
 	if af.AgentPID != "" {
 		lines = append(lines, "agent-pid="+af.AgentPID)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -144,6 +144,46 @@ func TestWriteAlwaysIncludesSDD(t *testing.T) {
 	}
 }
 
+func TestDevPortRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := AgentFile{
+		Agent:     "claude",
+		SessionID: "s1",
+		DevPID:    "1234",
+		DevPort:   "3042",
+	}
+	if err := Write(dir, want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.DevPort != want.DevPort {
+		t.Errorf("DevPort: got %q, want %q", got.DevPort, want.DevPort)
+	}
+}
+
+func TestWriteOmitsEmptyDevPort(t *testing.T) {
+	dir := t.TempDir()
+	af := AgentFile{
+		Agent:     "claude",
+		SessionID: "s1",
+		DevPID:    "1234",
+		// DevPort intentionally empty (no dev server)
+	}
+	if err := Write(dir, af); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, FileName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if contains(string(raw), "dev-port=") {
+		t.Error("expected dev-port line to be absent when DevPort is empty")
+	}
+}
+
 func TestReadExtraKeys(t *testing.T) {
 	dir := t.TempDir()
 	content := "agent=claude\nsession-id=s1\ndev-pid=1\ncustom-key=hello\n"


### PR DESCRIPTION
## Summary

Fixes #218.

- Adds `DevPort string` field to `AgentFile` in `internal/state/state.go`, stored as `dev-port=` in the gitignored `.agent` file
- Removes `Port int` from `AgentctlConfig` in `internal/config/config.go` so `agentctl start` no longer writes a runtime value back to the source-controlled `.agentctl.yml`
- Updates the spawn path in `internal/cmd/commands.go` to populate `AgentFile.DevPort` instead of calling `config.Write`

## Test plan

- [x] `TestDevPortRoundTrip` — new: verifies `DevPort` survives a write/read round-trip through `.agent`
- [x] `TestWriteOmitsEmptyDevPort` — new: verifies `dev-port=` line is absent when no dev server is present
- [x] `TestStartDevServer_doesNotDirtyAgentctlYml` — new (replaces `TestStartDevServer_agentctlYml_writesPortBack`): verifies `.agentctl.yml` content is unchanged after `startDevServer`
- [x] All existing `internal/state` and `internal/config` tests pass (`go test ./internal/state/... ./internal/config/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)