### PR TITLE
feat: agentctl dev start — launch dev server in existing worktree

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -3,13 +3,14 @@
 //
 // Command surface:
 //
-//	agentctl start   [--agent name] [--headless] [--sdd=name] <issue> [slug]
-//	agentctl resume  <issue> [feedback]
-//	agentctl discard [issue]
-//	agentctl cleanup [issue | --all]
-//	agentctl status  [--verbose]
-//	agentctl logs    [--lines N] [--no-follow] <issue>
-//	agentctl attach  <issue>
+//	agentctl start      [--agent name] [--headless] [--sdd=name] <issue> [slug]
+//	agentctl resume     <issue> [feedback]
+//	agentctl discard    [issue]
+//	agentctl cleanup    [issue | --all]
+//	agentctl status     [--verbose]
+//	agentctl logs       [--lines N] [--no-follow] <issue>
+//	agentctl attach     <issue>
+//	agentctl dev start  [--quiet] [issue]
 package main
 
 import (
@@ -48,6 +49,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewStatusCmd(),
 		cmd.NewLogsCmd(),
 		cmd.NewAttachCmd(),
+		cmd.NewDevCmd(),
 		cmd.NewStreamLogCmd(),
 		cmd.NewStreamLogOpenHandsCmd(),
 	)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -224,7 +224,7 @@ Error cases:
 |-----------|---------------|
 | `dev_server` not set in `.agentctl.yml` | `dev_server not set in .agentctl.yml — nothing to start` |
 | `.agent` has no port recorded | `no port recorded in .agent — run agentctl start first` |
-| Dev server already running | `dev server already running (PID N) — use agentctl dev stop to restart` |
+| Dev server already running | `dev server already running (PID N) — run agentctl cleanup, then agentctl dev start` |
 | Port already in use | `port N already in use` (with PID if detectable) |
 
 ## Workflows

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -190,6 +190,43 @@ Error cases:
 | `.agent` file missing or no PID | `no agent PID recorded for issue N — was it started headless?` |
 | `agent.log` missing after 10s | `agent log not found — is the agent running? (looked for <path>)` |
 
+### `agentctl dev start`
+
+```bash
+agentctl dev start [issue]
+agentctl dev start [issue] --quiet
+```
+
+Launches the `dev_server` command from `.agentctl.yml` using the port already recorded in `.agent`. Does **not** allocate a new port — use this when the dev server was skipped during `agentctl start` (e.g. `.agentctl.yml` was added mid-PR) or after it crashed.
+
+Run without arguments inside a linked worktree to infer the issue number from the current branch.
+
+Flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--quiet` | `false` | Suppress log streaming; only print the ready URL |
+
+Behavior:
+
+- Reads the port from `.agent` (set by `agentctl start`).
+- Checks that the dev server is not already running; exits 1 if it is.
+- Starts `dev_server` with `{port}` substituted, writing output to `dev.log`.
+- Prints `Dev server ready → http://localhost:<port>` to stdout.
+- Sends an OS notification when ready if `notify: true` in `.agentctl.yml`.
+- Default: streams `dev.log` to stdout until Ctrl+C or the process exits.
+- `--quiet`: prints the URL and exits immediately.
+- Records the new dev server PID in `.agent` so `agentctl cleanup` can tear it down.
+
+Error cases:
+
+| Condition | Error message |
+|-----------|---------------|
+| `dev_server` not set in `.agentctl.yml` | `dev_server not set in .agentctl.yml — nothing to start` |
+| `.agent` has no port recorded | `no port recorded in .agent — run agentctl start first` |
+| Dev server already running | `dev server already running (PID N) — use agentctl dev stop to restart` |
+| Port already in use | `port N already in use` (with PID if detectable) |
+
 ## Workflows
 
 ### Interactive single-issue workflow

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -1138,10 +1139,10 @@ func runDevStart(wtPath string, quiet bool, out io.Writer) error {
 		return fmt.Errorf("updating .agent: %w", err)
 	}
 
-	fmt.Fprintf(out, "Dev server ready → http://localhost:%s\n", af.DevPort)
+	fmt.Fprintf(out, "Dev server: http://localhost:%s (log: %s/dev.log)\n", af.DevPort, wtPath)
 
 	if cfg.Notify {
-		msg := fmt.Sprintf("Dev server ready → http://localhost:%s", af.DevPort)
+		msg := fmt.Sprintf("Dev server: http://localhost:%s", af.DevPort)
 		if quiet {
 			notify.Send("agentctl", msg)
 		} else {
@@ -1157,15 +1158,29 @@ func runDevStart(wtPath string, quiet bool, out io.Writer) error {
 
 // isPortInUse reports whether a process is listening on port.
 // Returns the conflicting PID string if detectable.
+// It uses lsof when available, distinguishing exit-code-1 ("no listeners") from
+// other failures (e.g. lsof absent), and falls back to a cross-platform TCP
+// bind probe when lsof cannot be relied upon.
 func isPortInUse(port string) (pid string, inUse bool) {
-	if err := exec.Command("lsof", fmt.Sprintf("-iTCP:%s", port), "-sTCP:LISTEN").Run(); err != nil {
+	lsofErr := exec.Command("lsof", fmt.Sprintf("-iTCP:%s", port), "-sTCP:LISTEN").Run()
+	if lsofErr == nil {
+		// lsof exited 0 — something is listening on the port.
+		out, _ := exec.Command("lsof", "-t", fmt.Sprintf("-iTCP:%s", port), "-sTCP:LISTEN").Output() //nolint:gosec
+		return strings.TrimSpace(string(out)), true
+	}
+	// lsof exit code 1 means "no matching processes" (port is free).
+	var exitErr *exec.ExitError
+	if errors.As(lsofErr, &exitErr) && exitErr.ExitCode() == 1 {
 		return "", false
 	}
-	out, err := exec.Command("lsof", "-t", fmt.Sprintf("-iTCP:%s", port), "-sTCP:LISTEN").Output() //nolint:gosec
-	if err == nil {
-		pid = strings.TrimSpace(string(out))
+	// lsof unavailable or exited unexpectedly — fall back to a cross-platform TCP bind test.
+	ln, err := net.Listen("tcp", net.JoinHostPort("", port))
+	if err != nil {
+		// Cannot bind — port is already in use.
+		return "", true
 	}
-	return pid, true
+	_ = ln.Close()
+	return "", false
 }
 
 // startDevServerOnPort starts the dev server command from cfg using portStr

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1053,6 +1053,176 @@ func streamLog(wtPath string, lines int, noFollow bool, w io.Writer, logWait tim
 	}
 }
 
+// ─── dev ──────────────────────────────────────────────────────────────────────
+
+// NewDevCmd creates the `dev` subcommand group.
+func NewDevCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "dev",
+		Short: "Dev server management",
+		Long:  `Commands for managing the dev server in a worktree session.`,
+	}
+	c.AddCommand(NewDevStartCmd())
+	return c
+}
+
+// NewDevStartCmd creates the `dev start` subcommand.
+func NewDevStartCmd() *cobra.Command {
+	var quiet bool
+	c := &cobra.Command{
+		Use:   "start [issue]",
+		Short: "Start the dev server in the current worktree",
+		Long: `Launch the dev_server command from .agentctl.yml using the port already
+recorded in .agent. Does not allocate a new port.
+
+Run without arguments inside a linked worktree to infer the issue number
+from the current branch.
+
+By default, streams the dev server's stdout/stderr to the console in
+real time. Use --quiet to suppress log streaming and only print the URL.`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			issue, err := resolveIssueArg("dev start", args)
+			if err != nil {
+				return err
+			}
+			wtPath, err := findWorktreePath(issue)
+			if err != nil {
+				return err
+			}
+			return runDevStart(wtPath, quiet, os.Stdout)
+		},
+	}
+	c.Flags().BoolVar(&quiet, "quiet", false, "Suppress log streaming; only print the ready URL")
+	return c
+}
+
+// runDevStart launches the dev server in wtPath using the port already
+// recorded in the .agent state file. It updates dev-pid in .agent after
+// a successful launch.
+func runDevStart(wtPath string, quiet bool, out io.Writer) error {
+	cfg, err := config.Read(wtPath)
+	if err != nil {
+		return fmt.Errorf("reading .agentctl.yml: %w", err)
+	}
+	if cfg.DevServer == "" {
+		return fmt.Errorf("dev_server not set in .agentctl.yml — nothing to start")
+	}
+
+	af, err := state.Read(wtPath)
+	if err != nil {
+		return err
+	}
+	if af.DevPort == "" {
+		return fmt.Errorf("no port recorded in .agent — run `agentctl start` first")
+	}
+
+	if process.IsAlive(af.DevPID) {
+		return fmt.Errorf("dev server already running (PID %s) — use `agentctl dev stop` to restart", af.DevPID)
+	}
+
+	if conflictPID, inUse := isPortInUse(af.DevPort); inUse {
+		if conflictPID != "" {
+			return fmt.Errorf("port %s already in use by PID %s", af.DevPort, conflictPID)
+		}
+		return fmt.Errorf("port %s already in use", af.DevPort)
+	}
+
+	devPID, err := startDevServerOnPort(wtPath, cfg, af.DevPort, out)
+	if err != nil {
+		return err
+	}
+
+	af.DevPID = devPID
+	if err := state.Write(wtPath, af); err != nil {
+		return fmt.Errorf("updating .agent: %w", err)
+	}
+
+	fmt.Fprintf(out, "Dev server ready → http://localhost:%s\n", af.DevPort)
+
+	if cfg.Notify {
+		go notify.Send("agentctl", fmt.Sprintf("Dev server ready → http://localhost:%s", af.DevPort))
+	}
+
+	if !quiet {
+		return streamDevLog(wtPath, devPID, out)
+	}
+	return nil
+}
+
+// isPortInUse reports whether a process is listening on port.
+// Returns the conflicting PID string if detectable.
+func isPortInUse(port string) (pid string, inUse bool) {
+	if err := exec.Command("lsof", fmt.Sprintf("-iTCP:%s", port), "-sTCP:LISTEN").Run(); err != nil {
+		return "", false
+	}
+	out, err := exec.Command("lsof", "-t", fmt.Sprintf("-iTCP:%s", port), "-sTCP:LISTEN").Output() //nolint:gosec
+	if err == nil {
+		pid = strings.TrimSpace(string(out))
+	}
+	return pid, true
+}
+
+// startDevServerOnPort starts the dev server command from cfg using portStr
+// (already allocated) rather than finding a new port.
+func startDevServerOnPort(dir string, cfg *config.AgentctlConfig, portStr string, out io.Writer) (devPID string, err error) {
+	cmdStr := strings.TrimSpace(strings.ReplaceAll(cfg.DevServer, "{port}", portStr))
+	if cmdStr == "" {
+		return "", fmt.Errorf("dev_server in .agentctl.yml is empty after port substitution")
+	}
+	devLog, err := os.Create(filepath.Join(dir, "dev.log"))
+	if err != nil {
+		return "", err
+	}
+	devCmd := exec.Command("sh", "-c", cmdStr) //nolint:gosec
+	devCmd.Dir = dir
+	devCmd.Stdout = devLog
+	devCmd.Stderr = devLog
+	if err := devCmd.Start(); err != nil {
+		devLog.Close()
+		return "", fmt.Errorf("start dev server: %w", err)
+	}
+	if err := devLog.Close(); err != nil {
+		fmt.Fprintf(out, "warning: close dev log: %v\n", err)
+	}
+	return fmt.Sprintf("%d", devCmd.Process.Pid), nil
+}
+
+// streamDevLog tails dev.log in wtPath and blocks until the dev server
+// process exits or the user sends SIGINT/SIGTERM.
+func streamDevLog(wtPath, devPID string, w io.Writer) error {
+	logPath := filepath.Join(wtPath, "dev.log")
+	tail := exec.Command("tail", "-n", "0", "-F", logPath)
+	tail.Stdout = w
+	tail.Stderr = os.Stderr
+	if err := tail.Start(); err != nil {
+		return fmt.Errorf("tail dev.log: %w", err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-sigCh:
+			signal.Stop(sigCh)
+			_ = tail.Process.Kill()
+			_ = tail.Wait()
+			return nil
+		case <-ticker.C:
+			if !process.IsAlive(devPID) {
+				signal.Stop(sigCh)
+				time.Sleep(200 * time.Millisecond)
+				_ = tail.Process.Kill()
+				_ = tail.Wait()
+				fmt.Fprintln(w, "\ndev server process has exited")
+				return nil
+			}
+		}
+	}
+}
+
 // ─── attach ───────────────────────────────────────────────────────────────────
 
 // NewAttachCmd creates the `attach` subcommand.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1188,7 +1188,7 @@ func startDevServerOnPort(dir string, cfg *config.AgentctlConfig, portStr string
 		return "", fmt.Errorf("start dev server: %w", err)
 	}
 	if err := devLog.Close(); err != nil {
-		fmt.Fprintf(out, "warning: close dev log: %v\n", err)
+		fmt.Fprintf(os.Stderr, "warning: close dev log: %v\n", err)
 	}
 	return fmt.Sprintf("%d", devCmd.Process.Pid), nil
 }

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1141,7 +1141,12 @@ func runDevStart(wtPath string, quiet bool, out io.Writer) error {
 	fmt.Fprintf(out, "Dev server ready → http://localhost:%s\n", af.DevPort)
 
 	if cfg.Notify {
-		go notify.Send("agentctl", fmt.Sprintf("Dev server ready → http://localhost:%s", af.DevPort))
+		msg := fmt.Sprintf("Dev server ready → http://localhost:%s", af.DevPort)
+		if quiet {
+			notify.Send("agentctl", msg)
+		} else {
+			go notify.Send("agentctl", msg)
+		}
 	}
 
 	if !quiet {

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1118,7 +1118,7 @@ func runDevStart(wtPath string, quiet bool, out io.Writer) error {
 	}
 
 	if process.IsAlive(af.DevPID) {
-		return fmt.Errorf("dev server already running (PID %s) — use `agentctl dev stop` to restart", af.DevPID)
+		return fmt.Errorf("dev server already running (PID %s) — stop that process and clear the recorded dev-pid before restarting", af.DevPID)
 	}
 
 	if conflictPID, inUse := isPortInUse(af.DevPort); inUse {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/arun-gupta/agentctl/internal/notify"
+	"github.com/arun-gupta/agentctl/internal/process"
 	"github.com/arun-gupta/agentctl/internal/sdd"
 	"github.com/arun-gupta/agentctl/internal/state"
 )
@@ -4024,4 +4026,125 @@ func TestStartCmd_emptyIssueTokens(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ─── dev start ───────────────────────────────────────────────────────────────
+
+func TestRunDevStart_noDevServerInConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("notify: false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".agent"), []byte("agent=claude\nsession-id=abc\ndev-pid=\ndev-port=3042\nsdd=plain\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err := runDevStart(dir, true, &buf)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "dev_server not set") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunDevStart_noPortInDotAgent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"sleep 1\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".agent"), []byte("agent=claude\nsession-id=abc\ndev-pid=\nsdd=plain\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err := runDevStart(dir, true, &buf)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no port recorded") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunDevStart_alreadyRunning(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"sleep 100\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	selfPID := fmt.Sprintf("%d", os.Getpid())
+	content := "agent=claude\nsession-id=abc\ndev-pid=" + selfPID + "\ndev-port=3042\nsdd=plain\n"
+	if err := os.WriteFile(filepath.Join(dir, ".agent"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err := runDevStart(dir, true, &buf)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "already running") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunDevStart_portInUse(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skip("cannot bind test port:", err)
+	}
+	defer ln.Close()
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"sleep 100\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	content := "agent=claude\nsession-id=abc\ndev-pid=\ndev-port=" + port + "\nsdd=plain\n"
+	if err := os.WriteFile(filepath.Join(dir, ".agent"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err = runDevStart(dir, true, &buf)
+	if err == nil {
+		t.Fatal("expected error for port in use, got nil")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunDevStart_success(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"sleep 100\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	freePort, err := findFreePort(3010, 3100)
+	if err != nil {
+		t.Fatalf("findFreePort: %v", err)
+	}
+	portStr := strconv.Itoa(freePort)
+	content := "agent=claude\nsession-id=test-session\ndev-pid=\ndev-port=" + portStr + "\nsdd=plain\n"
+	if err := os.WriteFile(filepath.Join(dir, ".agent"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runDevStart(dir, true, &buf); err != nil {
+		t.Fatalf("runDevStart: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "http://localhost:"+portStr) {
+		t.Errorf("output missing URL; got: %q", buf.String())
+	}
+
+	af, readErr := state.Read(dir)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if af.DevPID == "" {
+		t.Error("expected dev-pid to be set in .agent after dev start")
+	}
+	if _, err := strconv.Atoi(af.DevPID); err != nil {
+		t.Errorf("dev-pid %q is not a valid integer: %v", af.DevPID, err)
+	}
+	t.Cleanup(func() { process.Kill(af.DevPID) })
 }


### PR DESCRIPTION
## Summary

- Implements `agentctl dev start [--quiet] [issue]` per issue #217
- Reads the port already recorded in `.agent` and launches `dev_server` from `.agentctl.yml` — without allocating a new port
- Solves the case where the dev server was skipped on initial `agentctl start` (e.g. `.agentctl.yml` added mid-PR) without requiring full teardown and recreate

## Behaviour

- Errors if `dev_server` not set in `.agentctl.yml`, `.agent` has no port, dev server already running, or port already in use
- Default: streams `dev.log` to stdout until Ctrl+C or process exits
- `--quiet`: prints `Dev server ready → http://localhost:<port>` and exits
- Sends OS notification if `notify: true` in `.agentctl.yml`
- Records new PID in `.agent` so `agentctl cleanup` tears it down cleanly

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./internal/cmd/ -run TestRunDevStart` — all 5 new tests pass:
  - `TestRunDevStart_noDevServerInConfig`
  - `TestRunDevStart_noPortInDotAgent`
  - `TestRunDevStart_alreadyRunning`
  - `TestRunDevStart_portInUse`
  - `TestRunDevStart_success`
- [ ] `agentctl dev --help` shows `start` subcommand
- [ ] `agentctl dev start --help` shows `--quiet` flag

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)