### PR TITLE
fix: symlink ~/.claude.json into agent home

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2128,8 +2128,8 @@ func isOpenHandsNoise(line string) bool {
 // and returns human-readable text, or "" to skip the event.
 func extractOpenHandsBlock(jsonBlock string) string {
 	var ev struct {
-		Kind   string `json:"kind"`
-		Source string `json:"source"`
+		Kind       string `json:"kind"`
+		Source     string `json:"source"`
 		LLMMessage *struct {
 			Content []struct {
 				Text string `json:"text"`
@@ -2492,21 +2492,32 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	realHome, err := os.UserHomeDir()
 	if err == nil {
-		// Link config files/dirs so git, SSH, OpenHands, and Codex work with real credentials/settings.
-		for _, name := range []string{".gitconfig", ".ssh", ".claude", ".openhands", ".codex"} {
+		// Link config files/dirs so git, SSH, Claude, OpenHands, and Codex work with real credentials/settings.
+		for _, name := range []string{".gitconfig", ".ssh", ".claude", ".claude.json", ".openhands", ".codex"} {
 			src := filepath.Join(realHome, name)
 			dst := filepath.Join(agentHome, name)
 
-			// Skip dst if already present; treat unexpected stat errors as a warning.
-			if _, statErr := os.Lstat(dst); statErr == nil {
-				continue
+			// Keep existing symlinks, but replace stale regular files for entries
+			// that must always point at live host credentials.
+			if dstInfo, statErr := os.Lstat(dst); statErr == nil {
+				if dstInfo.Mode()&os.ModeSymlink != 0 {
+					continue
+				}
+				if name != ".claude.json" {
+					continue
+				}
+				if removeErr := os.Remove(dst); removeErr != nil {
+					fmt.Fprintf(os.Stderr, "agentctl: warning: remove %s: %v\n", dst, removeErr)
+					continue
+				}
 			} else if !os.IsNotExist(statErr) {
 				fmt.Fprintf(os.Stderr, "agentctl: warning: stat %s: %v\n", dst, statErr)
 				continue
 			}
 
 			// Only proceed when src actually exists; warn on unexpected src errors.
-			if _, srcErr := os.Lstat(src); srcErr != nil {
+			srcInfo, srcErr := os.Lstat(src)
+			if srcErr != nil {
 				if !os.IsNotExist(srcErr) {
 					fmt.Fprintf(os.Stderr, "agentctl: warning: stat %s: %v\n", src, srcErr)
 				}
@@ -2515,9 +2526,9 @@ func agentEnv(wtPath string) ([]string, error) {
 
 			if symlinkErr := os.Symlink(src, dst); symlinkErr != nil {
 				// On Windows, symlinks require Developer Mode. Fall back to
-				// copying regular files (e.g. .gitconfig); for directories
-				// (.ssh) emit a warning so failures are diagnosable.
-				if name == ".gitconfig" {
+				// copying regular files; for directories emit a warning so
+				// failures are diagnosable.
+				if !srcInfo.IsDir() {
 					if copyErr := copyFile(src, dst); copyErr != nil {
 						fmt.Fprintf(os.Stderr, "agentctl: warning: copy %s: %v\n", name, copyErr)
 					}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2497,8 +2497,9 @@ func agentEnv(wtPath string) ([]string, error) {
 			src := filepath.Join(realHome, name)
 			dst := filepath.Join(agentHome, name)
 
-			// Keep existing symlinks, but replace stale regular files for entries
-			// that must always point at live host credentials.
+			// Keep existing symlinks, but plan to replace stale regular files for
+			// entries that must always point at live host credentials.
+			var dstNeedsReplacement bool
 			if dstInfo, statErr := os.Lstat(dst); statErr == nil {
 				if dstInfo.Mode()&os.ModeSymlink != 0 {
 					continue
@@ -2506,29 +2507,36 @@ func agentEnv(wtPath string) ([]string, error) {
 				if name != ".claude.json" {
 					continue
 				}
-				if removeErr := os.Remove(dst); removeErr != nil {
-					fmt.Fprintf(os.Stderr, "agentctl: warning: remove %s: %v\n", dst, removeErr)
-					continue
-				}
+				// dst is a regular .claude.json; replace it with a live symlink.
+				dstNeedsReplacement = true
 			} else if !os.IsNotExist(statErr) {
 				fmt.Fprintf(os.Stderr, "agentctl: warning: stat %s: %v\n", dst, statErr)
 				continue
 			}
 
 			// Only proceed when src actually exists; warn on unexpected src errors.
-			srcInfo, srcErr := os.Lstat(src)
-			if srcErr != nil {
+			// Removal of a stale dst is deferred until after src existence is confirmed.
+			if _, srcErr := os.Lstat(src); srcErr != nil {
 				if !os.IsNotExist(srcErr) {
 					fmt.Fprintf(os.Stderr, "agentctl: warning: stat %s: %v\n", src, srcErr)
 				}
 				continue
 			}
 
+			// src exists; now it is safe to remove the stale dst.
+			if dstNeedsReplacement {
+				if removeErr := os.Remove(dst); removeErr != nil {
+					fmt.Fprintf(os.Stderr, "agentctl: warning: remove %s: %v\n", dst, removeErr)
+					continue
+				}
+			}
+
 			if symlinkErr := os.Symlink(src, dst); symlinkErr != nil {
 				// On Windows, symlinks require Developer Mode. Fall back to
 				// copying regular files; for directories emit a warning so
 				// failures are diagnosable.
-				if !srcInfo.IsDir() {
+				// Use os.Stat to follow symlinks when determining directory-ness.
+				if srcStat, statErr := os.Stat(src); statErr != nil || !srcStat.IsDir() {
 					if copyErr := copyFile(src, dst); copyErr != nil {
 						fmt.Fprintf(os.Stderr, "agentctl: warning: copy %s: %v\n", name, copyErr)
 					}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2146,15 +2146,28 @@ func TestAgentEnv_claudeJSONSymlinkReplacesStaleFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf(".agent-home/.claude.json missing: %v", err)
 	}
-	if fi.Mode()&os.ModeSymlink == 0 {
-		t.Fatal(".agent-home/.claude.json must be a symlink")
+	if fi.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(claudeJSONDst)
+		if err != nil {
+			t.Fatalf("readlink .agent-home/.claude.json: %v", err)
+		}
+		if target != claudeJSONSrc {
+			t.Errorf(".agent-home/.claude.json symlink target = %q; want %q", target, claudeJSONSrc)
+		}
+		return
 	}
-	target, err := os.Readlink(claudeJSONDst)
+
+	// Symlinks not supported (e.g. Windows without Developer Mode); verify copy fallback.
+	got, err := os.ReadFile(claudeJSONDst)
 	if err != nil {
-		t.Fatalf("readlink .agent-home/.claude.json: %v", err)
+		t.Fatalf("read .agent-home/.claude.json: %v", err)
 	}
-	if target != claudeJSONSrc {
-		t.Errorf(".agent-home/.claude.json symlink target = %q; want %q", target, claudeJSONSrc)
+	want, err := os.ReadFile(claudeJSONSrc)
+	if err != nil {
+		t.Fatalf("read source .claude.json: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf(".agent-home/.claude.json contents = %q; want %q", string(got), string(want))
 	}
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2116,6 +2116,48 @@ func TestAgentEnv_codexSymlink(t *testing.T) {
 	}
 }
 
+// TestAgentEnv_claudeJSONSymlinkReplacesStaleFile verifies that agentEnv
+// replaces a stale regular .agent-home/.claude.json with a symlink to the real
+// ~/.claude.json so Claude keeps using live host credentials.
+func TestAgentEnv_claudeJSONSymlinkReplacesStaleFile(t *testing.T) {
+	fakeHome := t.TempDir()
+	claudeJSONSrc := filepath.Join(fakeHome, ".claude.json")
+	if err := os.WriteFile(claudeJSONSrc, []byte("{\"token\":\"live\"}\n"), 0o600); err != nil {
+		t.Fatalf("setup fake HOME: %v", err)
+	}
+
+	t.Setenv("HOME", fakeHome)
+
+	dir := t.TempDir()
+	agentHome := filepath.Join(dir, ".agent-home")
+	if err := os.MkdirAll(agentHome, 0o755); err != nil {
+		t.Fatalf("setup agent HOME: %v", err)
+	}
+	claudeJSONDst := filepath.Join(agentHome, ".claude.json")
+	if err := os.WriteFile(claudeJSONDst, []byte("{\"token\":\"stale\"}\n"), 0o600); err != nil {
+		t.Fatalf("write stale claude config: %v", err)
+	}
+
+	if _, err := agentEnv(dir); err != nil {
+		t.Fatalf("agentEnv: %v", err)
+	}
+
+	fi, err := os.Lstat(claudeJSONDst)
+	if err != nil {
+		t.Fatalf(".agent-home/.claude.json missing: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal(".agent-home/.claude.json must be a symlink")
+	}
+	target, err := os.Readlink(claudeJSONDst)
+	if err != nil {
+		t.Fatalf("readlink .agent-home/.claude.json: %v", err)
+	}
+	if target != claudeJSONSrc {
+		t.Errorf(".agent-home/.claude.json symlink target = %q; want %q", target, claudeJSONSrc)
+	}
+}
+
 // fakeGHBin writes a small shell script to dir/gh that outputs token when
 // called as "gh auth token", and updates PATH so exec.Command("gh", …) finds it.
 func fakeGHBin(t *testing.T, token string) {


### PR DESCRIPTION
Summary:
- add .claude.json to the agent HOME symlink set
- replace a stale regular .agent-home/.claude.json with a live symlink to the real home file
- cover the regression with a focused agentEnv test

Testing:
- go test ./internal/cmd -run TestAgentEnv_ -count=1
- GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go build ./...
- GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go vet ./...
- GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./... (still hits pre-existing TestResolveIssueArg_noArgs_notLinked)

Closes #222