### PR TITLE
[codex] fix failed headless starts for #221

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1897,7 +1897,9 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 		timer := time.NewTimer(500 * time.Millisecond)
 		select {
 		case <-exitCh:
-			timer.Stop()
+			if !timer.Stop() {
+				<-timer.C
+			}
 			if agentExitErr != nil {
 				exitCode := "unknown"
 				var exitErr *exec.ExitError

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -178,6 +178,13 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 	if err := git.AddWorktree(repoRoot, wtPath, branch); err != nil {
 		return fmt.Errorf("git worktree add: %w", err)
 	}
+	cleanupOnError := true
+	defer func() {
+		if !cleanupOnError {
+			return
+		}
+		_ = cleanupFailedStart(repoRoot, wtPath, branch, "")
+	}()
 
 	// Seed .env.local from main repo if present (strips any existing PORT= line).
 	if err := seedEnvLocal(filepath.Join(repoRoot, ".env.local"), filepath.Join(wtPath, ".env.local")); err != nil {
@@ -219,7 +226,16 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 		kickoff = m.KickoffPrompt(issueNum, portStr)
 	}
 
-	return launchAgent(agentName, wtPath, issueNum, portStr, sessionID, kickoff, sddName, headless, quiet, sendNotify, out)
+	if err := launchAgent(agentName, wtPath, issueNum, portStr, sessionID, kickoff, sddName, headless, quiet, sendNotify, out); err != nil {
+		cleanupOnError = false
+		if cleanupErr := cleanupFailedStart(repoRoot, wtPath, branch, devPID); cleanupErr != nil {
+			return fmt.Errorf("%w\ncleanup warning: %v", err, cleanupErr)
+		}
+		return err
+	}
+
+	cleanupOnError = false
+	return nil
 }
 
 // runBatch provisions worktrees and launches agents for multiple issues
@@ -1441,6 +1457,40 @@ func worktreeExistsError(wtPath, issueNum string) error {
 	return fmt.Errorf("Worktree already exists for issue %s.\nWorktree: %s\n\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, issueNum)
 }
 
+func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
+	process.Kill(devPID)
+
+	var errs []string
+	if _, err := os.Stat(wtPath); err == nil {
+		if rmErr := git.RemoveWorktree(repoRoot, wtPath); rmErr != nil {
+			wts, listErr := git.LinkedWorktrees(repoRoot)
+			registered := listErr == nil && false
+			for _, wt := range wts {
+				if wt.Path == wtPath {
+					registered = true
+					break
+				}
+			}
+			if registered {
+				errs = append(errs, rmErr.Error())
+			} else if removeErr := os.RemoveAll(wtPath); removeErr != nil {
+				errs = append(errs, removeErr.Error())
+			}
+		}
+	}
+
+	if git.BranchExists(repoRoot, branch) {
+		if err := git.DeleteLocalBranch(repoRoot, branch); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}
+
 // slugFromIssue fetches the GitHub issue title and converts it to a slug.
 // issueArg may be a bare issue number or a full GitHub issue URL; both are
 // accepted by `gh issue view`.
@@ -1838,6 +1888,19 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 	}
 
 	if headless {
+		select {
+		case <-exitCh:
+			if agentExitErr != nil {
+				exitCode := "unknown"
+				var exitErr *exec.ExitError
+				if errors.As(agentExitErr, &exitErr) {
+					exitCode = strconv.Itoa(exitErr.ExitCode())
+				}
+				return fmt.Errorf("Agent exited immediately (code %s) — check credentials or run `agentctl logs %s` for details.", exitCode, issue)
+			}
+		case <-time.After(500 * time.Millisecond):
+		}
+
 		fmt.Fprintf(out, "Agent PID %d — log: %s\n", pid, logPath)
 		fmt.Fprintf(out, "agentctl logs %s      # follow log\n", issue)
 		fmt.Fprintf(out, "agentctl attach %s    # stream live and wait\n", issue)
@@ -2128,8 +2191,8 @@ func isOpenHandsNoise(line string) bool {
 // and returns human-readable text, or "" to skip the event.
 func extractOpenHandsBlock(jsonBlock string) string {
 	var ev struct {
-		Kind   string `json:"kind"`
-		Source string `json:"source"`
+		Kind       string `json:"kind"`
+		Source     string `json:"source"`
 		LLMMessage *struct {
 			Content []struct {
 				Text string `json:"text"`

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -183,7 +183,9 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 		if !cleanupOnError {
 			return
 		}
-		_ = cleanupFailedStart(repoRoot, wtPath, branch, "")
+		if cleanupErr := cleanupFailedStart(repoRoot, wtPath, branch, ""); cleanupErr != nil {
+			fmt.Fprintf(out, "Warning: failed to clean up worktree after start failure (path: %s, branch: %s): %v\n", wtPath, branch, cleanupErr)
+		}
 	}()
 
 	// Seed .env.local from main repo if present (strips any existing PORT= line).
@@ -1464,17 +1466,21 @@ func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
 	if _, err := os.Stat(wtPath); err == nil {
 		if rmErr := git.RemoveWorktree(repoRoot, wtPath); rmErr != nil {
 			wts, listErr := git.LinkedWorktrees(repoRoot)
-			registered := listErr == nil && false
-			for _, wt := range wts {
-				if wt.Path == wtPath {
-					registered = true
-					break
+			registered := false
+			if listErr != nil {
+				errs = append(errs, rmErr.Error(), listErr.Error())
+			} else {
+				for _, wt := range wts {
+					if wt.Path == wtPath {
+						registered = true
+						break
+					}
 				}
-			}
-			if registered {
-				errs = append(errs, rmErr.Error())
-			} else if removeErr := os.RemoveAll(wtPath); removeErr != nil {
-				errs = append(errs, removeErr.Error())
+				if registered {
+					errs = append(errs, rmErr.Error())
+				} else if removeErr := os.RemoveAll(wtPath); removeErr != nil {
+					errs = append(errs, removeErr.Error())
+				}
 			}
 		}
 	}
@@ -1888,8 +1894,10 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 	}
 
 	if headless {
+		timer := time.NewTimer(500 * time.Millisecond)
 		select {
 		case <-exitCh:
+			timer.Stop()
 			if agentExitErr != nil {
 				exitCode := "unknown"
 				var exitErr *exec.ExitError
@@ -1898,7 +1906,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 				}
 				return fmt.Errorf("Agent exited immediately (code %s) — check credentials or run `agentctl logs %s` for details.", exitCode, issue)
 			}
-		case <-time.After(500 * time.Millisecond):
+		case <-timer.C:
 		}
 
 		fmt.Fprintf(out, "Agent PID %d — log: %s\n", pid, logPath)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/arun-gupta/agentctl/internal/git"
 	"github.com/arun-gupta/agentctl/internal/notify"
 	"github.com/arun-gupta/agentctl/internal/sdd"
 	"github.com/arun-gupta/agentctl/internal/state"
@@ -410,6 +411,7 @@ func TestResolveIssueArg_withArg(t *testing.T) {
 
 func TestResolveIssueArg_noArgs_notLinked(t *testing.T) {
 	// Running from the primary worktree (not a linked one) must return an error.
+	chdirTemp(t, t.TempDir())
 	_, err := resolveIssueArg("test", []string{})
 	if err == nil {
 		t.Error("expected error when no arg given and not inside a linked worktree")
@@ -851,6 +853,7 @@ func initGitRepoWithBareOrigin(t *testing.T) string {
 
 	gitRun(t, repo, "config", "user.email", "test@example.com")
 	gitRun(t, repo, "config", "user.name", "Test")
+	gitRun(t, repo, "config", "commit.gpgsign", "false")
 	return repo
 }
 
@@ -1658,6 +1661,27 @@ func TestLaunchAgent_nonZeroExitLogsToStderr(t *testing.T) {
 	}
 }
 
+func TestLaunchAgent_headless_immediateNonZeroExitReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	writeLocalAdapter(t, dir, "falseagent", "binary: false\n")
+	chdirTemp(t, dir)
+
+	var out bytes.Buffer
+	err := launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, false, &out)
+	if err == nil {
+		t.Fatal("expected error for immediate non-zero headless exit, got nil")
+	}
+	if !strings.Contains(err.Error(), "Agent exited immediately") {
+		t.Fatalf("expected immediate-exit error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "agentctl logs 42") {
+		t.Errorf("expected logs hint in error, got: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("headless immediate-exit path should not print success hints, got: %q", out.String())
+	}
+}
+
 func TestLaunchAgent_nonHeadless_nonZeroExitPrintsErrorHint(t *testing.T) {
 	dir := t.TempDir()
 	writeLocalAdapter(t, dir, "falseagent", "binary: false\n")
@@ -1696,6 +1720,40 @@ func TestAgentResume_unknownAdapter(t *testing.T) {
 	err := agentResume("nonexistent-xyz-abc", dir, "42", "sess-123", "my feedback", true, false, false)
 	if err == nil {
 		t.Error("expected error for unknown adapter")
+	}
+}
+
+func TestStartOne_headlessImmediateExitCleansUpWorktree(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	writeLocalAdapter(t, repo, "falseagent", "binary: false\n")
+	chdirTemp(t, repo)
+
+	var out bytes.Buffer
+	err := startOne("42", "plain-fails", "falseagent", "", true, false, false, &out)
+	if err == nil {
+		t.Fatal("expected startOne to fail when headless agent exits immediately")
+	}
+	if !strings.Contains(err.Error(), "Agent exited immediately") {
+		t.Fatalf("expected immediate-exit error, got: %v", err)
+	}
+
+	wtPath := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-42-plain-fails")
+	if _, statErr := os.Stat(wtPath); !os.IsNotExist(statErr) {
+		t.Fatalf("worktree path should be removed after failed start, stat err=%v", statErr)
+	}
+
+	if git.BranchExists(repo, "42-plain-fails") {
+		t.Fatal("local branch should be removed after failed start")
+	}
+
+	wts, wtErr := git.LinkedWorktrees(repo)
+	if wtErr != nil {
+		t.Fatalf("LinkedWorktrees: %v", wtErr)
+	}
+	for _, wt := range wts {
+		if wt.Path == wtPath {
+			t.Fatalf("worktree %s should not remain registered after failed start", wtPath)
+		}
 	}
 }
 
@@ -3710,6 +3768,7 @@ func initGitRepoForStale(t *testing.T) string {
 	gitRun("init")
 	gitRun("config", "user.email", "test@example.com")
 	gitRun("config", "user.name", "Test")
+	gitRun("config", "commit.gpgsign", "false")
 	if err := os.WriteFile(filepath.Join(dir, "README"), []byte("test\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -27,6 +27,7 @@ func initRepo(t *testing.T) string {
 	gitRun("init")
 	gitRun("config", "user.email", "test@example.com")
 	gitRun("config", "user.name", "Test")
+	gitRun("config", "commit.gpgsign", "false")
 	if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

This fixes the headless startup path for issue #221.

When the launched agent process exits immediately with a non-zero status, `agentctl start` now fails fast with a clear error instead of printing normal success hints.

The startup path also cleans up the just-created worktree and local branch so a failed launch does not leave a dead worktree behind.

## Root cause

`agentctl` was treating headless launch as successful as soon as the child process started, even if the agent exited almost immediately afterward with an authentication or other startup failure.

That made `--sdd=plain` look suspicious even though the real failure was the external agent CLI exiting in the headless environment.

## Changes

- add a short immediate-exit check in headless `launchAgent`
- return a clear startup error that points users to `agentctl logs <issue>`
- clean up the created worktree and local branch on failed startup after worktree creation
- add regression coverage for the immediate non-zero exit path
- harden git-related tests against local GPG-signing config and linked-worktree assumptions

## Validation

- `go test ./internal/cmd -run 'TestLaunchAgent_headless_immediateNonZeroExitReturnsError|TestStartOne_headlessImmediateExitCleansUpWorktree'`
- `go test ./...`
- `go build ./...`
- `go vet ./...`

Closes #221