### PR TITLE
fix: improve headless UX — resume hints, contextual exit message, spec path in notification

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2250,12 +2250,12 @@ func sendCompletionNotification(issue, wtPath, sddName string, exitErr error) {
 	if branch != "" {
 		branchPart = " (" + branch + ")"
 	}
+	specPath := findSpecPath(wtPath, issue)
 	var message string
 	switch {
 	case exitErr != nil:
 		message = fmt.Sprintf("Agent failed — issue #%s%s: check agentctl logs %s", issue, branchPart, issue)
-	case sddName != "" && findSpecPath(wtPath, issue) != "":
-		specPath := findSpecPath(wtPath, issue)
+	case sddName != "" && specPath != "":
 		message = fmt.Sprintf("Spec ready for review — issue #%s%s: %s — agentctl resume %s", issue, branchPart, specPath, issue)
 	default:
 		message = fmt.Sprintf("Agent finished — issue #%s%s: succeeded", issue, branchPart)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1003,13 +1003,13 @@ func runLogs(issue string, lines int, noFollow bool, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return streamLog(wtPath, lines, noFollow, w, 10*time.Second)
+	return streamLog(wtPath, issue, lines, noFollow, w, 10*time.Second)
 }
 
 // streamLog is the inner implementation of the logs command.
 // logWait controls how long to wait for agent.log to appear; callers should
 // pass 10*time.Second in production and a short duration in tests.
-func streamLog(wtPath string, lines int, noFollow bool, w io.Writer, logWait time.Duration) error {
+func streamLog(wtPath, issue string, lines int, noFollow bool, w io.Writer, logWait time.Duration) error {
 	logPath := filepath.Join(wtPath, "agent.log")
 	if err := waitForFile(logPath, logWait); err != nil {
 		return fmt.Errorf("agent log not found — is the agent running? (looked for %s)", logPath)
@@ -1065,7 +1065,12 @@ func streamLog(wtPath string, lines int, noFollow bool, w io.Writer, logWait tim
 				time.Sleep(200 * time.Millisecond) // drain any final log writes
 				_ = tail.Process.Kill()
 				_ = tail.Wait()
-				fmt.Fprintln(w, "\nagent process has exited — use `agentctl attach <issue>` to see the full log or `agentctl resume <issue>` to continue")
+				af2, _ := state.Read(wtPath)
+				if af2.SDD != "" && findSpecPath(wtPath, issue) != "" {
+					fmt.Fprintf(w, "\nSpec ready for review — agentctl resume %s\n", issue)
+				} else {
+					fmt.Fprintf(w, "\nagent process has exited\n")
+				}
 				return nil
 			}
 		}
@@ -2096,7 +2101,12 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 				if errors.As(agentExitErr, &exitErr) {
 					exitCode = strconv.Itoa(exitErr.ExitCode())
 				}
-				return fmt.Errorf("Agent exited immediately (code %s) — check credentials or run `agentctl logs %s` for details.", exitCode, issue)
+				// Give the detached stream-log converter a moment to flush output.
+				time.Sleep(200 * time.Millisecond)
+				if content, readErr := os.ReadFile(logPath); readErr == nil && len(content) > 0 {
+					fmt.Fprintf(out, "%s\n", content)
+				}
+				return fmt.Errorf("Agent exited immediately (code %s) — re-run without --headless to see live output.", exitCode)
 			}
 		case <-timer.C:
 		}
@@ -2245,7 +2255,8 @@ func sendCompletionNotification(issue, wtPath, sddName string, exitErr error) {
 	case exitErr != nil:
 		message = fmt.Sprintf("Agent failed — issue #%s%s: check agentctl logs %s", issue, branchPart, issue)
 	case sddName != "" && findSpecPath(wtPath, issue) != "":
-		message = fmt.Sprintf("Spec ready for review — issue #%s%s: run agentctl resume %s", issue, branchPart, issue)
+		specPath := findSpecPath(wtPath, issue)
+		message = fmt.Sprintf("Spec ready for review — issue #%s%s: %s — agentctl resume %s", issue, branchPart, specPath, issue)
 	default:
 		message = fmt.Sprintf("Agent finished — issue #%s%s: succeeded", issue, branchPart)
 	}
@@ -3092,7 +3103,9 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 
 	if headless {
 		fmt.Printf("Released pause for issue %s; Stage 2 running in background.\n", issue)
-		fmt.Printf("Tail: %s\n", logPath)
+		fmt.Printf("agentctl logs %s      # follow log\n", issue)
+		fmt.Printf("agentctl attach %s    # stream live and wait\n", issue)
+		fmt.Printf("agentctl discard %s   # abandon\n", issue)
 		if sendNotify {
 			maybeFireTestNotification(issue, os.Stdout)
 			go func() {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1806,12 +1806,15 @@ func TestAgentResume_headless_hints(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		r.Close()
+		os.Stdout = oldStdout
+	})
 	os.Stdout = w
 
 	resumeErr := agentResume("echoagent", dir, "42", "sess-123", "my feedback", true, false, false)
 
 	w.Close()
-	os.Stdout = oldStdout
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, r); err != nil {
 		t.Fatal(err)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1035,6 +1035,9 @@ func TestSendCompletionNotification_sddSpecReady(t *testing.T) {
 	if !strings.Contains(got[1], "agentctl resume 46") {
 		t.Errorf("SDD notify message must include resume command, got: %q", got[1])
 	}
+	if !strings.Contains(got[1], "spec.md") {
+		t.Errorf("SDD notify message must include spec path, got: %q", got[1])
+	}
 }
 
 // TestSendCompletionNotification_nonSDD verifies the generic finish message.
@@ -1676,11 +1679,8 @@ func TestLaunchAgent_headless_immediateNonZeroExitReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "Agent exited immediately") {
 		t.Fatalf("expected immediate-exit error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "agentctl logs 42") {
-		t.Errorf("expected logs hint in error, got: %v", err)
-	}
-	if out.Len() != 0 {
-		t.Errorf("headless immediate-exit path should not print success hints, got: %q", out.String())
+	if !strings.Contains(err.Error(), "--headless") {
+		t.Errorf("expected --headless hint in error, got: %v", err)
 	}
 }
 
@@ -1790,6 +1790,41 @@ func TestAgentResume_headless_success(t *testing.T) {
 	}
 	if !strings.Contains(string(logData), "sess-123") {
 		t.Fatalf("agent.log missing resumed session output:\n%s", string(logData))
+	}
+}
+
+// TestAgentResume_headless_hints verifies that agentctl resume --headless prints
+// actionable follow-up hints (logs, attach, discard) rather than just the tail path.
+func TestAgentResume_headless_hints(t *testing.T) {
+	dir := t.TempDir()
+	writeLocalAdapter(t, dir, "echoagent", "binary: echo\nsession: --session\n")
+	chdirTemp(t, dir)
+
+	// Capture os.Stdout because agentResume uses fmt.Printf.
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	resumeErr := agentResume("echoagent", dir, "42", "sess-123", "my feedback", true, false, false)
+
+	w.Close()
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+
+	if resumeErr != nil {
+		t.Fatalf("agentResume headless: %v", resumeErr)
+	}
+	out := buf.String()
+	for _, hint := range []string{"agentctl logs 42", "agentctl attach 42", "agentctl discard 42"} {
+		if !strings.Contains(out, hint) {
+			t.Errorf("expected hint %q in resume headless output; got: %q", hint, out)
+		}
 	}
 }
 
@@ -2326,7 +2361,7 @@ func TestStreamLog_fileExists(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := streamLog(dir, 50, true, &buf, 100*time.Millisecond); err != nil {
+	if err := streamLog(dir, "42", 50, true, &buf, 100*time.Millisecond); err != nil {
 		t.Fatalf("streamLog: %v", err)
 	}
 	out := buf.String()
@@ -2340,7 +2375,7 @@ func TestStreamLog_fileExists(t *testing.T) {
 func TestStreamLog_fileMissing(t *testing.T) {
 	dir := t.TempDir()
 	var buf bytes.Buffer
-	err := streamLog(dir, 50, true, &buf, 50*time.Millisecond)
+	err := streamLog(dir, "42", 50, true, &buf, 50*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected error when agent.log is missing")
 	}
@@ -2379,7 +2414,7 @@ func TestStreamLog_followExitsOnProcessDeath(t *testing.T) {
 	var buf bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- streamLog(dir, 50, false, &buf, 100*time.Millisecond)
+		done <- streamLog(dir, "42", 50, false, &buf, 100*time.Millisecond)
 	}()
 
 	select {
@@ -2393,6 +2428,58 @@ func TestStreamLog_followExitsOnProcessDeath(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("streamLog did not return within 5s after agent process exited")
+	}
+}
+
+// TestStreamLog_followExitMessage_sdd verifies that streamLog prints the spec
+// ready hint when the agent exits and an SDD spec file is present.
+func TestStreamLog_followExitMessage_sdd(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "agent.log")
+	if err := os.WriteFile(logPath, []byte("agent started\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".agent"), []byte("agent=claude\nsdd=plain\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "specs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "specs", "spec.md"), []byte("# spec\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("could not start helper process: %v", err)
+	}
+	pid := strconv.Itoa(cmd.Process.Pid)
+	_ = cmd.Wait()
+
+	if err := state.AppendKey(dir, "agent-pid", pid); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- streamLog(dir, "42", 50, false, &buf, 100*time.Millisecond)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("streamLog: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "Spec ready for review") {
+			t.Errorf("expected 'Spec ready for review' exit message in SDD mode; got: %q", out)
+		}
+		if !strings.Contains(out, "agentctl resume 42") {
+			t.Errorf("expected 'agentctl resume 42' hint; got: %q", out)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("streamLog did not return within 5s")
 	}
 }
 
@@ -2417,7 +2504,7 @@ func TestStreamLog_followExitsWhenPIDAppearsLate(t *testing.T) {
 	var buf bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- streamLog(dir, 50, false, &buf, 100*time.Millisecond)
+		done <- streamLog(dir, "42", 50, false, &buf, 100*time.Millisecond)
 	}()
 
 	// Write the dead PID after streamLog has started so the re-read logic


### PR DESCRIPTION
## Summary

- **Immediate exit error**: when a headless agent exits within 500 ms, print `agent.log` content inline before worktree cleanup (so the error is visible) and change the error message from \"run \`agentctl logs\`\" (which fails because the worktree is gone) to \"re-run without --headless\"
- **Resume hints**: \`agentctl resume --headless\` now prints the same \`agentctl logs / attach / discard\` hints as \`agentctl start --headless\`
- **Contextual exit message**: \`agentctl logs\` exit message is now context-aware — \"Spec ready for review — agentctl resume \<issue\>\" in SDD mode; \"agent process has exited\" otherwise (removes the misleading \"use agentctl resume to continue\" hint shown even after a successful PR)
- **Spec path in notification**: SDD completion notification now includes the spec file path so users know where to look without digging through logs

## Test plan

- [ ] `go test ./...` — all pass
- [ ] `agentctl start <issue> --sdd=plain --headless` then `agentctl resume <issue> --headless` shows logs/attach/discard hints
- [ ] `agentctl logs <issue>` shows \"Spec ready for review\" when agent pauses in SDD mode
- [ ] SDD desktop notification includes spec file path

🤖 Generated with [Claude Code](https://claude.com/claude-code)