### PR TITLE
docs: fix stale comment on startDevServer

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1760,8 +1760,8 @@ func seedEnvLocal(src, dst string) error {
 //  1. .agentctl.yml with dev_server field  → run that command with {port} substituted
 //  2. otherwise                            → silently skip, return ("","",nil)
 //
-// On success the allocated port is written back to .agentctl.yml so it serves
-// as the single source of truth for all agentctl repo config.
+// On success the URL is printed to out and the PID/port are returned to the
+// caller for storage in the .agent state file. .agentctl.yml is not modified.
 func startDevServer(dir string, out io.Writer) (devPID, portStr string, err error) {
 	cfg, err := config.Read(dir)
 	if err != nil {


### PR DESCRIPTION
## Summary

The doc comment on `startDevServer` claimed the allocated port was written back to `.agentctl.yml`. That was never true — the actual behaviour is:
- URL is printed to `out` (`Dev server: http://localhost:<port>`)
- PID and port are returned to the caller and stored in the `.agent` state file
- `.agentctl.yml` is not modified at runtime (it is a static config file)

## Test plan
- [ ] Comment-only change, no behaviour affected — `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)