### PR TITLE
fix: detach dev server process and guard .agent-home from build tools

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2814,7 +2814,7 @@ func agentEnv(wtPath string) ([]string, error) {
 			}
 			if !hasAgentHomeExclude {
 				updatedContent := content
-				if len(updatedContent) > 0 && !bytes.HasSuffix(updatedContent, []byte("\n")) {
+				if !bytes.HasSuffix(updatedContent, []byte("\n")) {
 					updatedContent = append(updatedContent, '\n')
 				}
 				updatedContent = append(updatedContent, []byte(".agent-home\n")...)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1224,6 +1224,7 @@ func startDevServerOnPort(dir string, cfg *config.AgentctlConfig, portStr string
 	devCmd.Dir = dir
 	devCmd.Stdout = devLog
 	devCmd.Stderr = devLog
+	detachProcess(devCmd)
 	if err := devCmd.Start(); err != nil {
 		devLog.Close()
 		return "", fmt.Errorf("start dev server: %w", err)
@@ -1798,6 +1799,7 @@ func startCustomDevServer(dir string, cfg *config.AgentctlConfig, out io.Writer)
 	devCmd.Dir = dir
 	devCmd.Stdout = devLog
 	devCmd.Stderr = devLog
+	detachProcess(devCmd)
 	if err := devCmd.Start(); err != nil {
 		devLog.Close()
 		return "", "", fmt.Errorf("start dev server: %w", err)
@@ -2768,6 +2770,30 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	if err := os.MkdirAll(agentHome, 0o755); err != nil {
 		return nil, fmt.Errorf("agentEnv: create agent home dir: %w", err)
+	}
+
+	// Write a .gitignore that ignores all contents of .agent-home. This
+	// prevents build tools that respect .gitignore (e.g. Turbopack) from
+	// following symlinks inside here that point outside the project root.
+	gitignorePath := filepath.Join(agentHome, ".gitignore")
+	if _, err := os.Stat(gitignorePath); os.IsNotExist(err) {
+		_ = os.WriteFile(gitignorePath, []byte("*\n"), 0o644)
+	}
+
+	// Also add .agent-home to the worktree-local git exclude so it doesn't
+	// appear in git status. This file lives in the worktree's own git metadata
+	// dir and is never committed.
+	if out, err := exec.Command("git", "-C", wtPath, "rev-parse", "--git-dir").Output(); err == nil {
+		gitDir := strings.TrimSpace(string(out))
+		if !filepath.IsAbs(gitDir) {
+			gitDir = filepath.Join(wtPath, gitDir)
+		}
+		excludePath := filepath.Join(gitDir, "info", "exclude")
+		if content, err := os.ReadFile(excludePath); err == nil {
+			if !strings.Contains(string(content), ".agent-home") {
+				_ = os.WriteFile(excludePath, append(content, []byte(".agent-home\n")...), 0o644)
+			}
+		}
 	}
 
 	realHome, err := os.UserHomeDir()

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2775,9 +2775,24 @@ func agentEnv(wtPath string) ([]string, error) {
 	// Write a .gitignore that ignores all contents of .agent-home. This
 	// prevents build tools that respect .gitignore (e.g. Turbopack) from
 	// following symlinks inside here that point outside the project root.
+	// Use Lstat + O_EXCL so a malicious repo cannot plant a symlink at
+	// .agent-home/.gitignore and redirect our write to a path outside the
+	// worktree.
 	gitignorePath := filepath.Join(agentHome, ".gitignore")
-	if _, err := os.Stat(gitignorePath); os.IsNotExist(err) {
-		_ = os.WriteFile(gitignorePath, []byte("*\n"), 0o644)
+	if fi, err := os.Lstat(gitignorePath); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("agentEnv: .agent-home/.gitignore is a symlink; refusing to write")
+		}
+	} else if os.IsNotExist(err) {
+		f, createErr := os.OpenFile(gitignorePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if createErr == nil {
+			_, _ = f.Write([]byte("*\n"))
+			_ = f.Close()
+		} else if !errors.Is(createErr, os.ErrExist) {
+			fmt.Fprintf(os.Stderr, "agentctl: warning: failed to create %s: %v\n", gitignorePath, createErr)
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "agentctl: warning: failed to stat %s: %v\n", gitignorePath, err)
 	}
 
 	// Also add .agent-home to the worktree-local git exclude so it doesn't
@@ -2790,8 +2805,20 @@ func agentEnv(wtPath string) ([]string, error) {
 		}
 		excludePath := filepath.Join(gitDir, "info", "exclude")
 		if content, err := os.ReadFile(excludePath); err == nil {
-			if !strings.Contains(string(content), ".agent-home") {
-				_ = os.WriteFile(excludePath, append(content, []byte(".agent-home\n")...), 0o644)
+			hasAgentHomeExclude := false
+			for _, line := range strings.Split(string(content), "\n") {
+				if strings.TrimSpace(line) == ".agent-home" {
+					hasAgentHomeExclude = true
+					break
+				}
+			}
+			if !hasAgentHomeExclude {
+				updatedContent := content
+				if len(updatedContent) > 0 && !bytes.HasSuffix(updatedContent, []byte("\n")) {
+					updatedContent = append(updatedContent, '\n')
+				}
+				updatedContent = append(updatedContent, []byte(".agent-home\n")...)
+				_ = os.WriteFile(excludePath, updatedContent, 0o644)
 			}
 		}
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2355,6 +2355,146 @@ func TestAgentEnv_replacesEmptyToken(t *testing.T) {
 	t.Error("GITHUB_TOKEN not found in env at all")
 }
 
+// TestAgentEnv_gitignoreCreated verifies that agentEnv writes "*\n" into
+// .agent-home/.gitignore when it does not yet exist.
+func TestAgentEnv_gitignoreCreated(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := agentEnv(dir); err != nil {
+		t.Fatalf("agentEnv: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, ".agent-home", ".gitignore"))
+	if err != nil {
+		t.Fatalf(".agent-home/.gitignore missing: %v", err)
+	}
+	if string(got) != "*\n" {
+		t.Errorf(".agent-home/.gitignore = %q; want %q", string(got), "*\n")
+	}
+}
+
+// TestAgentEnv_gitignoreSymlinkRejected verifies that agentEnv returns an error
+// when .agent-home/.gitignore is a pre-planted symlink (malicious-repo guard).
+func TestAgentEnv_gitignoreSymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	agentHome := filepath.Join(dir, ".agent-home")
+	if err := os.MkdirAll(agentHome, 0o755); err != nil {
+		t.Fatalf("mkdir .agent-home: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "injected")
+	gitignorePath := filepath.Join(agentHome, ".gitignore")
+	if err := os.Symlink(target, gitignorePath); err != nil {
+		t.Skipf("symlinks not supported on this platform: %v", err)
+	}
+	_, err := agentEnv(dir)
+	if err == nil {
+		t.Fatal("expected error when .agent-home/.gitignore is a symlink")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error should mention symlink; got: %v", err)
+	}
+	// Confirm the symlink target was NOT written by agentEnv.
+	if _, statErr := os.Stat(target); statErr == nil {
+		t.Error("agentEnv wrote through the symlink; expected no file at target path")
+	}
+}
+
+// TestAgentEnv_gitExcludeUpdated verifies that agentEnv adds ".agent-home" to
+// the worktree-local git/info/exclude file when running inside a git repository.
+func TestAgentEnv_gitExcludeUpdated(t *testing.T) {
+	// Initialise a temporary git repository so "git rev-parse --git-dir" succeeds.
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Skipf("git init failed (git not available?): %v – %s", err, out)
+	}
+	// Ensure git/info/exclude exists (git init usually creates it).
+	excludePath := filepath.Join(dir, ".git", "info", "exclude")
+	if _, err := os.Stat(excludePath); os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
+			t.Fatalf("mkdir git/info: %v", err)
+		}
+		if err := os.WriteFile(excludePath, []byte("# git ls-files --others --exclude-from=.git/info/exclude\n"), 0o644); err != nil {
+			t.Fatalf("create exclude: %v", err)
+		}
+	}
+
+	if _, err := agentEnv(dir); err != nil {
+		t.Fatalf("agentEnv: %v", err)
+	}
+
+	content, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	found := false
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.TrimSpace(line) == ".agent-home" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("'.agent-home' not found as an exact line in git/info/exclude; got:\n%s", string(content))
+	}
+}
+
+// TestAgentEnv_gitExcludeNoMissingNewline verifies that the .agent-home entry
+// is appended on its own line even when the existing exclude file does not end
+// with a newline.
+func TestAgentEnv_gitExcludeNoMissingNewline(t *testing.T) {
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Skipf("git init failed (git not available?): %v – %s", err, out)
+	}
+	excludePath := filepath.Join(dir, ".git", "info", "exclude")
+	// Write file without a trailing newline.
+	if err := os.WriteFile(excludePath, []byte("# comment"), 0o644); err != nil {
+		t.Fatalf("write exclude: %v", err)
+	}
+
+	if _, err := agentEnv(dir); err != nil {
+		t.Fatalf("agentEnv: %v", err)
+	}
+
+	content, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.TrimSpace(line) == ".agent-home" {
+			return // found on its own line
+		}
+	}
+	t.Errorf("'.agent-home' not found as an exact line; got:\n%s", string(content))
+}
+
+// TestAgentEnv_gitExcludeNoDuplicate verifies that running agentEnv twice does
+// not add a second ".agent-home" line to git/info/exclude.
+func TestAgentEnv_gitExcludeNoDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Skipf("git init failed (git not available?): %v – %s", err, out)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := agentEnv(dir); err != nil {
+			t.Fatalf("agentEnv (run %d): %v", i+1, err)
+		}
+	}
+
+	excludePath := filepath.Join(dir, ".git", "info", "exclude")
+	content, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	count := 0
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.TrimSpace(line) == ".agent-home" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("'.agent-home' appears %d times in git/info/exclude; want exactly 1\n%s", count, string(content))
+	}
+}
+
 func TestStreamLog_fileExists(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "agent.log")


### PR DESCRIPTION
## Summary

- **Dev server stays alive after agentctl exits**: `detachProcess()` (which sets `Setsid`) was already called for agent processes but not for the dev server. Without it the dev server shared the same process group as agentctl and was killed when the parent exited. Fixed in both `startDevServerOnPort` and `startCustomDevServer`.

- **Turbopack / build-tool panic on `.agent-home` symlinks**: `.agent-home` contains symlinks like `.claude -> ../../.claude` that resolve to paths outside the project root. Turbopack (and similar tools) panic when they follow a symlink that escapes the project root. Fix: write a catch-all `.gitignore` (`*`) inside `.agent-home` so tools that respect `.gitignore` skip its contents entirely. Also append `.agent-home` to the worktree-local `git/info/exclude` so it stays out of `git status`.

## Test plan

- [ ] `go test ./internal/cmd/...` passes
- [ ] `go build ./...` passes
- [ ] Start a worktree with a dev server, exit agentctl — confirm dev server is still reachable
- [ ] Inspect `.agent-home/.gitignore` — should contain `*`
- [ ] Inspect `.git/worktrees/<wt>/info/exclude` — should contain `.agent-home`

🤖 Generated with [Claude Code](https://claude.com/claude-code)