### PR TITLE
fix: --quiet uses detached log routing so Ctrl+C doesn't orphan the pipe

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ Creates a linked worktree for a GitHub issue and launches the selected coding ag
 - `--agent <name>`: adapter name; default is `claude`. See [adapters.md](adapters.md) for available adapters.
 - `--headless`: run the agent in the background and write agent output to `agent.log`.
 - `--notify`: send a native desktop notification when the headless agent finishes. No-op when `--headless` is not set. See [Desktop notifications](#desktop-notifications).
-- `--quiet`: suppress agent log output in the terminal; show only the spinner (TTY) or heartbeat lines (non-TTY/CI). Has no effect with `--headless`.
+- `--quiet`: suppress all agent log output in the terminal; the parent still waits for the agent to finish (foreground). Has no effect with `--headless`.
 - `--sdd=<name>`: opt into an SDD methodology (e.g. `--sdd=plain`, `--sdd=speckit`). Omit to skip SDD and work directly toward a PR. See [sdd.md](sdd.md).
 - `<issue-number-or-url>`: a bare GitHub issue number (e.g. `42`) **or** a full GitHub issue URL (e.g. `https://github.com/owner/repo/issues/42`). When a URL is supplied, `agentctl` locates or clones the target repository automatically so you do not need to `cd` into it first.
 - `[slug]`: optional branch/worktree slug. If omitted, `agentctl` uses `gh issue view` to fetch the issue title and derive a slug.
@@ -36,8 +36,8 @@ Side effects:
 ### `agentctl resume`
 
 ```bash
-agentctl resume [--headless] [--notify] [--quiet] <issue-number>
-agentctl resume [--headless] [--notify] [--quiet] <issue-number> [feedback]
+agentctl resume [--headless] [--notify] [--quiet] <issue-number-or-url>
+agentctl resume [--headless] [--notify] [--quiet] <issue-number-or-url> [feedback]
 ```
 
 Resumes a paused agent after the spec-review checkpoint.
@@ -49,7 +49,9 @@ By default the resumed agent streams its output to the terminal (foreground mode
 
 - `--headless`: run the resumed agent in the background and write output to `agent.log`.
 - `--notify`: send a native desktop notification when the headless agent finishes. No-op when `--headless` is not set. See [Desktop notifications](#desktop-notifications).
-- `--quiet`: suppress agent log output in the terminal; show only the spinner (TTY) or heartbeat lines (non-TTY/CI). Has no effect with `--headless`.
+- `--quiet`: suppress all agent log output in the terminal; the parent still waits for the agent to finish (foreground). Has no effect with `--headless`.
+
+`--agent` is not accepted by `resume` — the agent is recorded in `.agent` at `start` time and reused automatically.
 
 The command requires:
 
@@ -91,7 +93,7 @@ PR column shows the PR number and state from `gh pr view <branch>`, e.g. `#42 OP
 ### `agentctl cleanup`
 
 ```bash
-agentctl cleanup [issue-number]
+agentctl cleanup [issue-number-or-url]
 agentctl cleanup --all
 ```
 
@@ -114,7 +116,7 @@ If the PR is not merged, use `agentctl discard` for abandoned work.
 ### `agentctl discard`
 
 ```bash
-agentctl discard [issue-number]
+agentctl discard [issue-number-or-url]
 agentctl discard --stale
 ```
 
@@ -139,9 +141,9 @@ Note: N stale worktree(s) found with no agent and no PR — run `agentctl discar
 ### `agentctl logs`
 
 ```bash
-agentctl logs <issue-number>
-agentctl logs <issue-number> --lines 100
-agentctl logs <issue-number> --no-follow
+agentctl logs <issue-number-or-url>
+agentctl logs <issue-number-or-url> --lines 100
+agentctl logs <issue-number-or-url> --no-follow
 ```
 
 Streams `agent.log` for the given issue to stdout.
@@ -170,7 +172,7 @@ Error cases:
 ### `agentctl attach`
 
 ```bash
-agentctl attach <issue-number>
+agentctl attach <issue-number-or-url>
 ```
 
 Streams `agent.log` and exits automatically when the agent process finishes — mirrors the non-headless `start` experience for an already-running headless agent.
@@ -224,7 +226,7 @@ Error cases:
 |-----------|---------------|
 | `dev_server` not set in `.agentctl.yml` | `dev_server not set in .agentctl.yml — nothing to start` |
 | `.agent` has no port recorded | `no port recorded in .agent — run agentctl start first` |
-| Dev server already running | `dev server already running (PID N) — run agentctl cleanup, then agentctl dev start` |
+| Dev server already running | `dev server already running (PID N) — stop that process and clear the recorded dev-pid before restarting` |
 | Port already in use | `port N already in use` (with PID if detectable) |
 
 ## Workflows
@@ -241,7 +243,7 @@ agentctl start https://github.com/owner/repo/issues/42
 
 The agent runs in your terminal with its log streamed live so you can follow along. Without `--sdd`, the agent works directly toward a PR. Use `--sdd=plain` or `--sdd=speckit` after the issue number to add a spec-review checkpoint.
 
-To suppress log output and show only a spinner/heartbeat:
+To suppress log output while still waiting for the agent to finish:
 
 ```bash
 agentctl start --quiet 42

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ Creates a linked worktree for a GitHub issue and launches the selected coding ag
 - `--agent <name>`: adapter name; default is `claude`. See [adapters.md](adapters.md) for available adapters.
 - `--headless`: run the agent in the background and write agent output to `agent.log`.
 - `--notify`: send a native desktop notification when the headless agent finishes. No-op when `--headless` is not set. See [Desktop notifications](#desktop-notifications).
-- `--quiet`: suppress all agent log output in the terminal; the parent still waits for the agent to finish (foreground). Has no effect with `--headless`.
+- `--quiet`: suppress agent log output in the terminal; show only the spinner (TTY) or heartbeat lines (non-TTY/CI). Has no effect with `--headless`.
 - `--sdd=<name>`: opt into an SDD methodology (e.g. `--sdd=plain`, `--sdd=speckit`). Omit to skip SDD and work directly toward a PR. See [sdd.md](sdd.md).
 - `<issue-number-or-url>`: a bare GitHub issue number (e.g. `42`) **or** a full GitHub issue URL (e.g. `https://github.com/owner/repo/issues/42`). When a URL is supplied, `agentctl` locates or clones the target repository automatically so you do not need to `cd` into it first.
 - `[slug]`: optional branch/worktree slug. If omitted, `agentctl` uses `gh issue view` to fetch the issue title and derive a slug.
@@ -36,8 +36,8 @@ Side effects:
 ### `agentctl resume`
 
 ```bash
-agentctl resume [--headless] [--notify] [--quiet] <issue-number-or-url>
-agentctl resume [--headless] [--notify] [--quiet] <issue-number-or-url> [feedback]
+agentctl resume [--headless] [--notify] [--quiet] <issue-number>
+agentctl resume [--headless] [--notify] [--quiet] <issue-number> [feedback]
 ```
 
 Resumes a paused agent after the spec-review checkpoint.
@@ -49,9 +49,7 @@ By default the resumed agent streams its output to the terminal (foreground mode
 
 - `--headless`: run the resumed agent in the background and write output to `agent.log`.
 - `--notify`: send a native desktop notification when the headless agent finishes. No-op when `--headless` is not set. See [Desktop notifications](#desktop-notifications).
-- `--quiet`: suppress all agent log output in the terminal; the parent still waits for the agent to finish (foreground). Has no effect with `--headless`.
-
-`--agent` is not accepted by `resume` — the agent is recorded in `.agent` at `start` time and reused automatically.
+- `--quiet`: suppress agent log output in the terminal; show only the spinner (TTY) or heartbeat lines (non-TTY/CI). Has no effect with `--headless`.
 
 The command requires:
 
@@ -93,7 +91,7 @@ PR column shows the PR number and state from `gh pr view <branch>`, e.g. `#42 OP
 ### `agentctl cleanup`
 
 ```bash
-agentctl cleanup [issue-number-or-url]
+agentctl cleanup [issue-number]
 agentctl cleanup --all
 ```
 
@@ -116,7 +114,7 @@ If the PR is not merged, use `agentctl discard` for abandoned work.
 ### `agentctl discard`
 
 ```bash
-agentctl discard [issue-number-or-url]
+agentctl discard [issue-number]
 agentctl discard --stale
 ```
 
@@ -141,9 +139,9 @@ Note: N stale worktree(s) found with no agent and no PR — run `agentctl discar
 ### `agentctl logs`
 
 ```bash
-agentctl logs <issue-number-or-url>
-agentctl logs <issue-number-or-url> --lines 100
-agentctl logs <issue-number-or-url> --no-follow
+agentctl logs <issue-number>
+agentctl logs <issue-number> --lines 100
+agentctl logs <issue-number> --no-follow
 ```
 
 Streams `agent.log` for the given issue to stdout.
@@ -172,7 +170,7 @@ Error cases:
 ### `agentctl attach`
 
 ```bash
-agentctl attach <issue-number-or-url>
+agentctl attach <issue-number>
 ```
 
 Streams `agent.log` and exits automatically when the agent process finishes — mirrors the non-headless `start` experience for an already-running headless agent.
@@ -226,7 +224,7 @@ Error cases:
 |-----------|---------------|
 | `dev_server` not set in `.agentctl.yml` | `dev_server not set in .agentctl.yml — nothing to start` |
 | `.agent` has no port recorded | `no port recorded in .agent — run agentctl start first` |
-| Dev server already running | `dev server already running (PID N) — stop that process and clear the recorded dev-pid before restarting` |
+| Dev server already running | `dev server already running (PID N) — run agentctl cleanup, then agentctl dev start` |
 | Port already in use | `port N already in use` (with PID if detectable) |
 
 ## Workflows
@@ -243,7 +241,7 @@ agentctl start https://github.com/owner/repo/issues/42
 
 The agent runs in your terminal with its log streamed live so you can follow along. Without `--sdd`, the agent works directly toward a PR. Use `--sdd=plain` or `--sdd=speckit` after the issue number to add a spec-review checkpoint.
 
-To suppress log output while still waiting for the agent to finish:
+To suppress log output and show only a spinner/heartbeat:
 
 ```bash
 agentctl start --quiet 42

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1845,6 +1845,9 @@ func generateUUID() (string, error) {
 // it from the current branch when inside a linked worktree.
 func resolveIssueArg(flag string, args []string) (string, error) {
 	if len(args) == 1 && args[0] != "" {
+		if _, _, num, ok := parseIssueURL(args[0]); ok {
+			return num, nil
+		}
 		return args[0], nil
 	}
 	linked, issue, err := git.IsInsideLinkedWorktree()

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1920,11 +1920,10 @@ func findWorktreePath(issue string) (string, error) {
 // exact same argument they used with `start`. issue is the bare number used
 // for internal operations (PR linking, spec path globs, etc.).
 func launchAgent(adapterName, wtPath, issue, issueArg, port, sessionID, kickoff, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
-	// --quiet uses the detached subprocess log router so the converter
-	// survives if the user Ctrl+C's out of the foreground spinner.
-	if quiet {
-		headless = true
-	}
+	// --quiet uses the detached subprocess log router (same as headless) so
+	// the converter survives if the user Ctrl+C's, but the parent still waits
+	// for the agent to finish (foreground behaviour is preserved).
+	detachedRouter := headless || quiet
 
 	ad, err := adapters.Get(adapterName)
 	if err != nil {
@@ -1961,7 +1960,7 @@ func launchAgent(adapterName, wtPath, issue, issueArg, port, sessionID, kickoff,
 	// the file; Claude headless uses a pipe fed to a detached __stream-log
 	// subprocess so intermediate tool steps are captured progressively.
 	var pr, pw *os.File
-	if !headless {
+	if !detachedRouter {
 		pr, pw, err = os.Pipe()
 		if err != nil {
 			logFile.Close()
@@ -1979,9 +1978,8 @@ func launchAgent(adapterName, wtPath, issue, issueArg, port, sessionID, kickoff,
 	} else {
 		if adapterName == "claude" {
 			// Use stream-json so intermediate tool steps are captured progressively.
-			// Since the parent exits immediately in headless mode, a detached
-			// __stream-log subprocess converts the pipe to human-readable text in
-			// agent.log.
+			// A detached __stream-log subprocess converts the pipe to human-readable
+			// text in agent.log and survives the parent exiting.
 			agentCmd.Args = append(agentCmd.Args, "--output-format", "stream-json", "--verbose")
 			pr, pw, err = os.Pipe()
 			if err != nil {
@@ -2018,7 +2016,7 @@ func launchAgent(adapterName, wtPath, issue, issueArg, port, sessionID, kickoff,
 	// convWg tracks the converter goroutine so we can drain all remaining pipe
 	// content into the log file before signalling followLog to do its final read.
 	var convWg sync.WaitGroup
-	if headless {
+	if detachedRouter {
 		if pw != nil {
 			// Spawn a detached converter process. Its stdout is the already-open
 			// logFile fd so it never opens files by path (avoids race with test

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -229,7 +229,7 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 		kickoff = m.KickoffPrompt(issueNum, portStr)
 	}
 
-	if err := launchAgent(agentName, wtPath, issueNum, portStr, sessionID, kickoff, sddName, headless, quiet, sendNotify, out); err != nil {
+	if err := launchAgent(agentName, wtPath, issueNum, ghIssueArg, portStr, sessionID, kickoff, sddName, headless, quiet, sendNotify, out); err != nil {
 		cleanupOnError = false
 		if cleanupErr := cleanupFailedStart(repoRoot, wtPath, branch, devPID); cleanupErr != nil {
 			return fmt.Errorf("%w\ncleanup warning: %v", err, cleanupErr)
@@ -1912,7 +1912,11 @@ func findWorktreePath(issue string) (string, error) {
 // then either returns immediately (headless) or streams agent.log to stdout
 // until the agent exits (non-headless). quiet suppresses log lines, showing
 // only the spinner/heartbeat.
-func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+// issueArg is the original user-supplied argument (bare number or full GitHub
+// issue URL); it is used only in display hints so the user can copy-paste the
+// exact same argument they used with `start`. issue is the bare number used
+// for internal operations (PR linking, spec path globs, etc.).
+func launchAgent(adapterName, wtPath, issue, issueArg, port, sessionID, kickoff, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
 	// --quiet uses the detached subprocess log router so the converter
 	// survives if the user Ctrl+C's out of the foreground spinner.
 	if quiet {
@@ -2131,11 +2135,11 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 		}
 
 		fmt.Fprintf(out, "Agent PID %d — log: %s\n", pid, logPath)
-		fmt.Fprintf(out, "agentctl logs %s      # follow log\n", issue)
-		fmt.Fprintf(out, "agentctl attach %s    # stream live and wait\n", issue)
-		fmt.Fprintf(out, "agentctl discard %s   # abandon\n", issue)
+		fmt.Fprintf(out, "agentctl logs %s      # follow log\n", issueArg)
+		fmt.Fprintf(out, "agentctl attach %s    # stream live and wait\n", issueArg)
+		fmt.Fprintf(out, "agentctl discard %s   # abandon\n", issueArg)
 		if sddName != "" {
-			fmt.Fprintf(out, "agentctl resume %s [feedback]   # approve spec or send revisions\n", issue)
+			fmt.Fprintf(out, "agentctl resume %s [feedback]   # approve spec or send revisions\n", issueArg)
 		}
 		if sendNotify {
 			maybeFireTestNotification(issue, out)
@@ -2169,7 +2173,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			close(logDone)
 			wg.Wait()
 			if agentExitErr != nil {
-				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", issue)
+				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", issueArg)
 				return nil
 			}
 			branch, branchErr := git.CurrentBranch(wtPath)
@@ -2184,10 +2188,10 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 				if specPath := findSpecPath(wtPath, issue); specPath != "" {
 					fmt.Fprintf(out, "Spec: %s\n", specPath)
 				}
-				fmt.Fprintf(out, resumeHintFmt, issue)
+				fmt.Fprintf(out, resumeHintFmt, issueArg)
 			}
 			if hasPR {
-				fmt.Fprintf(out, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", issue)
+				fmt.Fprintf(out, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", issueArg)
 			}
 			return nil
 		case <-sigCh:
@@ -2195,9 +2199,9 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			close(logDone)
 			wg.Wait()
 			fmt.Fprintf(out, "agent still running in background\n")
-			fmt.Fprintf(out, "  agentctl logs %s     # follow log\n", issue)
-			fmt.Fprintf(out, "  agentctl attach %s   # stream live output\n", issue)
-			fmt.Fprintf(out, "  agentctl discard %s  # permanently delete worktree and branches\n", issue)
+			fmt.Fprintf(out, "  agentctl logs %s     # follow log\n", issueArg)
+			fmt.Fprintf(out, "  agentctl attach %s   # stream live output\n", issueArg)
+			fmt.Fprintf(out, "  agentctl discard %s  # permanently delete worktree and branches\n", issueArg)
 			return nil
 		}
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -229,7 +229,7 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 		kickoff = m.KickoffPrompt(issueNum, portStr)
 	}
 
-	if err := launchAgent(agentName, wtPath, issueNum, ghIssueArg, portStr, sessionID, kickoff, sddName, headless, quiet, sendNotify, out); err != nil {
+	if err := launchAgent(agentName, wtPath, issueNum, portStr, sessionID, kickoff, sddName, headless, quiet, sendNotify, out); err != nil {
 		cleanupOnError = false
 		if cleanupErr := cleanupFailedStart(repoRoot, wtPath, branch, devPID); cleanupErr != nil {
 			return fmt.Errorf("%w\ncleanup warning: %v", err, cleanupErr)
@@ -1845,8 +1845,8 @@ func generateUUID() (string, error) {
 // it from the current branch when inside a linked worktree.
 func resolveIssueArg(flag string, args []string) (string, error) {
 	if len(args) == 1 && args[0] != "" {
-		if _, _, num, ok := parseIssueURL(args[0]); ok {
-			return num, nil
+		if _, _, _, ok := parseIssueURL(args[0]); ok {
+			return "", fmt.Errorf("issue URLs are not accepted here; re-run with the bare issue number:\n  agentctl %s <issue>", flag)
 		}
 		return args[0], nil
 	}
@@ -1915,11 +1915,7 @@ func findWorktreePath(issue string) (string, error) {
 // then either returns immediately (headless) or streams agent.log to stdout
 // until the agent exits (non-headless). quiet suppresses log lines, showing
 // only the spinner/heartbeat.
-// issueArg is the original user-supplied argument (bare number or full GitHub
-// issue URL); it is used only in display hints so the user can copy-paste the
-// exact same argument they used with `start`. issue is the bare number used
-// for internal operations (PR linking, spec path globs, etc.).
-func launchAgent(adapterName, wtPath, issue, issueArg, port, sessionID, kickoff, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
 	// --quiet uses the detached subprocess log router (same as headless) so
 	// the converter survives if the user Ctrl+C's, but the parent still waits
 	// for the agent to finish (foreground behaviour is preserved).
@@ -2136,11 +2132,11 @@ func launchAgent(adapterName, wtPath, issue, issueArg, port, sessionID, kickoff,
 		}
 
 		fmt.Fprintf(out, "Agent PID %d — log: %s\n", pid, logPath)
-		fmt.Fprintf(out, "agentctl logs %s      # follow log\n", issueArg)
-		fmt.Fprintf(out, "agentctl attach %s    # stream live and wait\n", issueArg)
-		fmt.Fprintf(out, "agentctl discard %s   # abandon\n", issueArg)
+		fmt.Fprintf(out, "agentctl logs %s      # follow log\n", issue)
+		fmt.Fprintf(out, "agentctl attach %s    # stream live and wait\n", issue)
+		fmt.Fprintf(out, "agentctl discard %s   # abandon\n", issue)
 		if sddName != "" {
-			fmt.Fprintf(out, "agentctl resume %s [feedback]   # approve spec or send revisions\n", issueArg)
+			fmt.Fprintf(out, "agentctl resume %s [feedback]   # approve spec or send revisions\n", issue)
 		}
 		if sendNotify {
 			maybeFireTestNotification(issue, out)
@@ -2174,7 +2170,7 @@ func launchAgent(adapterName, wtPath, issue, issueArg, port, sessionID, kickoff,
 			close(logDone)
 			wg.Wait()
 			if agentExitErr != nil {
-				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", issueArg)
+				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", issue)
 				return nil
 			}
 			branch, branchErr := git.CurrentBranch(wtPath)
@@ -2189,10 +2185,10 @@ func launchAgent(adapterName, wtPath, issue, issueArg, port, sessionID, kickoff,
 				if specPath := findSpecPath(wtPath, issue); specPath != "" {
 					fmt.Fprintf(out, "Spec: %s\n", specPath)
 				}
-				fmt.Fprintf(out, resumeHintFmt, issueArg)
+				fmt.Fprintf(out, resumeHintFmt, issue)
 			}
 			if hasPR {
-				fmt.Fprintf(out, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", issueArg)
+				fmt.Fprintf(out, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", issue)
 			}
 			return nil
 		case <-sigCh:
@@ -2200,9 +2196,9 @@ func launchAgent(adapterName, wtPath, issue, issueArg, port, sessionID, kickoff,
 			close(logDone)
 			wg.Wait()
 			fmt.Fprintf(out, "agent still running in background\n")
-			fmt.Fprintf(out, "  agentctl logs %s     # follow log\n", issueArg)
-			fmt.Fprintf(out, "  agentctl attach %s   # stream live output\n", issueArg)
-			fmt.Fprintf(out, "  agentctl discard %s  # permanently delete worktree and branches\n", issueArg)
+			fmt.Fprintf(out, "  agentctl logs %s     # follow log\n", issue)
+			fmt.Fprintf(out, "  agentctl attach %s   # stream live output\n", issue)
+			fmt.Fprintf(out, "  agentctl discard %s  # permanently delete worktree and branches\n", issue)
 			return nil
 		}
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2187,7 +2187,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 				fmt.Fprintf(out, resumeHintFmt, issue)
 			}
 			if hasPR {
-				fmt.Fprintf(out, "agentctl cleanup %s   # after PR is merged\n", issue)
+				fmt.Fprintf(out, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", issue)
 			}
 			return nil
 		case <-sigCh:
@@ -3251,7 +3251,7 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 				fmt.Fprintf(os.Stdout, resumeHintFmt, issue)
 			}
 			if hasPR {
-				fmt.Fprintf(os.Stdout, "agentctl cleanup %s   # after PR is merged\n", issue)
+				fmt.Fprintf(os.Stdout, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", issue)
 			}
 			return nil
 		case <-sigCh:

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1913,6 +1913,12 @@ func findWorktreePath(issue string) (string, error) {
 // until the agent exits (non-headless). quiet suppresses log lines, showing
 // only the spinner/heartbeat.
 func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+	// --quiet uses the detached subprocess log router so the converter
+	// survives if the user Ctrl+C's out of the foreground spinner.
+	if quiet {
+		headless = true
+	}
+
 	ad, err := adapters.Get(adapterName)
 	if err != nil {
 		return err

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -411,6 +411,16 @@ func TestResolveIssueArg_withArg(t *testing.T) {
 	}
 }
 
+func TestResolveIssueArg_rejectsURL(t *testing.T) {
+	_, err := resolveIssueArg("discard", []string{"https://github.com/myorg/myrepo/issues/42"})
+	if err == nil {
+		t.Error("expected error when a full issue URL is passed")
+	}
+	if !strings.Contains(err.Error(), "bare issue number") {
+		t.Errorf("expected 'bare issue number' in error, got: %v", err)
+	}
+}
+
 func TestResolveIssueArg_noArgs_notLinked(t *testing.T) {
 	// Running from the primary worktree (not a linked one) must return an error.
 	chdirTemp(t, t.TempDir())
@@ -880,7 +890,7 @@ func writeLocalAdapter(t *testing.T, dir, name, content string) {
 
 func TestLaunchAgent_unknownAdapter(t *testing.T) {
 	dir := t.TempDir()
-	err := launchAgent("nonexistent-xyz-abc", dir, "42", "42", "3010", "sess-123", "kickoff", "", true, false, false, &bytes.Buffer{})
+	err := launchAgent("nonexistent-xyz-abc", dir, "42", "3010", "sess-123", "kickoff", "", true, false, false, &bytes.Buffer{})
 	if err == nil {
 		t.Error("expected error for unknown adapter")
 	}
@@ -891,7 +901,7 @@ func TestLaunchAgent_binaryNotFound(t *testing.T) {
 	writeLocalAdapter(t, dir, "fakebinary", "binary: __nonexistent_binary_xyz__\n")
 	chdirTemp(t, dir)
 
-	err := launchAgent("fakebinary", dir, "42", "42", "3010", "sess-123", "kickoff", "", true, false, false, &bytes.Buffer{})
+	err := launchAgent("fakebinary", dir, "42", "3010", "sess-123", "kickoff", "", true, false, false, &bytes.Buffer{})
 	if err == nil {
 		t.Fatal("expected error when binary not found")
 	}
@@ -908,7 +918,7 @@ func TestLaunchAgent_headless(t *testing.T) {
 	chdirTemp(t, dir)
 
 	var out bytes.Buffer
-	err := launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", true, false, false, &out)
+	err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, false, &out)
 	if err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
@@ -949,7 +959,7 @@ func TestLaunchAgent_headless_withSDD_showsResumeHint(t *testing.T) {
 	chdirTemp(t, dir)
 
 	var out bytes.Buffer
-	err := launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "plain", true, false, false, &out)
+	err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "plain", true, false, false, &out)
 	if err != nil {
 		t.Fatalf("launchAgent headless SDD: %v", err)
 	}
@@ -991,7 +1001,7 @@ func TestLaunchAgent_headless_notify(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", true, false, true, &out)
+	err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, true, &out)
 	if err != nil {
 		t.Fatalf("launchAgent headless notify: %v", err)
 	}
@@ -1148,7 +1158,7 @@ func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 	// Ctrl+C or any other intervention.
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
+		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
 	}()
 
 	select {
@@ -1187,7 +1197,7 @@ func TestLaunchAgent_nonHeadless_exitNoPR_printsNoPR(t *testing.T) {
 	var out bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
+		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
 	}()
 
 	select {
@@ -1245,7 +1255,7 @@ func TestLaunchAgent_nonHeadless_withSDD_showsSpecPath(t *testing.T) {
 	var out bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "plain", false, false, false, &out)
+		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "plain", false, false, false, &out)
 	}()
 
 	select {
@@ -1278,7 +1288,7 @@ func TestLaunchAgent_nonClaudeNonHeadless_outputStreamed(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("echoagent2", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
+		done <- launchAgent("echoagent2", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
 	}()
 
 	select {
@@ -1320,7 +1330,7 @@ func TestLaunchAgent_claudeNonHeadlessInjectsStreamJsonAndVerbose(t *testing.T) 
 
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("claude", dir, "42", "42", "3010", "sess-abc", "kickoff text", "", false, false, false, &bytes.Buffer{})
+		done <- launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", "", false, false, false, &bytes.Buffer{})
 	}()
 
 	select {
@@ -1371,7 +1381,7 @@ func TestLaunchAgent_claudeHeadlessUsesStreamJson(t *testing.T) {
 	writeLocalAdapter(t, dir, "claude", "binary: "+scriptPath+"\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("claude", dir, "42", "42", "3010", "sess-abc", "kickoff text", "", true, false, false, &bytes.Buffer{}); err != nil {
+	if err := launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", "", true, false, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 
@@ -1415,7 +1425,7 @@ func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
 	var outBuf bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("sleepagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &outBuf)
+		done <- launchAgent("sleepagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &outBuf)
 	}()
 
 	// Give launchAgent time to start the agent process and register its signal
@@ -1645,7 +1655,7 @@ func TestLaunchAgent_nonZeroExitLogsToStderr(t *testing.T) {
 	// closed, which happens after fmt.Fprintf(os.Stderr, ...) in the reaper
 	// goroutine — so by the time launchAgent returns, the message is already
 	// captured in the pipe.
-	launchErr := launchAgent("falseagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
+	launchErr := launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
 
 	// Close the write end and restore stderr before reading.
 	w.Close()
@@ -1672,7 +1682,7 @@ func TestLaunchAgent_headless_immediateNonZeroExitReturnsError(t *testing.T) {
 	chdirTemp(t, dir)
 
 	var out bytes.Buffer
-	err := launchAgent("falseagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", true, false, false, &out)
+	err := launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, false, &out)
 	if err == nil {
 		t.Fatal("expected error for immediate non-zero headless exit, got nil")
 	}
@@ -1692,7 +1702,7 @@ func TestLaunchAgent_nonHeadless_nonZeroExitPrintsErrorHint(t *testing.T) {
 	var out bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("falseagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
+		done <- launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
 	}()
 
 	select {
@@ -2041,7 +2051,7 @@ func TestLaunchAgent_homeIsolation(t *testing.T) {
 	writeLocalAdapter(t, dir, "envagent", "binary: "+scriptPath+"\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("envagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", true, false, false, &bytes.Buffer{}); err != nil {
+	if err := launchAgent("envagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 
@@ -3449,7 +3459,7 @@ func TestLaunchAgent_claudeHeadlessWritesSettingsJson(t *testing.T) {
 	writeLocalAdapter(t, dir, "claude", "binary: "+scriptPath+"\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("claude", dir, "42", "42", "3010", "sess-abc", "kickoff text", "", true, false, false, &bytes.Buffer{}); err != nil {
+	if err := launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", "", true, false, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 
@@ -3477,7 +3487,7 @@ func TestLaunchAgent_nonClaudeDoesNotWriteSettingsJson(t *testing.T) {
 	writeLocalAdapter(t, dir, "echoagent", "binary: echo\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", true, false, false, &bytes.Buffer{}); err != nil {
+	if err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -880,7 +880,7 @@ func writeLocalAdapter(t *testing.T, dir, name, content string) {
 
 func TestLaunchAgent_unknownAdapter(t *testing.T) {
 	dir := t.TempDir()
-	err := launchAgent("nonexistent-xyz-abc", dir, "42", "3010", "sess-123", "kickoff", "", true, false, false, &bytes.Buffer{})
+	err := launchAgent("nonexistent-xyz-abc", dir, "42", "42", "3010", "sess-123", "kickoff", "", true, false, false, &bytes.Buffer{})
 	if err == nil {
 		t.Error("expected error for unknown adapter")
 	}
@@ -891,7 +891,7 @@ func TestLaunchAgent_binaryNotFound(t *testing.T) {
 	writeLocalAdapter(t, dir, "fakebinary", "binary: __nonexistent_binary_xyz__\n")
 	chdirTemp(t, dir)
 
-	err := launchAgent("fakebinary", dir, "42", "3010", "sess-123", "kickoff", "", true, false, false, &bytes.Buffer{})
+	err := launchAgent("fakebinary", dir, "42", "42", "3010", "sess-123", "kickoff", "", true, false, false, &bytes.Buffer{})
 	if err == nil {
 		t.Fatal("expected error when binary not found")
 	}
@@ -908,7 +908,7 @@ func TestLaunchAgent_headless(t *testing.T) {
 	chdirTemp(t, dir)
 
 	var out bytes.Buffer
-	err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, false, &out)
+	err := launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", true, false, false, &out)
 	if err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
@@ -949,7 +949,7 @@ func TestLaunchAgent_headless_withSDD_showsResumeHint(t *testing.T) {
 	chdirTemp(t, dir)
 
 	var out bytes.Buffer
-	err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "plain", true, false, false, &out)
+	err := launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "plain", true, false, false, &out)
 	if err != nil {
 		t.Fatalf("launchAgent headless SDD: %v", err)
 	}
@@ -991,7 +991,7 @@ func TestLaunchAgent_headless_notify(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, true, &out)
+	err := launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", true, false, true, &out)
 	if err != nil {
 		t.Fatalf("launchAgent headless notify: %v", err)
 	}
@@ -1148,7 +1148,7 @@ func TestLaunchAgent_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 	// Ctrl+C or any other intervention.
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
+		done <- launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
 	}()
 
 	select {
@@ -1187,7 +1187,7 @@ func TestLaunchAgent_nonHeadless_exitNoPR_printsNoPR(t *testing.T) {
 	var out bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
+		done <- launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
 	}()
 
 	select {
@@ -1245,7 +1245,7 @@ func TestLaunchAgent_nonHeadless_withSDD_showsSpecPath(t *testing.T) {
 	var out bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "plain", false, false, false, &out)
+		done <- launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "plain", false, false, false, &out)
 	}()
 
 	select {
@@ -1278,7 +1278,7 @@ func TestLaunchAgent_nonClaudeNonHeadless_outputStreamed(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("echoagent2", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
+		done <- launchAgent("echoagent2", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
 	}()
 
 	select {
@@ -1320,7 +1320,7 @@ func TestLaunchAgent_claudeNonHeadlessInjectsStreamJsonAndVerbose(t *testing.T) 
 
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", "", false, false, false, &bytes.Buffer{})
+		done <- launchAgent("claude", dir, "42", "42", "3010", "sess-abc", "kickoff text", "", false, false, false, &bytes.Buffer{})
 	}()
 
 	select {
@@ -1371,7 +1371,7 @@ func TestLaunchAgent_claudeHeadlessUsesStreamJson(t *testing.T) {
 	writeLocalAdapter(t, dir, "claude", "binary: "+scriptPath+"\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", "", true, false, false, &bytes.Buffer{}); err != nil {
+	if err := launchAgent("claude", dir, "42", "42", "3010", "sess-abc", "kickoff text", "", true, false, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 
@@ -1415,7 +1415,7 @@ func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
 	var outBuf bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("sleepagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &outBuf)
+		done <- launchAgent("sleepagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &outBuf)
 	}()
 
 	// Give launchAgent time to start the agent process and register its signal
@@ -1645,7 +1645,7 @@ func TestLaunchAgent_nonZeroExitLogsToStderr(t *testing.T) {
 	// closed, which happens after fmt.Fprintf(os.Stderr, ...) in the reaper
 	// goroutine — so by the time launchAgent returns, the message is already
 	// captured in the pipe.
-	launchErr := launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
+	launchErr := launchAgent("falseagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &bytes.Buffer{})
 
 	// Close the write end and restore stderr before reading.
 	w.Close()
@@ -1672,7 +1672,7 @@ func TestLaunchAgent_headless_immediateNonZeroExitReturnsError(t *testing.T) {
 	chdirTemp(t, dir)
 
 	var out bytes.Buffer
-	err := launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, false, &out)
+	err := launchAgent("falseagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", true, false, false, &out)
 	if err == nil {
 		t.Fatal("expected error for immediate non-zero headless exit, got nil")
 	}
@@ -1692,7 +1692,7 @@ func TestLaunchAgent_nonHeadless_nonZeroExitPrintsErrorHint(t *testing.T) {
 	var out bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- launchAgent("falseagent", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
+		done <- launchAgent("falseagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
 	}()
 
 	select {
@@ -2041,7 +2041,7 @@ func TestLaunchAgent_homeIsolation(t *testing.T) {
 	writeLocalAdapter(t, dir, "envagent", "binary: "+scriptPath+"\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("envagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, false, &bytes.Buffer{}); err != nil {
+	if err := launchAgent("envagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", true, false, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 
@@ -3449,7 +3449,7 @@ func TestLaunchAgent_claudeHeadlessWritesSettingsJson(t *testing.T) {
 	writeLocalAdapter(t, dir, "claude", "binary: "+scriptPath+"\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("claude", dir, "42", "3010", "sess-abc", "kickoff text", "", true, false, false, &bytes.Buffer{}); err != nil {
+	if err := launchAgent("claude", dir, "42", "42", "3010", "sess-abc", "kickoff text", "", true, false, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 
@@ -3477,7 +3477,7 @@ func TestLaunchAgent_nonClaudeDoesNotWriteSettingsJson(t *testing.T) {
 	writeLocalAdapter(t, dir, "echoagent", "binary: echo\nsession: --session\n")
 	chdirTemp(t, dir)
 
-	if err := launchAgent("echoagent", dir, "42", "3010", "sess-abc", "do the thing", "", true, false, false, &bytes.Buffer{}); err != nil {
+	if err := launchAgent("echoagent", dir, "42", "42", "3010", "sess-abc", "do the thing", "", true, false, false, &bytes.Buffer{}); err != nil {
 		t.Fatalf("launchAgent headless: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- `--quiet` foreground mode ran the log converter as a goroutine inside the parent process
- If the user Ctrl+C'd out of the quiet start, the parent exited, the goroutine died, and `agent.log` stopped receiving output — even though the agent was still alive
- `agentctl logs` and `agentctl attach` would then hang silently following an empty/stale file
- Fix: `--quiet` now sets `headless=true` inside `launchAgent`, using the detached `__stream-log` subprocess for log routing — this survives the parent exiting

## Test plan

- [ ] `agentctl start <issue> --quiet` then Ctrl+C; verify `agentctl logs <issue>` still streams output
- [ ] `agentctl start <issue> --quiet` completes normally; verify `agentctl logs <issue>` shows history

🤖 Generated with [Claude Code](https://claude.com/claude-code)