### PR TITLE
fix: always resolve bare issue numbers to full GitHub URLs in issue-arg

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -213,6 +213,7 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 		DevPID:    devPID,
 		DevPort:   portStr,
 		SDD:       sddName,
+		IssueArg:  ghIssueArg,
 	}
 	if err := state.Write(wtPath, af); err != nil {
 		return err
@@ -1075,8 +1076,12 @@ func streamLog(wtPath, issue string, lines int, noFollow bool, w io.Writer, logW
 				if af2.DevPort != "" {
 					fmt.Fprintf(w, "\nDev server: http://localhost:%s\n", af2.DevPort)
 				}
+				id := af2.IssueArg
+				if id == "" {
+					id = issue
+				}
 				if specPath := findSpecPath(wtPath, issue); af2.SDD != "" && specPath != "" {
-					fmt.Fprintf(w, "Spec: %s\nSpec ready for review — agentctl resume %s\n", specPath, issue)
+					fmt.Fprintf(w, "Spec: %s\nSpec ready for review — agentctl resume %s\n", specPath, id)
 				} else {
 					fmt.Fprintf(w, "agent process has exited\n")
 				}
@@ -1685,13 +1690,28 @@ func repoRootForIssue(arg string, out io.Writer) (repoRoot, issueNum, ghIssueArg
 // and a bare worktree with no .agent file.
 func worktreeExistsError(wtPath, issueNum string) error {
 	af, readErr := state.Read(wtPath)
+	id := issueNum
+	if readErr == nil && af.IssueArg != "" {
+		id = af.IssueArg
+	}
 	if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
-		return fmt.Errorf("Worktree already exists for issue %s — agent is still running.\nWorktree: %s\n\n  agentctl attach %s   to follow its output\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, issueNum, issueNum)
+		return fmt.Errorf("Worktree already exists for issue %s — agent is still running.\nWorktree: %s\n\n  agentctl attach %s   to follow its output\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, id, id)
 	}
 	if readErr == nil && af.AgentPID != "" {
-		return fmt.Errorf("Worktree already exists for issue %s — agent has finished.\nWorktree: %s\n\n  agentctl cleanup %s   if the PR is merged\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, issueNum, issueNum)
+		return fmt.Errorf("Worktree already exists for issue %s — agent has finished.\nWorktree: %s\n\n  agentctl cleanup %s   if the PR is merged\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, id, id)
 	}
-	return fmt.Errorf("Worktree already exists for issue %s.\nWorktree: %s\n\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, issueNum)
+	return fmt.Errorf("Worktree already exists for issue %s.\nWorktree: %s\n\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, id)
+}
+
+// issueDisplayFor reads the issue-arg stored in the .agent state file and
+// returns it when non-empty. Falls back to fallback (the bare issue number)
+// when the state cannot be read or the field is absent, so callers always get
+// a usable string regardless of worktree age.
+func issueDisplayFor(wtPath, fallback string) string {
+	if af, err := state.Read(wtPath); err == nil && af.IssueArg != "" {
+		return af.IssueArg
+	}
+	return fallback
 }
 
 func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
@@ -2159,12 +2179,13 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 		case <-timer.C:
 		}
 
+		id := issueDisplayFor(wtPath, issue)
 		fmt.Fprintf(out, "Agent PID %d — log: %s\n", pid, logPath)
-		fmt.Fprintf(out, "agentctl logs %s      # follow log\n", issue)
-		fmt.Fprintf(out, "agentctl attach %s    # stream live and wait\n", issue)
-		fmt.Fprintf(out, "agentctl discard %s   # abandon\n", issue)
+		fmt.Fprintf(out, "agentctl logs %s      # follow log\n", id)
+		fmt.Fprintf(out, "agentctl attach %s    # stream live and wait\n", id)
+		fmt.Fprintf(out, "agentctl discard %s   # abandon\n", id)
 		if sddName != "" {
-			fmt.Fprintf(out, "agentctl resume %s [feedback]   # approve spec or send revisions\n", issue)
+			fmt.Fprintf(out, "agentctl resume %s [feedback]   # approve spec or send revisions\n", id)
 		}
 		if sendNotify {
 			maybeFireTestNotification(issue, out)
@@ -2198,7 +2219,8 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			close(logDone)
 			wg.Wait()
 			if agentExitErr != nil {
-				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", issue)
+				id2 := issueDisplayFor(wtPath, issue)
+				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", id2)
 				return nil
 			}
 			branch, branchErr := git.CurrentBranch(wtPath)
@@ -2206,27 +2228,33 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 				branch = ""
 			}
 			hasPR := reportPRStatus(out, wtPath, branch, issue, sddName != "")
-			if af3, err3 := state.Read(wtPath); err3 == nil && af3.DevPort != "" {
+			af3, _ := state.Read(wtPath)
+			if af3.DevPort != "" {
 				fmt.Fprintf(out, "Dev server: http://localhost:%s\n", af3.DevPort)
+			}
+			id3 := af3.IssueArg
+			if id3 == "" {
+				id3 = issue
 			}
 			if sddName != "" && !hasPR {
 				if specPath := findSpecPath(wtPath, issue); specPath != "" {
 					fmt.Fprintf(out, "Spec: %s\n", specPath)
 				}
-				fmt.Fprintf(out, resumeHintFmt, issue)
+				fmt.Fprintf(out, resumeHintFmt, id3)
 			}
 			if hasPR {
-				fmt.Fprintf(out, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", issue)
+				fmt.Fprintf(out, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", id3)
 			}
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)
 			close(logDone)
 			wg.Wait()
+			id4 := issueDisplayFor(wtPath, issue)
 			fmt.Fprintf(out, "agent still running in background\n")
-			fmt.Fprintf(out, "  agentctl logs %s     # follow log\n", issue)
-			fmt.Fprintf(out, "  agentctl attach %s   # stream live output\n", issue)
-			fmt.Fprintf(out, "  agentctl discard %s  # permanently delete worktree and branches\n", issue)
+			fmt.Fprintf(out, "  agentctl logs %s     # follow log\n", id4)
+			fmt.Fprintf(out, "  agentctl attach %s   # stream live output\n", id4)
+			fmt.Fprintf(out, "  agentctl discard %s  # permanently delete worktree and branches\n", id4)
 			return nil
 		}
 	}
@@ -3205,10 +3233,11 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 	}
 
 	if headless {
+		id := issueDisplayFor(wtPath, issue)
 		fmt.Printf("Released pause for issue %s; Stage 2 running in background.\n", issue)
-		fmt.Printf("agentctl logs %s      # follow log\n", issue)
-		fmt.Printf("agentctl attach %s    # stream live and wait\n", issue)
-		fmt.Printf("agentctl discard %s   # abandon\n", issue)
+		fmt.Printf("agentctl logs %s      # follow log\n", id)
+		fmt.Printf("agentctl attach %s    # stream live and wait\n", id)
+		fmt.Printf("agentctl discard %s   # abandon\n", id)
 		if sendNotify {
 			maybeFireTestNotification(issue, os.Stdout)
 			go func() {
@@ -3324,24 +3353,29 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			af2, _ := state.Read(wtPath)
 			resumeSDD := af2.SDD
 			hasPR := reportPRStatus(os.Stdout, wtPath, branch, issue, resumeSDD != "")
+			id := af2.IssueArg
+			if id == "" {
+				id = issue
+			}
 			if resumeSDD != "" && !hasPR {
 				if specPath := findSpecPath(wtPath, issue); specPath != "" {
 					fmt.Fprintf(os.Stdout, "Spec: %s\n", specPath)
 				}
-				fmt.Fprintf(os.Stdout, resumeHintFmt, issue)
+				fmt.Fprintf(os.Stdout, resumeHintFmt, id)
 			}
 			if hasPR {
-				fmt.Fprintf(os.Stdout, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", issue)
+				fmt.Fprintf(os.Stdout, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", id)
 			}
 			return nil
 		case <-sigCh:
 			signal.Stop(sigCh)
 			close(logDone)
 			wg.Wait()
+			id2 := issueDisplayFor(wtPath, issue)
 			fmt.Fprintf(os.Stdout, "agent still running in background\n")
-			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", issue)
-			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", issue)
-			fmt.Fprintf(os.Stdout, "  agentctl discard %s  # permanently delete worktree and branches\n", issue)
+			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", id2)
+			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", id2)
+			fmt.Fprintf(os.Stdout, "  agentctl discard %s  # permanently delete worktree and branches\n", id2)
 			return nil
 		}
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1591,6 +1591,27 @@ func matchesGitHubOrigin(repoRoot, owner, repoName string) bool {
 	return strings.HasSuffix(u, "/"+suffix) || strings.HasSuffix(u, ":"+suffix)
 }
 
+// githubIssueURL builds the canonical https://github.com/<owner>/<repo>/issues/<num>
+// URL from the git origin of repoRoot. Returns "" when the origin is not a
+// recognised GitHub remote (so callers can fall back gracefully).
+func githubIssueURL(repoRoot, issueNum string) string {
+	u, err := git.OriginURL(repoRoot)
+	if err != nil {
+		return ""
+	}
+	u = strings.TrimSuffix(strings.TrimSpace(u), ".git")
+	// HTTPS: https://github.com/owner/repo
+	if strings.HasPrefix(u, "https://github.com/") {
+		return u + "/issues/" + issueNum
+	}
+	// SSH: git@github.com:owner/repo
+	const sshPrefix = "git@github.com:"
+	if strings.HasPrefix(u, sshPrefix) {
+		return "https://github.com/" + strings.TrimPrefix(u, sshPrefix) + "/issues/" + issueNum
+	}
+	return ""
+}
+
 // locateOrCloneRepo returns the local git repo root for github.com/<owner>/<repoName>.
 // It searches in order:
 //  1. The repo that contains the current working directory.
@@ -1641,6 +1662,11 @@ func repoRootForIssue(arg string, out io.Writer) (repoRoot, issueNum, ghIssueArg
 		root, err := git.RepoRoot()
 		if err != nil {
 			return "", "", "", fmt.Errorf("cannot determine repo root: %w", err)
+		}
+		// Resolve bare number to a full GitHub URL so IssueArg is always
+		// unambiguous regardless of how the issue was supplied.
+		if fullURL := githubIssueURL(root, arg); fullURL != "" {
+			return root, arg, fullURL, nil
 		}
 		return root, arg, arg, nil
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1011,6 +1011,9 @@ Ctrl+C. Use --no-follow to print history and exit immediately.`,
 
 // runLogs resolves the worktree for issue and streams its agent.log.
 func runLogs(issue string, lines int, noFollow bool, w io.Writer) error {
+	if _, _, num, ok := parseIssueURL(issue); ok {
+		issue = num
+	}
 	wtPath, err := findWorktreePath(issue)
 	if err != nil {
 		return err
@@ -1302,11 +1305,15 @@ and the command exits with "agent has already finished".
 Press Ctrl+C to detach without stopping the agent.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			wtPath, err := findWorktreePath(args[0])
+			arg := args[0]
+			if _, _, num, ok := parseIssueURL(arg); ok {
+				arg = num
+			}
+			wtPath, err := findWorktreePath(arg)
 			if err != nil {
 				return err
 			}
-			return attachLog(wtPath, args[0], os.Stdout, 10*time.Second)
+			return attachLog(wtPath, arg, os.Stdout, 10*time.Second)
 		},
 	}
 }
@@ -1614,10 +1621,15 @@ func githubIssueURL(repoRoot, issueNum string) string {
 	if strings.HasPrefix(u, "https://github.com/") {
 		return u + "/issues/" + issueNum
 	}
-	// SSH: git@github.com:owner/repo
+	// SSH scp-style: git@github.com:owner/repo
 	const sshPrefix = "git@github.com:"
 	if strings.HasPrefix(u, sshPrefix) {
 		return "https://github.com/" + strings.TrimPrefix(u, sshPrefix) + "/issues/" + issueNum
+	}
+	// SSH URL-style: ssh://git@github.com/owner/repo
+	const sshURLPrefix = "ssh://git@github.com/"
+	if strings.HasPrefix(u, sshURLPrefix) {
+		return "https://github.com/" + strings.TrimPrefix(u, sshURLPrefix) + "/issues/" + issueNum
 	}
 	return ""
 }

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -367,6 +367,11 @@ Use --headless to run it in the background and write output to agent.log.`,
 }
 
 func runReleasePausedSession(issue, feedback string, headless, quiet, sendNotify bool) error {
+	// Accept full GitHub issue URLs; extract the bare number for local lookup.
+	if _, _, num, ok := parseIssueURL(issue); ok {
+		issue = num
+	}
+
 	repoRoot, err := git.RepoRoot()
 	if err != nil {
 		return fmt.Errorf("cannot determine repo root: %w", err)
@@ -1893,8 +1898,8 @@ func generateUUID() (string, error) {
 // it from the current branch when inside a linked worktree.
 func resolveIssueArg(flag string, args []string) (string, error) {
 	if len(args) == 1 && args[0] != "" {
-		if _, _, _, ok := parseIssueURL(args[0]); ok {
-			return "", fmt.Errorf("issue URLs are not accepted here; re-run with the bare issue number:\n  agentctl %s <issue>", flag)
+		if _, _, num, ok := parseIssueURL(args[0]); ok {
+			return num, nil
 		}
 		return args[0], nil
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -547,6 +547,39 @@ func TestMatchesGitHubOrigin_noOrigin(t *testing.T) {
 	}
 }
 
+// ─── githubIssueURL ──────────────────────────────────────────────────────────
+
+func TestGithubIssueURL_https(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://github.com/myorg/myrepo.git")
+	got := githubIssueURL(dir, "42")
+	want := "https://github.com/myorg/myrepo/issues/42"
+	if got != want {
+		t.Errorf("githubIssueURL (HTTPS) = %q, want %q", got, want)
+	}
+}
+
+func TestGithubIssueURL_ssh(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "git@github.com:myorg/myrepo.git")
+	got := githubIssueURL(dir, "7")
+	want := "https://github.com/myorg/myrepo/issues/7"
+	if got != want {
+		t.Errorf("githubIssueURL (SSH) = %q, want %q", got, want)
+	}
+}
+
+func TestGithubIssueURL_noOrigin(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	got := githubIssueURL(dir, "1")
+	if got != "" {
+		t.Errorf("githubIssueURL without origin = %q, want empty string", got)
+	}
+}
+
 // ─── locateOrCloneRepo ───────────────────────────────────────────────────────
 
 func TestLocateOrCloneRepo_cwdMatch(t *testing.T) {
@@ -655,8 +688,8 @@ func TestRepoRootForIssue_bareNumber(t *testing.T) {
 	if issueNum != "42" {
 		t.Errorf("issueNum = %q, want %q", issueNum, "42")
 	}
-	if ghArg != "42" {
-		t.Errorf("ghArg = %q, want %q", ghArg, "42")
+	if ghArg != "https://github.com/myorg/myrepo/issues/42" {
+		t.Errorf("ghArg = %q, want full GitHub URL", ghArg)
 	}
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -411,13 +411,13 @@ func TestResolveIssueArg_withArg(t *testing.T) {
 	}
 }
 
-func TestResolveIssueArg_rejectsURL(t *testing.T) {
-	_, err := resolveIssueArg("discard", []string{"https://github.com/myorg/myrepo/issues/42"})
-	if err == nil {
-		t.Error("expected error when a full issue URL is passed")
+func TestResolveIssueArg_acceptsURL(t *testing.T) {
+	issue, err := resolveIssueArg("discard", []string{"https://github.com/myorg/myrepo/issues/42"})
+	if err != nil {
+		t.Fatalf("unexpected error for URL arg: %v", err)
 	}
-	if !strings.Contains(err.Error(), "bare issue number") {
-		t.Errorf("expected 'bare issue number' in error, got: %v", err)
+	if issue != "42" {
+		t.Errorf("got %q, want %q", issue, "42")
 	}
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -567,6 +567,15 @@ func TestGithubIssueURL_ssh(t *testing.T) {
 	}
 }
 
+func TestGithubIssueURL_sshURL(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "ssh://git@github.com/myorg/myrepo.git")
+	got := githubIssueURL(dir, "5")
+	want := "https://github.com/myorg/myrepo/issues/5"
+	if got != want {
+		t.Errorf("githubIssueURL (ssh://) = %q, want %q", got, want)
+	}
+}
+
 func TestGithubIssueURL_noOrigin(t *testing.T) {
 	dir := t.TempDir()
 	cmd := exec.Command("git", "init")

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -20,7 +20,7 @@ type AgentFile struct {
 	DevPort   string // port allocated for the dev server; empty when no dev server
 	AgentPID  string // PID of the background agent process (headless only)
 	SDD       string // SDD methodology name, e.g. "plain", "speckit"; empty if none
-	IssueArg  string // original user-supplied arg (URL or bare number); used for display hints
+	IssueArg  string // canonical GitHub issue URL for display hints (e.g. https://github.com/owner/repo/issues/42); empty when not set
 	// SDDSet is true when the sdd= key was explicitly present in the .agent file,
 	// even if its value is empty. Use this to distinguish new worktrees created
 	// without --sdd (SDDSet=true, SDD="") from legacy worktrees written before the
@@ -96,6 +96,8 @@ func GetKey(worktreePath, key string) (string, error) {
 		return af.AgentPID, nil
 	case "sdd":
 		return af.SDD, nil
+	case "issue-arg":
+		return af.IssueArg, nil
 	default:
 		return af.Extra[key], nil
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -20,6 +20,7 @@ type AgentFile struct {
 	DevPort   string // port allocated for the dev server; empty when no dev server
 	AgentPID  string // PID of the background agent process (headless only)
 	SDD       string // SDD methodology name, e.g. "plain", "speckit"; empty if none
+	IssueArg  string // original user-supplied arg (URL or bare number); used for display hints
 	// SDDSet is true when the sdd= key was explicitly present in the .agent file,
 	// even if its value is empty. Use this to distinguish new worktrees created
 	// without --sdd (SDDSet=true, SDD="") from legacy worktrees written before the
@@ -66,6 +67,8 @@ func Read(worktreePath string) (AgentFile, error) {
 		case "sdd":
 			af.SDD = v
 			af.SDDSet = true
+		case "issue-arg":
+			af.IssueArg = v
 		default:
 			af.Extra[k] = v
 		}
@@ -116,6 +119,9 @@ func Write(worktreePath string, af AgentFile) error {
 	// Always write sdd= so readers can distinguish new worktrees created without
 	// --sdd (sdd= present but empty) from legacy worktrees that predate this key.
 	lines = append(lines, "sdd="+af.SDD)
+	if af.IssueArg != "" {
+		lines = append(lines, "issue-arg="+af.IssueArg)
+	}
 	for k, v := range af.Extra {
 		lines = append(lines, k+"="+v)
 	}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -199,6 +199,38 @@ func TestReadExtraKeys(t *testing.T) {
 	}
 }
 
+func TestIssueArgRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	af := AgentFile{
+		Agent:     "claude",
+		SessionID: "s1",
+		DevPID:    "0",
+		IssueArg:  "https://github.com/owner/repo/issues/42",
+	}
+	if err := Write(dir, af); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.IssueArg != af.IssueArg {
+		t.Errorf("IssueArg = %q, want %q", got.IssueArg, af.IssueArg)
+	}
+}
+
+func TestIssueArgOmittedWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	af := AgentFile{Agent: "claude", SessionID: "s1", DevPID: "0"}
+	if err := Write(dir, af); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, FileName))
+	if strings.Contains(string(raw), "issue-arg") {
+		t.Errorf("expected no issue-arg line when IssueArg is empty, got:\n%s", raw)
+	}
+}
+
 func contains(s, sub string) bool {
 	return strings.Contains(s, sub)
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -225,7 +225,10 @@ func TestIssueArgOmittedWhenEmpty(t *testing.T) {
 	if err := Write(dir, af); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
-	raw, _ := os.ReadFile(filepath.Join(dir, FileName))
+	raw, err := os.ReadFile(filepath.Join(dir, FileName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
 	if strings.Contains(string(raw), "issue-arg") {
 		t.Errorf("expected no issue-arg line when IssueArg is empty, got:\n%s", raw)
 	}


### PR DESCRIPTION
## Summary

Ensures the full GitHub issue URL (e.g. \`https://github.com/owner/repo/issues/42\`) is always stored in \`issue-arg\` in \`.agent\` and shown in every command hint, regardless of whether the user started with a bare number or a URL.

**Changes:**

- **`internal/state`**: Added `IssueArg` field to `AgentFile`; persisted as `issue-arg=` in `.agent`; two new tests for round-trip and empty-omission.
- **`repoRootForIssue`**: When given a bare issue number, calls new `githubIssueURL()` helper to derive the canonical URL from the git origin (HTTPS and SSH formats), so `IssueArg` is always a full URL.
- **`startOne`**: Writes `IssueArg` (full URL) into `.agent` at start time.
- **`issueDisplayFor(wtPath, fallback)`**: New helper that reads `issue-arg` from `.agent` and falls back to the bare number for older worktrees.
- **All hint sites updated** to use `issueDisplayFor` or `IssueArg` directly:
  - `launchAgent`: headless launch hints, foreground exit, Ctrl+C detach
  - `agentResume`: headless release hints, foreground exit, Ctrl+C detach
  - `streamLog`: spec-ready resume hint after agent exits
  - `worktreeExistsError`: attach/cleanup/discard hints in duplicate-worktree error

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes — including new `TestGithubIssueURL_*`, `TestIssueArgRoundTrip`, `TestIssueArgOmittedWhenEmpty`, and updated `TestRepoRootForIssue_bareNumber`
- [ ] Manual: `agentctl start 42` → `.agent` contains `issue-arg=https://github.com/<owner>/<repo>/issues/42`; all subsequent hints (`logs`, `resume`, `cleanup`, Ctrl+C) show full URL
- [ ] Manual: `agentctl start https://github.com/owner/repo/issues/42` → same full URL in `issue-arg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)