### PR TITLE
fix: discard accepts comma-separated issue list

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -426,7 +426,12 @@ This action is NOT recoverable. You will be prompted to type YES to confirm.
 If no issue number is given, it is inferred from the current branch when
 you are inside a linked worktree.
 
-Multiple issues may be given as a comma-separated list (e.g. 55,56,57).
+Multiple issues may be given as a comma-separated list. Each list item may
+be a bare issue number or a full GitHub issue URL, e.g.:
+
+  agentctl discard 55,56,57
+  agentctl discard 55,https://github.com/org/repo/issues/56,57
+
 Each worktree is discarded in sequence; you will be prompted to confirm
 each one.
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -418,13 +418,17 @@ func runReleasePausedSession(issue, feedback string, headless, quiet, sendNotify
 func NewDiscardCmd() *cobra.Command {
 	var stale bool
 	c := &cobra.Command{
-		Use:   "discard [issue]",
+		Use:   "discard [issue[,issue...]]",
 		Short: "Permanently delete a worktree and its local/remote branches",
 		Long: `Discard the worktree for an issue and delete the local and remote branches.
 This action is NOT recoverable. You will be prompted to type YES to confirm.
 
 If no issue number is given, it is inferred from the current branch when
 you are inside a linked worktree.
+
+Multiple issues may be given as a comma-separated list (e.g. 55,56,57).
+Each worktree is discarded in sequence; you will be prompted to confirm
+each one.
 
 Use --stale to discard all worktrees that have no running agent and no PR.`,
 		Args: cobra.RangeArgs(0, 1),
@@ -435,11 +439,32 @@ Use --stale to discard all worktrees that have no running agent and no PR.`,
 				}
 				return runDiscardStale()
 			}
-			issue, err := resolveIssueArg("discard", args)
-			if err != nil {
-				return err
+			if len(args) == 0 {
+				issue, err := resolveIssueArg("discard", nil)
+				if err != nil {
+					return err
+				}
+				return runRemoveWorktree(issue)
 			}
-			return runRemoveWorktree(issue)
+			rawIssues := strings.Split(args[0], ",")
+			issues := make([]string, 0, len(rawIssues))
+			for _, iss := range rawIssues {
+				if s := strings.TrimSpace(iss); s != "" {
+					if _, _, num, ok := parseIssueURL(s); ok {
+						s = num
+					}
+					issues = append(issues, s)
+				}
+			}
+			if len(issues) == 0 {
+				return fmt.Errorf("no valid issue tokens found in %q", args[0])
+			}
+			for _, issue := range issues {
+				if err := runRemoveWorktree(issue); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}
 	c.Flags().BoolVar(&stale, "stale", false, "Discard all worktrees with no running agent and no PR")

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -3949,6 +3949,42 @@ func TestDiscardCmd_staleMutuallyExclusiveWithIssue(t *testing.T) {
 	}
 }
 
+// TestDiscardCmd_useFieldIncludesCommaSyntax verifies that the discard command
+// advertises comma-separated input in its Use string.
+func TestDiscardCmd_useFieldIncludesCommaSyntax(t *testing.T) {
+	c := NewDiscardCmd()
+	if !strings.Contains(c.Use, ",") {
+		t.Errorf("discard Use field should advertise comma-separated issues; got: %q", c.Use)
+	}
+}
+
+// TestDiscardCmd_emptyTokensRejected verifies that a comma-only or
+// whitespace-only issue argument returns a user-facing error.
+func TestDiscardCmd_emptyTokensRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+	}{
+		{"comma only", ","},
+		{"spaced commas", " , "},
+		{"multiple commas", ",,"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewDiscardCmd()
+			c.SilenceUsage = true
+			c.SetArgs([]string{tt.arg})
+			err := c.Execute()
+			if err == nil {
+				t.Fatal("expected error for empty issue tokens, got nil")
+			}
+			if !strings.Contains(err.Error(), "no valid issue tokens found") {
+				t.Errorf("wrong error message: %v", err)
+			}
+		})
+	}
+}
+
 func TestIsAgentRunning_noAgentFile(t *testing.T) {
 	dir := t.TempDir()
 	if isAgentRunning(dir) {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -3968,6 +3968,7 @@ func TestDiscardCmd_emptyTokensRejected(t *testing.T) {
 		{"comma only", ","},
 		{"spaced commas", " , "},
 		{"multiple commas", ",,"},
+		{"whitespace only", "   "},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -3980,6 +3981,71 @@ func TestDiscardCmd_emptyTokensRejected(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), "no valid issue tokens found") {
 				t.Errorf("wrong error message: %v", err)
+			}
+		})
+	}
+}
+
+// TestDiscardCmd_commaSplitAndURLNormalization verifies that comma-separated
+// inputs (including full GitHub issue URLs) are each resolved and processed
+// individually — producing a "Nothing to remove" message per token when the
+// repo has no matching worktrees or branches.
+func TestDiscardCmd_commaSplitAndURLNormalization(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	repo := initGitRepoForStale(t)
+	chdirTemp(t, repo)
+
+	tests := []struct {
+		name      string
+		arg       string
+		wantIssues []string // issue numbers expected in "Nothing to remove" output
+	}{
+		{
+			name:       "two bare numbers",
+			arg:        "55,56",
+			wantIssues: []string{"55", "56"},
+		},
+		{
+			name:       "bare number and URL",
+			arg:        "43,https://github.com/org/repo/issues/44",
+			wantIssues: []string{"43", "44"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture os.Stdout because runRemoveWorktree uses fmt.Printf.
+			oldStdout := os.Stdout
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Stdout = w
+
+			c := NewDiscardCmd()
+			c.SilenceUsage = true
+			c.SetArgs([]string{tt.arg})
+			runErr := c.Execute()
+
+			w.Close()
+			var buf bytes.Buffer
+			if _, err := io.Copy(&buf, r); err != nil {
+				t.Fatal(err)
+			}
+			os.Stdout = oldStdout
+			r.Close()
+
+			if runErr != nil {
+				t.Fatalf("unexpected error: %v", runErr)
+			}
+			out := buf.String()
+			for _, issue := range tt.wantIssues {
+				if !strings.Contains(out, "Nothing to remove") || !strings.Contains(out, issue) {
+					t.Errorf("expected 'Nothing to remove' for issue %s in output; got: %q", issue, out)
+				}
 			}
 		})
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -4043,8 +4043,13 @@ func TestDiscardCmd_commaSplitAndURLNormalization(t *testing.T) {
 			}
 			out := buf.String()
 			for _, issue := range tt.wantIssues {
-				if !strings.Contains(out, "Nothing to remove") || !strings.Contains(out, issue) {
-					t.Errorf("expected 'Nothing to remove' for issue %s in output; got: %q", issue, out)
+				// runRemoveWorktree emits exactly:
+				//   "Nothing to remove: no worktree or branch found for issue <N>.\n"
+				// Check that the complete phrase appears so we don't get a false
+				// positive when multiple issues share digit substrings.
+				want := fmt.Sprintf("Nothing to remove: no worktree or branch found for issue %s.", issue)
+				if !strings.Contains(out, want) {
+					t.Errorf("expected %q in output; got: %q", want, out)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

- `agentctl discard 55,56` now splits on commas and discards each worktree in sequence, matching how `start` handles comma-separated input
- Empty-token inputs like `,,` return a clear error (`no valid issue tokens found`) instead of silently finding nothing
- URL tokens (e.g. `https://github.com/…/issues/42`) inside a comma list are resolved to bare issue numbers before lookup

## Test plan

- [ ] `go test ./...` passes (all packages green)
- [ ] `go build ./...` and `go vet ./...` are clean
- [ ] `TestDiscardCmd_useFieldIncludesCommaSyntax` — Use field advertises comma syntax
- [ ] `TestDiscardCmd_emptyTokensRejected` — empty tokens return `no valid issue tokens found`

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)