### PR TITLE
feat: cache PR number and URL in .agent (#159)

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -986,16 +986,26 @@ func runStatus(verbose bool) error {
 		if branch != "?" && branch != "HEAD" {
 			if af.PRNumber != "" {
 				// Cache hit — use stored number, call gh live for current state.
-				if ps, _, _, err := ghPRInfoWithURL(repoRoot, af.PRNumber); err == nil && ps != "" {
+				if ps, _, prURL, err := ghPRInfoWithURL(repoRoot, af.PRNumber); err == nil && ps != "" {
 					prState = fmt.Sprintf("#%s %s", af.PRNumber, ps)
+					// Backfill pr-url if it was missing (partial write or manually edited .agent).
+					if af.PRURL == "" && prURL != "" {
+						if appendErr := state.AppendKeyIfExists(wt.Path, "pr-url", prURL); appendErr != nil {
+							fmt.Fprintf(os.Stderr, "WARNING: could not cache pr-url: %v\n", appendErr)
+						}
+					}
 				}
 			} else {
 				// Cache miss — discover PR via branch name.
 				if ps, n, prURL, err := ghPRInfoWithURL(repoRoot, branch); err == nil && ps != "" {
 					if n > 0 {
 						prState = fmt.Sprintf("#%d %s", n, ps)
-						_ = state.AppendKey(wt.Path, "pr", strconv.Itoa(n))
-						_ = state.AppendKey(wt.Path, "pr-url", prURL)
+						if appendErr := state.AppendKeyIfExists(wt.Path, "pr", strconv.Itoa(n)); appendErr != nil {
+							fmt.Fprintf(os.Stderr, "WARNING: could not cache pr: %v\n", appendErr)
+						}
+						if appendErr := state.AppendKeyIfExists(wt.Path, "pr-url", prURL); appendErr != nil {
+							fmt.Fprintf(os.Stderr, "WARNING: could not cache pr-url: %v\n", appendErr)
+						}
 					} else {
 						prState = ps
 					}
@@ -1559,7 +1569,12 @@ func ghPRInfoWithURL(repoRoot, ref string) (prState string, number int, url stri
 		URL    string `json:"url"`
 	}
 	if err = json.Unmarshal(out.Bytes(), &result); err != nil {
-		return "", 0, "", fmt.Errorf("unexpected gh output: %q", out.String())
+		snippet := strings.TrimSpace(out.String())
+		runes := []rune(snippet)
+		if len(runes) > 200 {
+			snippet = string(runes[:200]) + "..."
+		}
+		return "", 0, "", fmt.Errorf("unexpected gh output: %w (output: %q)", err, snippet)
 	}
 	return result.State, result.Number, result.URL, nil
 }

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -984,11 +984,21 @@ func runStatus(verbose bool) error {
 
 		prState := "none"
 		if branch != "?" && branch != "HEAD" {
-			if ps, n, err := ghPRInfo(repoRoot, branch); err == nil && ps != "" {
-				if n > 0 {
-					prState = fmt.Sprintf("#%d %s", n, ps)
-				} else {
-					prState = ps
+			if af.PRNumber != "" {
+				// Cache hit — use stored number, call gh live for current state.
+				if ps, _, _, err := ghPRInfoWithURL(repoRoot, af.PRNumber); err == nil && ps != "" {
+					prState = fmt.Sprintf("#%s %s", af.PRNumber, ps)
+				}
+			} else {
+				// Cache miss — discover PR via branch name.
+				if ps, n, prURL, err := ghPRInfoWithURL(repoRoot, branch); err == nil && ps != "" {
+					if n > 0 {
+						prState = fmt.Sprintf("#%d %s", n, ps)
+						_ = state.AppendKey(wt.Path, "pr", strconv.Itoa(n))
+						_ = state.AppendKey(wt.Path, "pr-url", prURL)
+					} else {
+						prState = ps
+					}
 				}
 			}
 		}
@@ -1529,6 +1539,29 @@ func ghHasPR(repoRoot, branch string) (bool, error) {
 func ghPRState(repoRoot, branch string) (string, error) {
 	state, _, err := ghPRInfo(repoRoot, branch)
 	return state, err
+}
+
+// ghPRInfoWithURL calls `gh pr view <ref>` in repoRoot and returns the PR state,
+// number, and URL. ref can be a branch name or a PR number string — gh accepts both.
+// All are zero-values on error.
+func ghPRInfoWithURL(repoRoot, ref string) (prState string, number int, url string, err error) {
+	cmd := exec.Command("gh", "pr", "view", ref, "--json", "state,number,url")
+	cmd.Dir = repoRoot
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err = cmd.Run(); err != nil {
+		return "", 0, "", fmt.Errorf("%w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	var result struct {
+		State  string `json:"state"`
+		Number int    `json:"number"`
+		URL    string `json:"url"`
+	}
+	if err = json.Unmarshal(out.Bytes(), &result); err != nil {
+		return "", 0, "", fmt.Errorf("unexpected gh output: %q", out.String())
+	}
+	return result.State, result.Number, result.URL, nil
 }
 
 type prInfo struct {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -4686,3 +4686,38 @@ func TestRunDevStart_success(t *testing.T) {
 	}
 	t.Cleanup(func() { process.Kill(af.DevPID) })
 }
+
+func TestGhPRInfoWithURL_found(t *testing.T) {
+	stubDir := t.TempDir()
+	viewJSON := `{"state":"OPEN","number":42,"url":"https://github.com/owner/repo/pull/42"}`
+	makeGHStub(t, stubDir, viewJSON, "", false)
+	prependPath(t, stubDir)
+
+	prState, number, url, err := ghPRInfoWithURL(t.TempDir(), "my-feature-branch")
+	if err != nil {
+		t.Fatalf("ghPRInfoWithURL: %v", err)
+	}
+	if prState != "OPEN" {
+		t.Errorf("prState: got %q, want %q", prState, "OPEN")
+	}
+	if number != 42 {
+		t.Errorf("number: got %d, want %d", number, 42)
+	}
+	if url != "https://github.com/owner/repo/pull/42" {
+		t.Errorf("url: got %q, want %q", url, "https://github.com/owner/repo/pull/42")
+	}
+}
+
+func TestGhPRInfoWithURL_noPR(t *testing.T) {
+	stubDir := t.TempDir()
+	makeGHStub(t, stubDir, "", "", false)
+	prependPath(t, stubDir)
+
+	prState, number, url, err := ghPRInfoWithURL(t.TempDir(), "my-feature-branch")
+	if err == nil {
+		t.Fatal("expected error when no PR exists, got nil")
+	}
+	if prState != "" || number != 0 || url != "" {
+		t.Errorf("expected zero values on error, got prState=%q number=%d url=%q", prState, number, url)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -21,6 +21,8 @@ type AgentFile struct {
 	AgentPID  string // PID of the background agent process (headless only)
 	SDD       string // SDD methodology name, e.g. "plain", "speckit"; empty if none
 	IssueArg  string // canonical GitHub issue URL for display hints (e.g. https://github.com/owner/repo/issues/42); empty when not set
+	PRNumber  string // PR number, e.g. "42"; empty until first agentctl status after PR opens
+	PRURL     string // full PR URL, e.g. "https://github.com/owner/repo/pull/42"; empty until first agentctl status after PR opens
 	// SDDSet is true when the sdd= key was explicitly present in the .agent file,
 	// even if its value is empty. Use this to distinguish new worktrees created
 	// without --sdd (SDDSet=true, SDD="") from legacy worktrees written before the
@@ -69,6 +71,10 @@ func Read(worktreePath string) (AgentFile, error) {
 			af.SDDSet = true
 		case "issue-arg":
 			af.IssueArg = v
+		case "pr":
+			af.PRNumber = v
+		case "pr-url":
+			af.PRURL = v
 		default:
 			af.Extra[k] = v
 		}
@@ -98,6 +104,10 @@ func GetKey(worktreePath, key string) (string, error) {
 		return af.SDD, nil
 	case "issue-arg":
 		return af.IssueArg, nil
+	case "pr":
+		return af.PRNumber, nil
+	case "pr-url":
+		return af.PRURL, nil
 	default:
 		return af.Extra[key], nil
 	}
@@ -123,6 +133,12 @@ func Write(worktreePath string, af AgentFile) error {
 	lines = append(lines, "sdd="+af.SDD)
 	if af.IssueArg != "" {
 		lines = append(lines, "issue-arg="+af.IssueArg)
+	}
+	if af.PRNumber != "" {
+		lines = append(lines, "pr="+af.PRNumber)
+	}
+	if af.PRURL != "" {
+		lines = append(lines, "pr-url="+af.PRURL)
 	}
 	for k, v := range af.Extra {
 		lines = append(lines, k+"="+v)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -160,3 +160,21 @@ func AppendKey(worktreePath, key, value string) error {
 	_, err = fmt.Fprintf(f, "%s=%s\n", key, value)
 	return err
 }
+
+// AppendKeyIfExists appends a single key=value line to the .agent file only
+// if the file already exists. It is a no-op (returns nil) when the file is
+// absent, so callers cannot accidentally create a .agent file in a worktree
+// that agentctl never initialised.
+func AppendKeyIfExists(worktreePath, key, value string) error {
+	path := filepath.Join(worktreePath, FileName)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = fmt.Fprintf(f, "%s=%s\n", key, value)
+	return err
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -234,6 +234,93 @@ func TestIssueArgOmittedWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestPRNumberRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := AgentFile{
+		Agent:     "claude",
+		SessionID: "s1",
+		DevPID:    "1234",
+		PRNumber:  "42",
+		PRURL:     "https://github.com/owner/repo/pull/42",
+	}
+	if err := Write(dir, want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.PRNumber != want.PRNumber {
+		t.Errorf("PRNumber: got %q, want %q", got.PRNumber, want.PRNumber)
+	}
+	if got.PRURL != want.PRURL {
+		t.Errorf("PRURL: got %q, want %q", got.PRURL, want.PRURL)
+	}
+}
+
+func TestWriteOmitsPRFieldsWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	af := AgentFile{Agent: "claude", SessionID: "s1", DevPID: "0"}
+	if err := Write(dir, af); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, FileName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(raw)
+	if strings.Contains(content, "pr=") {
+		t.Error("expected no pr= line when PRNumber is empty")
+	}
+	if strings.Contains(content, "pr-url=") {
+		t.Error("expected no pr-url= line when PRURL is empty")
+	}
+}
+
+func TestAppendKeyPRNumber(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, AgentFile{Agent: "claude", SessionID: "s1", DevPID: "0"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := AppendKey(dir, "pr", "7"); err != nil {
+		t.Fatalf("AppendKey pr: %v", err)
+	}
+	if err := AppendKey(dir, "pr-url", "https://github.com/owner/repo/pull/7"); err != nil {
+		t.Fatalf("AppendKey pr-url: %v", err)
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.PRNumber != "7" {
+		t.Errorf("PRNumber: got %q, want %q", got.PRNumber, "7")
+	}
+	if got.PRURL != "https://github.com/owner/repo/pull/7" {
+		t.Errorf("PRURL: got %q, want %q", got.PRURL, "https://github.com/owner/repo/pull/7")
+	}
+}
+
+func TestGetKeyPR(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, AgentFile{
+		Agent:     "claude",
+		SessionID: "s1",
+		DevPID:    "0",
+		PRNumber:  "99",
+		PRURL:     "https://github.com/owner/repo/pull/99",
+	}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	v, err := GetKey(dir, "pr")
+	if err != nil || v != "99" {
+		t.Errorf("GetKey pr: got %q %v", v, err)
+	}
+	v, err = GetKey(dir, "pr-url")
+	if err != nil || v != "https://github.com/owner/repo/pull/99" {
+		t.Errorf("GetKey pr-url: got %q %v", v, err)
+	}
+}
+
 func contains(s, sub string) bool {
 	return strings.Contains(s, sub)
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -321,6 +321,35 @@ func TestGetKeyPR(t *testing.T) {
 	}
 }
 
+func TestAppendKeyIfExists_existingFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, AgentFile{Agent: "claude", SessionID: "s1", DevPID: "0"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := AppendKeyIfExists(dir, "pr", "55"); err != nil {
+		t.Fatalf("AppendKeyIfExists: %v", err)
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.PRNumber != "55" {
+		t.Errorf("PRNumber: got %q, want %q", got.PRNumber, "55")
+	}
+}
+
+func TestAppendKeyIfExists_missingFile(t *testing.T) {
+	dir := t.TempDir()
+	// No .agent file exists — AppendKeyIfExists must be a no-op and return nil.
+	if err := AppendKeyIfExists(dir, "pr", "55"); err != nil {
+		t.Fatalf("AppendKeyIfExists on missing file returned error: %v", err)
+	}
+	// Confirm the file was NOT created.
+	if _, statErr := os.Stat(filepath.Join(dir, FileName)); !os.IsNotExist(statErr) {
+		t.Error("expected .agent file to remain absent after AppendKeyIfExists on missing file")
+	}
+}
+
 func contains(s, sub string) bool {
 	return strings.Contains(s, sub)
 }


### PR DESCRIPTION
## Summary

- Adds `PRNumber` and `PRURL` fields to `state.AgentFile`, stored as `pr=<n>` and `pr-url=<url>` in `.agent`
- `agentctl status` writes both on first detection of a PR (cache miss path), then uses the cached number on subsequent runs — only calling `gh` live for the current state
- Adds `ghPRInfoWithURL` helper that accepts a branch name or PR number and returns state, number, and URL in one `gh pr view` call

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./internal/state/...` — covers `TestPRNumberRoundTrip`, `TestWriteOmitsPRFieldsWhenEmpty`, `TestAppendKeyPRNumber`, `TestGetKeyPR`
- [ ] `go test ./internal/cmd/...` — covers `TestGhPRInfoWithURL_found`, `TestGhPRInfoWithURL_noPR`
- [ ] `go test ./...`
- [ ] Manual: run `agentctl status` on a worktree with an open PR; confirm `pr=` and `pr-url=` appear in `.agent`; run again and confirm cached path is used

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)