### PR TITLE
fix: eliminate macOS keychain access — require GITHUB_TOKEN env var

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1878,7 +1878,7 @@ func ensureGHToken() error {
 		os.Setenv("GITHUB_TOKEN", tok)
 		return nil
 	}
-	return fmt.Errorf("GITHUB_TOKEN is not set\n\nAdd the following to your shell profile (~/.zshrc or ~/.bashrc) and re-run:\n  export GITHUB_TOKEN=$(gh auth token)")
+	return fmt.Errorf("GITHUB_TOKEN is not set\n\nSet it in your current shell (or shell profile) and re-run:\n  export GITHUB_TOKEN=<your-token>\n\nBoth GITHUB_TOKEN and GH_TOKEN are accepted. To obtain a token, run:\n  gh auth token")
 }
 
 // slugFromIssue fetches the GitHub issue title and converts it to a slug.
@@ -3104,7 +3104,8 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	env := os.Environ()
 
-	// GITHUB_TOKEN is guaranteed to be set by ensureGHToken() at startOne entry.
+	// GITHUB_TOKEN is guaranteed to be set by ensureGHToken(), which all
+	// agent-launch entrypoints (startOne, agentResume) call before reaching here.
 	// os.Environ() picks it up automatically; nothing extra needed here.
 
 	for i, kv := range env {
@@ -3180,6 +3181,11 @@ func writeClaudeSettings(wtPath string) error {
 // blocks until the agent exits. When headless is true it detaches immediately
 // and writes output to agent.log.
 func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless, quiet, sendNotify bool) error {
+	// Verify GITHUB_TOKEN is set before any gh calls. Never touches the keychain.
+	if err := ensureGHToken(); err != nil {
+		return err
+	}
+
 	ad, err := adapters.Get(adapterName)
 	if err != nil {
 		return err

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -133,6 +133,11 @@ func buildKickoff(issue, port string) string {
 // startOne provisions a worktree for a single issue and launches the agent.
 // It is the per-issue unit used by both single-issue and batch invocations.
 func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+	// Verify GITHUB_TOKEN is set before any gh calls. Never touches the keychain.
+	if err := ensureGHToken(); err != nil {
+		return err
+	}
+
 	// Validate the adapter exists before doing any setup work.
 	if err := validateAdapter(agentName); err != nil {
 		return err
@@ -1861,6 +1866,21 @@ func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
 	return nil
 }
 
+// ensureGHToken verifies that GITHUB_TOKEN (or GH_TOKEN) is present in the
+// environment. It never calls gh or touches the macOS keychain. If GH_TOKEN
+// is set it is normalised to GITHUB_TOKEN so the agent subprocess sees it
+// under the conventional name. Returns an actionable error when neither is set.
+func ensureGHToken() error {
+	if os.Getenv("GITHUB_TOKEN") != "" {
+		return nil
+	}
+	if tok := os.Getenv("GH_TOKEN"); tok != "" {
+		os.Setenv("GITHUB_TOKEN", tok)
+		return nil
+	}
+	return fmt.Errorf("GITHUB_TOKEN is not set\n\nAdd the following to your shell profile (~/.zshrc or ~/.bashrc) and re-run:\n  export GITHUB_TOKEN=$(gh auth token)")
+}
+
 // slugFromIssue fetches the GitHub issue title and converts it to a slug.
 // issueArg may be a bare issue number or a full GitHub issue URL; both are
 // accepted by `gh issue view`.
@@ -3084,31 +3104,8 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	env := os.Environ()
 
-	// If GITHUB_TOKEN is absent or empty, pull it from `gh auth token` so
-	// the agent can push to GitHub without needing keychain access (the agent
-	// process runs detached and cannot unlock the macOS keychain).
-	hasGHToken := false
-	ghTokenIdx := -1
-	for i, kv := range env {
-		if strings.HasPrefix(kv, "GITHUB_TOKEN=") {
-			ghTokenIdx = i
-			if strings.TrimPrefix(kv, "GITHUB_TOKEN=") != "" {
-				hasGHToken = true
-			}
-			break
-		}
-	}
-	if !hasGHToken {
-		if out, err := exec.Command("gh", "auth", "token").Output(); err == nil {
-			if token := strings.TrimSpace(string(out)); token != "" {
-				if ghTokenIdx >= 0 {
-					env[ghTokenIdx] = "GITHUB_TOKEN=" + token
-				} else {
-					env = append(env, "GITHUB_TOKEN="+token)
-				}
-			}
-		}
-	}
+	// GITHUB_TOKEN is guaranteed to be set by ensureGHToken() at startOne entry.
+	// os.Environ() picks it up automatically; nothing extra needed here.
 
 	for i, kv := range env {
 		if strings.HasPrefix(kv, "HOME=") {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1812,6 +1812,8 @@ func TestStartOne_headlessImmediateExitCleansUpWorktree(t *testing.T) {
 	writeLocalAdapter(t, repo, "falseagent", "binary: false\n")
 	chdirTemp(t, repo)
 
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
 	var out bytes.Buffer
 	err := startOne("42", "plain-fails", "falseagent", "", true, false, false, &out)
 	if err == nil {
@@ -2351,34 +2353,12 @@ func TestAgentEnv_claudeJSONSymlinkReplacesStaleFile(t *testing.T) {
 	}
 }
 
-// fakeGHBin writes a small shell script to dir/gh that outputs token when
-// called as "gh auth token", and updates PATH so exec.Command("gh", …) finds it.
-func fakeGHBin(t *testing.T, token string) {
-	t.Helper()
-	dir := t.TempDir()
-	script := "#!/bin/sh\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"token\" ]; then\n  echo " + token + "\n  exit 0\nfi\nexit 1\n"
-	bin := filepath.Join(dir, "gh")
-	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
-		t.Fatalf("fakeGHBin: write script: %v", err)
-	}
-	orig := os.Getenv("PATH")
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+orig)
-}
 
-// TestAgentEnv_injectsTokenWhenAbsent verifies that GITHUB_TOKEN is added to
-// the environment when it is not already present.
-func TestAgentEnv_injectsTokenWhenAbsent(t *testing.T) {
-	fakeGHBin(t, "test-token-injected")
-	// Truly unset GITHUB_TOKEN (not just set to empty) so it is absent.
-	orig, had := os.LookupEnv("GITHUB_TOKEN")
-	os.Unsetenv("GITHUB_TOKEN")
-	t.Cleanup(func() {
-		if had {
-			os.Setenv("GITHUB_TOKEN", orig)
-		} else {
-			os.Unsetenv("GITHUB_TOKEN")
-		}
-	})
+// TestAgentEnv_passesTokenToEnv verifies that a GITHUB_TOKEN already in the
+// process environment is forwarded to the agent env unchanged. Token injection
+// is now ensureGHToken's responsibility, not agentEnv's.
+func TestAgentEnv_passesTokenToEnv(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "pre-set-token")
 
 	dir := t.TempDir()
 	env, err := agentEnv(dir)
@@ -2386,17 +2366,16 @@ func TestAgentEnv_injectsTokenWhenAbsent(t *testing.T) {
 		t.Fatalf("agentEnv: %v", err)
 	}
 	for _, kv := range env {
-		if kv == "GITHUB_TOKEN=test-token-injected" {
+		if kv == "GITHUB_TOKEN=pre-set-token" {
 			return // found — pass
 		}
 	}
-	t.Error("GITHUB_TOKEN=test-token-injected not found in env")
+	t.Error("GITHUB_TOKEN=pre-set-token not found in env")
 }
 
 // TestAgentEnv_preservesExistingToken verifies that a non-empty GITHUB_TOKEN
 // already present in the environment is left unchanged.
 func TestAgentEnv_preservesExistingToken(t *testing.T) {
-	fakeGHBin(t, "should-not-be-used")
 	t.Setenv("GITHUB_TOKEN", "existing-token")
 
 	dir := t.TempDir()
@@ -2415,26 +2394,30 @@ func TestAgentEnv_preservesExistingToken(t *testing.T) {
 	t.Error("GITHUB_TOKEN not found in env at all")
 }
 
-// TestAgentEnv_replacesEmptyToken verifies that an empty GITHUB_TOKEN is
-// treated as absent and replaced with the token from `gh auth token`.
-func TestAgentEnv_replacesEmptyToken(t *testing.T) {
-	fakeGHBin(t, "replacement-token")
-	t.Setenv("GITHUB_TOKEN", "")
-
-	dir := t.TempDir()
-	env, err := agentEnv(dir)
-	if err != nil {
-		t.Fatalf("agentEnv: %v", err)
-	}
-	for _, kv := range env {
-		if strings.HasPrefix(kv, "GITHUB_TOKEN=") {
-			if kv != "GITHUB_TOKEN=replacement-token" {
-				t.Errorf("expected GITHUB_TOKEN=replacement-token, got %q", kv)
-			}
-			return
+// TestEnsureGHToken_failsWhenAbsent verifies that ensureGHToken returns an
+// error when neither GITHUB_TOKEN nor GH_TOKEN is set, rather than falling
+// back to the macOS keychain via `gh auth token`.
+func TestEnsureGHToken_failsWhenAbsent(t *testing.T) {
+	origGH, hadGH := os.LookupEnv("GITHUB_TOKEN")
+	origGHT, hadGHT := os.LookupEnv("GH_TOKEN")
+	os.Unsetenv("GITHUB_TOKEN")
+	os.Unsetenv("GH_TOKEN")
+	t.Cleanup(func() {
+		if hadGH {
+			os.Setenv("GITHUB_TOKEN", origGH)
+		} else {
+			os.Unsetenv("GITHUB_TOKEN")
 		}
+		if hadGHT {
+			os.Setenv("GH_TOKEN", origGHT)
+		} else {
+			os.Unsetenv("GH_TOKEN")
+		}
+	})
+
+	if err := ensureGHToken(); err == nil {
+		t.Fatal("expected error when GITHUB_TOKEN and GH_TOKEN are both absent")
 	}
-	t.Error("GITHUB_TOKEN not found in env at all")
 }
 
 // TestAgentEnv_gitignoreCreated verifies that agentEnv writes "*\n" into

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1844,6 +1844,7 @@ func TestStartOne_headlessImmediateExitCleansUpWorktree(t *testing.T) {
 }
 
 func TestAgentResume_headless_success(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token")
 	dir := t.TempDir()
 	// Use `echo` as the resume binary — always on PATH, exits immediately.
 	writeLocalAdapter(t, dir, "echoagent",
@@ -1880,6 +1881,7 @@ func TestAgentResume_headless_success(t *testing.T) {
 // TestAgentResume_headless_hints verifies that agentctl resume --headless prints
 // actionable follow-up hints (logs, attach, discard) rather than just the tail path.
 func TestAgentResume_headless_hints(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token")
 	dir := t.TempDir()
 	writeLocalAdapter(t, dir, "echoagent", "binary: echo\nsession: --session\n")
 	chdirTemp(t, dir)
@@ -1918,6 +1920,7 @@ func TestAgentResume_headless_hints(t *testing.T) {
 // TestAgentResume_headless_notify verifies that a desktop notification is
 // fired after the headless resume agent exits when sendNotify=true.
 func TestAgentResume_headless_notify(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token")
 	dir := t.TempDir()
 	writeLocalAdapter(t, dir, "echoagent",
 		"binary: echo\nsession: --session\n")
@@ -1953,6 +1956,7 @@ func TestAgentResume_headless_notify(t *testing.T) {
 }
 
 func TestAgentResume_nonHeadless_exitsWhenAgentDone(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token")
 	dir := t.TempDir()
 	// Use `echo` as the resume binary — always on PATH, exits immediately.
 	writeLocalAdapter(t, dir, "echoagent",
@@ -1986,6 +1990,7 @@ func TestAgentResume_nonHeadless_exitsWhenAgentDone(t *testing.T) {
 }
 
 func TestAgentResume_nonHeadless_exitNoPR_printsNoPR(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token")
 	dir := t.TempDir()
 	writeLocalAdapter(t, dir, "echoagent",
 		"binary: echo\nsession: --session\n")
@@ -2047,6 +2052,7 @@ func TestAgentResume_nonHeadless_exitNoPR_printsNoPR(t *testing.T) {
 }
 
 func TestAgentResume_nonHeadless_sigintPrintsHints(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token")
 	dir := t.TempDir()
 
 	scriptPath := filepath.Join(dir, "sleepagent")
@@ -2151,6 +2157,7 @@ func TestLaunchAgent_homeIsolation(t *testing.T) {
 // TestAgentResume_homeIsolation verifies that a process spawned by agentResume
 // sees HOME set to $wtPath/.agent-home and not the user's real home directory.
 func TestAgentResume_homeIsolation(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token")
 	dir := t.TempDir()
 	envFile := filepath.Join(dir, "env.txt")
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2420,6 +2420,35 @@ func TestEnsureGHToken_failsWhenAbsent(t *testing.T) {
 	}
 }
 
+// TestEnsureGHToken_normalizesGHToken verifies that when only GH_TOKEN is set,
+// ensureGHToken copies it to GITHUB_TOKEN so agent subprocesses see the
+// conventional name, and returns nil.
+func TestEnsureGHToken_normalizesGHToken(t *testing.T) {
+	origGH, hadGH := os.LookupEnv("GITHUB_TOKEN")
+	origGHT, hadGHT := os.LookupEnv("GH_TOKEN")
+	os.Unsetenv("GITHUB_TOKEN")
+	os.Setenv("GH_TOKEN", "gh-token-value")
+	t.Cleanup(func() {
+		if hadGH {
+			os.Setenv("GITHUB_TOKEN", origGH)
+		} else {
+			os.Unsetenv("GITHUB_TOKEN")
+		}
+		if hadGHT {
+			os.Setenv("GH_TOKEN", origGHT)
+		} else {
+			os.Unsetenv("GH_TOKEN")
+		}
+	})
+
+	if err := ensureGHToken(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv("GITHUB_TOKEN"); got != "gh-token-value" {
+		t.Errorf("GITHUB_TOKEN = %q; want %q", got, "gh-token-value")
+	}
+}
+
 // TestAgentEnv_gitignoreCreated verifies that agentEnv writes "*\n" into
 // .agent-home/.gitignore when it does not yet exist.
 func TestAgentEnv_gitignoreCreated(t *testing.T) {


### PR DESCRIPTION
## Summary

- `agentctl start` was triggering a macOS \"Keychain Not Found\" dialog because two code paths called `gh auth token` to extract the GitHub token from the keychain
- Replaces both with a single `ensureGHToken()` call at the top of `startOne` that checks `GITHUB_TOKEN` / `GH_TOKEN` env vars only — no subprocess, no keychain access
- If neither var is set, fails immediately with a clear message directing the user to add `export GITHUB_TOKEN=$(gh auth token)` to their shell profile
- Removes the now-dead `fakeGHBin` test helper and updates three tests to match the new contract

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./...`
- [ ] Manual: unset `GITHUB_TOKEN` and run `agentctl start` — confirm actionable error message, no keychain dialog
- [ ] Manual: set `GITHUB_TOKEN` and run `agentctl start <issue>` — confirm no keychain dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)