### PR TITLE
feat: agentctl merge — one-step PR merge and worktree cleanup

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -7,6 +7,7 @@
 //	agentctl resume     <issue> [feedback]
 //	agentctl discard    [issue]
 //	agentctl cleanup    [issue | --all]
+//	agentctl merge      [--strategy squash|merge|rebase] [--no-delete] [--dry-run] <issue>
 //	agentctl status     [--verbose]
 //	agentctl logs       [--lines N] [--no-follow] <issue>
 //	agentctl attach     <issue>
@@ -46,6 +47,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewResumeCmd(),
 		cmd.NewDiscardCmd(),
 		cmd.NewCleanupCmd(),
+		cmd.NewMergeCmd(),
 		cmd.NewStatusCmd(),
 		cmd.NewLogsCmd(),
 		cmd.NewAttachCmd(),

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -7,7 +7,7 @@
 //	agentctl resume     <issue> [feedback]
 //	agentctl discard    [issue]
 //	agentctl cleanup    [issue | --all]
-//	agentctl merge      [--strategy squash|merge|rebase] [--no-delete] [--dry-run] <issue>
+//	agentctl merge      [--strategy squash|merge|rebase] [--no-delete] [--dry-run] [issue]
 //	agentctl status     [--verbose]
 //	agentctl logs       [--lines N] [--no-follow] <issue>
 //	agentctl attach     <issue>

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -758,9 +758,13 @@ func runMerge(issue, strategy string, noDelete, dryRun bool) error {
 	}
 	var branch string
 	if found {
-		branch, err = git.CurrentBranch(wt.Path)
-		if err != nil || branch == "" || branch == "HEAD" {
-			return fmt.Errorf("could not determine branch for %s", wt.Path)
+		if wt.Branch != "" && wt.Branch != "HEAD" {
+			branch = wt.Branch
+		} else {
+			branch, err = git.CurrentBranch(wt.Path)
+			if err != nil || branch == "" || branch == "HEAD" {
+				return fmt.Errorf("could not determine branch for %s", wt.Path)
+			}
 		}
 	} else {
 		branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
@@ -770,9 +774,9 @@ func runMerge(issue, strategy string, noDelete, dryRun bool) error {
 	}
 
 	// Validate the PR is open and not conflicting.
-	prState, mergeable, err := ghPRMergeInfo(repoRoot, branch)
+	prState, mergeable, reviewDecision, err := ghPRMergeInfo(repoRoot, branch)
 	if err != nil {
-		return fmt.Errorf("could not determine PR state for %s.\nIs gh installed and authenticated?", branch)
+		return fmt.Errorf("could not determine PR state for %s: %w\nIs gh installed and authenticated?", branch, err)
 	}
 	switch prState {
 	case "MERGED":
@@ -784,6 +788,9 @@ func runMerge(issue, strategy string, noDelete, dryRun bool) error {
 	}
 	if mergeable == "CONFLICTING" {
 		return fmt.Errorf("PR for %s has merge conflicts; resolve them before merging", branch)
+	}
+	if reviewDecision == "CHANGES_REQUESTED" {
+		return fmt.Errorf("PR for %s has changes requested; resolve review feedback before merging", branch)
 	}
 
 	if dryRun {
@@ -810,7 +817,7 @@ func runMerge(issue, strategy string, noDelete, dryRun bool) error {
 		if currentBranch != "main" {
 			fmt.Printf("Primary worktree at %s is on '%s'; checking out main...\n", repoRoot, currentBranch)
 			if err := git.CheckoutMain(repoRoot); err != nil {
-				return fmt.Errorf("cannot check out main in %s", repoRoot)
+				return fmt.Errorf("cannot check out main in %s: %w", repoRoot, err)
 			}
 		}
 		fmt.Printf("Pulling main in %s ...\n", repoRoot)
@@ -820,32 +827,35 @@ func runMerge(issue, strategy string, noDelete, dryRun bool) error {
 	return cleanupMerged(repoRoot, issue)
 }
 
-// ghPRMergeInfo calls `gh pr view <branch>` and returns the PR state and
-// mergeability (MERGEABLE, CONFLICTING, UNKNOWN).
-func ghPRMergeInfo(repoRoot, branch string) (prState, mergeable string, err error) {
+// ghPRMergeInfo calls `gh pr view <branch>` and returns the PR state,
+// mergeability (MERGEABLE, CONFLICTING, UNKNOWN), and review decision.
+func ghPRMergeInfo(repoRoot, branch string) (prState, mergeable, reviewDecision string, err error) {
 	cmd := exec.Command("gh", "pr", "view", branch,
-		"--json", "state,mergeable",
-		"-q", ".state+\" \"+.mergeable")
+		"--json", "state,mergeable,reviewDecision",
+		"-q", ".state+\" \"+.mergeable+\" \"+.reviewDecision")
 	cmd.Dir = repoRoot
 	var out, errBuf bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &errBuf
 	if err := cmd.Run(); err != nil {
-		return "", "", fmt.Errorf("%s", strings.TrimSpace(errBuf.String()))
+		return "", "", "", fmt.Errorf("%s", strings.TrimSpace(errBuf.String()))
 	}
 	parts := strings.Fields(strings.TrimSpace(out.String()))
+	if len(parts) >= 3 {
+		return parts[0], parts[1], parts[2], nil
+	}
 	if len(parts) >= 2 {
-		return parts[0], parts[1], nil
+		return parts[0], parts[1], "", nil
 	}
 	if len(parts) == 1 {
-		return parts[0], "", nil
+		return parts[0], "", "", nil
 	}
-	return "", "", nil
+	return "", "", "", nil
 }
 
 // ghPRMerge calls `gh pr merge <branch>` with the given strategy.
 func ghPRMerge(repoRoot, branch, strategy string) error {
-	args := []string{"pr", "merge", branch}
+	args := []string{"pr", "merge", branch, "--yes"}
 	switch strategy {
 	case "squash":
 		args = append(args, "--squash")

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -683,6 +683,188 @@ func runRemoveWorktree(issue string) error {
 	return nil
 }
 
+// ─── merge ────────────────────────────────────────────────────────────────────
+
+// NewMergeCmd creates the `merge` subcommand.
+// It merges an approved PR via gh and then performs worktree cleanup.
+func NewMergeCmd() *cobra.Command {
+	var strategy string
+	var noDelete bool
+	var dryRun bool
+	c := &cobra.Command{
+		Use:   "merge [issue]",
+		Short: "Merge an approved PR and clean up the worktree",
+		Long: `One-step merge: verify the PR is mergeable, run gh pr merge, pull main,
+and (unless --no-delete) remove the worktree and branches.
+
+Run without arguments inside a linked worktree to infer the issue number
+from the current branch.`,
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			issue, err := resolveIssueArg("merge", args)
+			if err != nil {
+				return err
+			}
+			return runMerge(issue, strategy, noDelete, dryRun)
+		},
+	}
+	c.Flags().StringVar(&strategy, "strategy", "", "Merge strategy: squash (default), merge, or rebase")
+	c.Flags().BoolVar(&noDelete, "no-delete", false, "Skip worktree deletion after merge")
+	c.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would happen without doing it")
+	return c
+}
+
+// resolveMergeStrategy returns the effective strategy: flag > config > "squash".
+func resolveMergeStrategy(flag, cfgStrategy string) string {
+	if flag != "" {
+		return flag
+	}
+	if cfgStrategy != "" {
+		return cfgStrategy
+	}
+	return "squash"
+}
+
+// validateMergeStrategy returns an error for unrecognised strategy names.
+func validateMergeStrategy(s string) error {
+	switch s {
+	case "squash", "merge", "rebase":
+		return nil
+	default:
+		return fmt.Errorf("unknown merge strategy %q: must be squash, merge, or rebase", s)
+	}
+}
+
+func runMerge(issue, strategy string, noDelete, dryRun bool) error {
+	repoRoot, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("cannot determine repo root: %w", err)
+	}
+
+	cfg, err := config.Read(repoRoot)
+	if err != nil {
+		return fmt.Errorf("cannot read config: %w", err)
+	}
+
+	strategy = resolveMergeStrategy(strategy, cfg.MergeStrategy)
+	if err := validateMergeStrategy(strategy); err != nil {
+		return err
+	}
+
+	// Locate the worktree and branch for the issue.
+	wt, found, err := git.FindWorktreeByIssue(repoRoot, issue)
+	if err != nil {
+		return err
+	}
+	var branch string
+	if found {
+		branch, err = git.CurrentBranch(wt.Path)
+		if err != nil || branch == "" || branch == "HEAD" {
+			return fmt.Errorf("could not determine branch for %s", wt.Path)
+		}
+	} else {
+		branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
+		if branch == "" {
+			return fmt.Errorf("no worktree or local branch found for issue %s", issue)
+		}
+	}
+
+	// Validate the PR is open and not conflicting.
+	prState, mergeable, err := ghPRMergeInfo(repoRoot, branch)
+	if err != nil {
+		return fmt.Errorf("could not determine PR state for %s.\nIs gh installed and authenticated?", branch)
+	}
+	switch prState {
+	case "MERGED":
+		return fmt.Errorf("PR for %s is already MERGED — use: agentctl cleanup %s", branch, issue)
+	case "CLOSED":
+		return fmt.Errorf("PR for %s is CLOSED and cannot be merged", branch)
+	case "":
+		return fmt.Errorf("no open PR found for branch %s", branch)
+	}
+	if mergeable == "CONFLICTING" {
+		return fmt.Errorf("PR for %s has merge conflicts; resolve them before merging", branch)
+	}
+
+	if dryRun {
+		fmt.Printf("[dry-run] Would merge PR for issue %s (branch: %s, strategy: %s)\n", issue, branch, strategy)
+		if !noDelete {
+			fmt.Printf("[dry-run] Would pull main and remove worktree after merge\n")
+		} else {
+			fmt.Printf("[dry-run] Would pull main (--no-delete: worktree kept)\n")
+		}
+		return nil
+	}
+
+	fmt.Printf("Merging PR for issue %s (branch: %s, strategy: %s)...\n", issue, branch, strategy)
+	if err := ghPRMerge(repoRoot, branch, strategy); err != nil {
+		return fmt.Errorf("gh pr merge failed: %w", err)
+	}
+	fmt.Println("PR merged.")
+
+	if noDelete {
+		currentBranch, err := git.CurrentBranch(repoRoot)
+		if err != nil {
+			return err
+		}
+		if currentBranch != "main" {
+			fmt.Printf("Primary worktree at %s is on '%s'; checking out main...\n", repoRoot, currentBranch)
+			if err := git.CheckoutMain(repoRoot); err != nil {
+				return fmt.Errorf("cannot check out main in %s", repoRoot)
+			}
+		}
+		fmt.Printf("Pulling main in %s ...\n", repoRoot)
+		return git.PullFFOnly(repoRoot)
+	}
+
+	return cleanupMerged(repoRoot, issue)
+}
+
+// ghPRMergeInfo calls `gh pr view <branch>` and returns the PR state and
+// mergeability (MERGEABLE, CONFLICTING, UNKNOWN).
+func ghPRMergeInfo(repoRoot, branch string) (prState, mergeable string, err error) {
+	cmd := exec.Command("gh", "pr", "view", branch,
+		"--json", "state,mergeable",
+		"-q", ".state+\" \"+.mergeable")
+	cmd.Dir = repoRoot
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", "", fmt.Errorf("%s", strings.TrimSpace(errBuf.String()))
+	}
+	parts := strings.Fields(strings.TrimSpace(out.String()))
+	if len(parts) >= 2 {
+		return parts[0], parts[1], nil
+	}
+	if len(parts) == 1 {
+		return parts[0], "", nil
+	}
+	return "", "", nil
+}
+
+// ghPRMerge calls `gh pr merge <branch>` with the given strategy.
+func ghPRMerge(repoRoot, branch, strategy string) error {
+	args := []string{"pr", "merge", branch}
+	switch strategy {
+	case "squash":
+		args = append(args, "--squash")
+	case "merge":
+		args = append(args, "--merge")
+	case "rebase":
+		args = append(args, "--rebase")
+	}
+	cmd := exec.Command("gh", args...)
+	cmd.Dir = repoRoot
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
 // ─── cleanup-merged ───────────────────────────────────────────────────────────
 
 // NewCleanupMergedCmd creates the `cleanup-merged` subcommand.

--- a/internal/cmd/merge_test.go
+++ b/internal/cmd/merge_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestNewMergeCmd_flags(t *testing.T) {
+	c := NewMergeCmd()
+	if c.Use != "merge [issue]" {
+		t.Errorf("Use = %q, want %q", c.Use, "merge [issue]")
+	}
+
+	strategyFlag := c.Flags().Lookup("strategy")
+	if strategyFlag == nil {
+		t.Fatal("--strategy flag not registered")
+	}
+	if strategyFlag.DefValue != "" {
+		t.Errorf("--strategy default = %q, want empty (resolved at runtime)", strategyFlag.DefValue)
+	}
+
+	noDeleteFlag := c.Flags().Lookup("no-delete")
+	if noDeleteFlag == nil {
+		t.Fatal("--no-delete flag not registered")
+	}
+	if noDeleteFlag.DefValue != "false" {
+		t.Errorf("--no-delete default = %q, want %q", noDeleteFlag.DefValue, "false")
+	}
+
+	dryRunFlag := c.Flags().Lookup("dry-run")
+	if dryRunFlag == nil {
+		t.Fatal("--dry-run flag not registered")
+	}
+	if dryRunFlag.DefValue != "false" {
+		t.Errorf("--dry-run default = %q, want %q", dryRunFlag.DefValue, "false")
+	}
+}
+
+func TestResolveMergeStrategy(t *testing.T) {
+	tests := []struct {
+		flag   string
+		config string
+		want   string
+	}{
+		{"", "", "squash"},
+		{"", "squash", "squash"},
+		{"", "merge", "merge"},
+		{"", "rebase", "rebase"},
+		{"squash", "merge", "squash"},
+		{"rebase", "", "rebase"},
+		{"merge", "squash", "merge"},
+	}
+	for _, tt := range tests {
+		got := resolveMergeStrategy(tt.flag, tt.config)
+		if got != tt.want {
+			t.Errorf("resolveMergeStrategy(%q, %q) = %q, want %q", tt.flag, tt.config, got, tt.want)
+		}
+	}
+}
+
+func TestValidateMergeStrategy(t *testing.T) {
+	valid := []string{"squash", "merge", "rebase"}
+	for _, s := range valid {
+		if err := validateMergeStrategy(s); err != nil {
+			t.Errorf("validateMergeStrategy(%q) returned unexpected error: %v", s, err)
+		}
+	}
+
+	invalid := []string{"fast-forward", "ours", "", " "}
+	// empty string is handled before validateMergeStrategy is called (resolved to "squash")
+	// but we still test it produces no error since the validator is called after resolution
+	for _, s := range invalid {
+		if s == "" {
+			continue // empty is valid input to validator (means "use default")
+		}
+		if err := validateMergeStrategy(s); err == nil {
+			t.Errorf("validateMergeStrategy(%q) expected error, got nil", s)
+		}
+	}
+}

--- a/internal/cmd/merge_test.go
+++ b/internal/cmd/merge_test.go
@@ -65,13 +65,8 @@ func TestValidateMergeStrategy(t *testing.T) {
 		}
 	}
 
-	invalid := []string{"fast-forward", "ours", "", " "}
-	// empty string is handled before validateMergeStrategy is called (resolved to "squash")
-	// but we still test it produces no error since the validator is called after resolution
+	invalid := []string{"fast-forward", "ours", " "}
 	for _, s := range invalid {
-		if s == "" {
-			continue // empty is valid input to validator (means "use default")
-		}
 		if err := validateMergeStrategy(s); err == nil {
 			t.Errorf("validateMergeStrategy(%q) expected error, got nil", s)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,11 @@ type AgentctlConfig struct {
 	// Linux: notify-send) after each agent exits. Can also be enabled
 	// per-invocation with the --notify flag.
 	Notify bool `yaml:"notify,omitempty"`
+
+	// MergeStrategy is the default merge strategy used by agentctl merge.
+	// Valid values: "squash" (default when empty), "merge", "rebase".
+	// Override per-invocation with the --strategy flag.
+	MergeStrategy string `yaml:"merge_strategy,omitempty"`
 }
 
 // Read loads .agentctl.yml from dir. If the file does not exist, an empty

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,3 +97,46 @@ func TestRead_notifyDefaultsFalse(t *testing.T) {
 		t.Errorf("Notify = true, want false (default)")
 	}
 }
+
+func TestRead_parsesMergeStrategy(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("merge_strategy: rebase\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MergeStrategy != "rebase" {
+		t.Errorf("MergeStrategy = %q, want %q", cfg.MergeStrategy, "rebase")
+	}
+}
+
+func TestRead_mergeStrategyDefaultsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"npm start\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MergeStrategy != "" {
+		t.Errorf("MergeStrategy = %q, want empty string (default)", cfg.MergeStrategy)
+	}
+}
+
+func TestWrite_preservesMergeStrategy(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{MergeStrategy: "squash"}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	got, err := config.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MergeStrategy != "squash" {
+		t.Errorf("MergeStrategy = %q, want %q", got.MergeStrategy, "squash")
+	}
+}


### PR DESCRIPTION
## Summary

Implements `agentctl merge <issue>` as described in #190.

- Verifies the PR is open and not conflicting before merging
- Calls `gh pr merge` with `--squash` (default), `--merge`, or `--rebase`
- Pulls main and removes the worktree + branches via the existing `cleanupMerged` path
- `--no-delete` skips worktree removal but still pulls main
- `--dry-run` prints the plan without touching anything
- `merge_strategy` key in `.agentctl.yml` sets the per-repo default; `--strategy` flag overrides it

## Test plan

- [ ] `go build ./...` compiles cleanly
- [ ] `go test ./...` passes (all packages green)
- [ ] `go vet ./...` is clean
- [ ] New tests in `internal/cmd/merge_test.go` cover flag registration, strategy resolution, and strategy validation
- [ ] New tests in `internal/config/config_test.go` cover `merge_strategy` YAML parsing and round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #190