### PR TITLE
fix: prune orphaned remote branches in cleanup --all

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -874,6 +874,7 @@ func runCleanupAllMerged() error {
 	}
 
 	cleaned, skipped, failed, staleCount := 0, 0, 0, 0
+	handledBranches := make(map[string]struct{}, len(wts))
 	for _, wt := range wts {
 		branch := wt.Branch
 		if branch == "" || branch == "HEAD" {
@@ -881,6 +882,7 @@ func runCleanupAllMerged() error {
 			skipped++
 			continue
 		}
+		handledBranches[branch] = struct{}{}
 		prState, err := ghPRState(repoRoot, branch)
 		if err != nil || prState == "" {
 			if !isAgentRunning(wt.Path) {
@@ -910,7 +912,51 @@ func runCleanupAllMerged() error {
 		}
 	}
 
-	fmt.Printf("\n%d merged worktrees cleaned, %d skipped\n", cleaned, skipped)
+	orphanedPruned := 0
+	remoteBranches, err := git.ListRemoteBranches(repoRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: could not list remote branches: %v\n", err)
+	} else {
+		for _, branch := range remoteBranches {
+			if branch == "main" || branch == "master" {
+				continue
+			}
+			if _, ok := handledBranches[branch]; ok {
+				continue
+			}
+			if git.InferIssue(branch) == "" {
+				continue
+			}
+
+			prState, err := ghPRState(repoRoot, branch)
+			if err != nil || prState == "" {
+				fmt.Printf("Skipping orphaned remote branch %s: no PR found\n", branch)
+				skipped++
+				continue
+			}
+			if prState != "MERGED" && prState != "CLOSED" {
+				fmt.Printf("Skipping orphaned remote branch %s: PR is %s\n", branch, prState)
+				skipped++
+				continue
+			}
+
+			fmt.Printf("Pruning orphaned remote branch %s (PR %s, no local worktree)\n", branch, prState)
+			msg, err := git.DeleteRemoteBranch(repoRoot, branch)
+			if err != nil {
+				if strings.Contains(msg, "remote ref does not exist") {
+					continue
+				}
+				fmt.Fprintf(os.Stderr, "WARNING: could not delete remote branch %s: %s\n", branch, strings.TrimSpace(msg))
+				failed++
+				continue
+			}
+
+			fmt.Printf("Deleted remote branch origin/%s\n", branch)
+			orphanedPruned++
+		}
+	}
+
+	fmt.Printf("\n%d merged worktrees cleaned, %d orphaned remote branches pruned, %d skipped\n", cleaned, orphanedPruned, skipped)
 	if staleCount > 0 {
 		fmt.Printf("Note: %d stale worktree(s) found with no agent and no PR — run `agentctl discard --stale` to remove them.\n", staleCount)
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -929,7 +929,12 @@ func runCleanupAllMerged() error {
 			}
 
 			prState, err := ghPRState(repoRoot, branch)
-			if err != nil || prState == "" {
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: could not get PR state for remote branch %s: %v\n", branch, err)
+				failed++
+				continue
+			}
+			if prState == "" {
 				fmt.Printf("Skipping orphaned remote branch %s: no PR found\n", branch)
 				skipped++
 				continue

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -133,6 +133,11 @@ func buildKickoff(issue, port string) string {
 // startOne provisions a worktree for a single issue and launches the agent.
 // It is the per-issue unit used by both single-issue and batch invocations.
 func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+	// Verify GITHUB_TOKEN is set before any gh calls. Never touches the keychain.
+	if err := ensureGHToken(); err != nil {
+		return err
+	}
+
 	// Validate the adapter exists before doing any setup work.
 	if err := validateAdapter(agentName); err != nil {
 		return err
@@ -1861,6 +1866,21 @@ func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
 	return nil
 }
 
+// ensureGHToken verifies that GITHUB_TOKEN (or GH_TOKEN) is present in the
+// environment. It never calls gh or touches the macOS keychain. If GH_TOKEN
+// is set it is normalised to GITHUB_TOKEN so the agent subprocess sees it
+// under the conventional name. Returns an actionable error when neither is set.
+func ensureGHToken() error {
+	if os.Getenv("GITHUB_TOKEN") != "" {
+		return nil
+	}
+	if tok := os.Getenv("GH_TOKEN"); tok != "" {
+		os.Setenv("GITHUB_TOKEN", tok)
+		return nil
+	}
+	return fmt.Errorf("GITHUB_TOKEN is not set\n\nAdd the following to your shell profile (~/.zshrc or ~/.bashrc) and re-run:\n  export GITHUB_TOKEN=$(gh auth token)")
+}
+
 // slugFromIssue fetches the GitHub issue title and converts it to a slug.
 // issueArg may be a bare issue number or a full GitHub issue URL; both are
 // accepted by `gh issue view`.
@@ -3084,31 +3104,8 @@ func agentEnv(wtPath string) ([]string, error) {
 
 	env := os.Environ()
 
-	// If GITHUB_TOKEN is absent or empty, pull it from `gh auth token` so
-	// the agent can push to GitHub without needing keychain access (the agent
-	// process runs detached and cannot unlock the macOS keychain).
-	hasGHToken := false
-	ghTokenIdx := -1
-	for i, kv := range env {
-		if strings.HasPrefix(kv, "GITHUB_TOKEN=") {
-			ghTokenIdx = i
-			if strings.TrimPrefix(kv, "GITHUB_TOKEN=") != "" {
-				hasGHToken = true
-			}
-			break
-		}
-	}
-	if !hasGHToken {
-		if out, err := exec.Command("gh", "auth", "token").Output(); err == nil {
-			if token := strings.TrimSpace(string(out)); token != "" {
-				if ghTokenIdx >= 0 {
-					env[ghTokenIdx] = "GITHUB_TOKEN=" + token
-				} else {
-					env = append(env, "GITHUB_TOKEN="+token)
-				}
-			}
-		}
-	}
+	// GITHUB_TOKEN is guaranteed to be set by ensureGHToken() at startOne entry.
+	// os.Environ() picks it up automatically; nothing extra needed here.
 
 	for i, kv := range env {
 		if strings.HasPrefix(kv, "HOME=") {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1812,6 +1812,8 @@ func TestStartOne_headlessImmediateExitCleansUpWorktree(t *testing.T) {
 	writeLocalAdapter(t, repo, "falseagent", "binary: false\n")
 	chdirTemp(t, repo)
 
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
 	var out bytes.Buffer
 	err := startOne("42", "plain-fails", "falseagent", "", true, false, false, &out)
 	if err == nil {
@@ -2351,34 +2353,12 @@ func TestAgentEnv_claudeJSONSymlinkReplacesStaleFile(t *testing.T) {
 	}
 }
 
-// fakeGHBin writes a small shell script to dir/gh that outputs token when
-// called as "gh auth token", and updates PATH so exec.Command("gh", …) finds it.
-func fakeGHBin(t *testing.T, token string) {
-	t.Helper()
-	dir := t.TempDir()
-	script := "#!/bin/sh\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"token\" ]; then\n  echo " + token + "\n  exit 0\nfi\nexit 1\n"
-	bin := filepath.Join(dir, "gh")
-	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
-		t.Fatalf("fakeGHBin: write script: %v", err)
-	}
-	orig := os.Getenv("PATH")
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+orig)
-}
 
-// TestAgentEnv_injectsTokenWhenAbsent verifies that GITHUB_TOKEN is added to
-// the environment when it is not already present.
-func TestAgentEnv_injectsTokenWhenAbsent(t *testing.T) {
-	fakeGHBin(t, "test-token-injected")
-	// Truly unset GITHUB_TOKEN (not just set to empty) so it is absent.
-	orig, had := os.LookupEnv("GITHUB_TOKEN")
-	os.Unsetenv("GITHUB_TOKEN")
-	t.Cleanup(func() {
-		if had {
-			os.Setenv("GITHUB_TOKEN", orig)
-		} else {
-			os.Unsetenv("GITHUB_TOKEN")
-		}
-	})
+// TestAgentEnv_passesTokenToEnv verifies that a GITHUB_TOKEN already in the
+// process environment is forwarded to the agent env unchanged. Token injection
+// is now ensureGHToken's responsibility, not agentEnv's.
+func TestAgentEnv_passesTokenToEnv(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "pre-set-token")
 
 	dir := t.TempDir()
 	env, err := agentEnv(dir)
@@ -2386,17 +2366,16 @@ func TestAgentEnv_injectsTokenWhenAbsent(t *testing.T) {
 		t.Fatalf("agentEnv: %v", err)
 	}
 	for _, kv := range env {
-		if kv == "GITHUB_TOKEN=test-token-injected" {
+		if kv == "GITHUB_TOKEN=pre-set-token" {
 			return // found — pass
 		}
 	}
-	t.Error("GITHUB_TOKEN=test-token-injected not found in env")
+	t.Error("GITHUB_TOKEN=pre-set-token not found in env")
 }
 
 // TestAgentEnv_preservesExistingToken verifies that a non-empty GITHUB_TOKEN
 // already present in the environment is left unchanged.
 func TestAgentEnv_preservesExistingToken(t *testing.T) {
-	fakeGHBin(t, "should-not-be-used")
 	t.Setenv("GITHUB_TOKEN", "existing-token")
 
 	dir := t.TempDir()
@@ -2415,26 +2394,30 @@ func TestAgentEnv_preservesExistingToken(t *testing.T) {
 	t.Error("GITHUB_TOKEN not found in env at all")
 }
 
-// TestAgentEnv_replacesEmptyToken verifies that an empty GITHUB_TOKEN is
-// treated as absent and replaced with the token from `gh auth token`.
-func TestAgentEnv_replacesEmptyToken(t *testing.T) {
-	fakeGHBin(t, "replacement-token")
-	t.Setenv("GITHUB_TOKEN", "")
-
-	dir := t.TempDir()
-	env, err := agentEnv(dir)
-	if err != nil {
-		t.Fatalf("agentEnv: %v", err)
-	}
-	for _, kv := range env {
-		if strings.HasPrefix(kv, "GITHUB_TOKEN=") {
-			if kv != "GITHUB_TOKEN=replacement-token" {
-				t.Errorf("expected GITHUB_TOKEN=replacement-token, got %q", kv)
-			}
-			return
+// TestEnsureGHToken_failsWhenAbsent verifies that ensureGHToken returns an
+// error when neither GITHUB_TOKEN nor GH_TOKEN is set, rather than falling
+// back to the macOS keychain via `gh auth token`.
+func TestEnsureGHToken_failsWhenAbsent(t *testing.T) {
+	origGH, hadGH := os.LookupEnv("GITHUB_TOKEN")
+	origGHT, hadGHT := os.LookupEnv("GH_TOKEN")
+	os.Unsetenv("GITHUB_TOKEN")
+	os.Unsetenv("GH_TOKEN")
+	t.Cleanup(func() {
+		if hadGH {
+			os.Setenv("GITHUB_TOKEN", origGH)
+		} else {
+			os.Unsetenv("GITHUB_TOKEN")
 		}
+		if hadGHT {
+			os.Setenv("GH_TOKEN", origGHT)
+		} else {
+			os.Unsetenv("GH_TOKEN")
+		}
+	})
+
+	if err := ensureGHToken(); err == nil {
+		t.Fatal("expected error when GITHUB_TOKEN and GH_TOKEN are both absent")
 	}
-	t.Error("GITHUB_TOKEN not found in env at all")
 }
 
 // TestAgentEnv_gitignoreCreated verifies that agentEnv writes "*\n" into

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -777,10 +777,10 @@ func TestRunCleanupAllMerged_prunesRemoteOnlyMergedBranch(t *testing.T) {
 		t.Fatalf("runCleanupAllMerged: %v", err)
 	}
 
-	if out := gitRun(t, repo, "branch", "-r", "--list", "origin/"+orphanedBranch); strings.TrimSpace(out) != "" {
+	if out := gitRun(t, repo, "ls-remote", "--heads", "origin", orphanedBranch); strings.TrimSpace(out) != "" {
 		t.Fatalf("expected remote branch %q to be deleted, still found %q", orphanedBranch, out)
 	}
-	if out := gitRun(t, repo, "branch", "-r", "--list", "origin/"+nonAgentBranch); strings.TrimSpace(out) == "" {
+	if out := gitRun(t, repo, "ls-remote", "--heads", "origin", nonAgentBranch); strings.TrimSpace(out) == "" {
 		t.Fatalf("expected non-agent remote branch %q to be preserved", nonAgentBranch)
 	}
 }
@@ -810,7 +810,7 @@ func TestRunCleanupAllMerged_skipsRemoteOnlyOpenBranch(t *testing.T) {
 		t.Fatalf("runCleanupAllMerged: %v", err)
 	}
 
-	if out := gitRun(t, repo, "branch", "-r", "--list", "origin/"+openBranch); strings.TrimSpace(out) == "" {
+	if out := gitRun(t, repo, "ls-remote", "--heads", "origin", openBranch); strings.TrimSpace(out) == "" {
 		t.Fatalf("expected remote branch %q to be preserved", openBranch)
 	}
 }

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -746,6 +746,75 @@ func TestRemoveBranchRefs_alreadyRemovedIsQuiet(t *testing.T) {
 	}
 }
 
+func TestRunCleanupAllMerged_prunesRemoteOnlyMergedBranch(t *testing.T) {
+	repo := initGitRepoWithBareOrigin(t)
+
+	createCommittedFile(t, repo, "tracked.txt", "initial\n")
+	gitRun(t, repo, "checkout", "-b", "main")
+	gitRun(t, repo, "add", ".")
+	gitRun(t, repo, "commit", "-m", "initial")
+	gitRun(t, repo, "push", "-u", "origin", "main")
+
+	const orphanedBranch = "251-cleanup-remote-only"
+	const nonAgentBranch = "feature-without-issue-prefix"
+
+	gitRun(t, repo, "checkout", "-b", orphanedBranch)
+	gitRun(t, repo, "push", "-u", "origin", orphanedBranch)
+	gitRun(t, repo, "checkout", "main")
+	gitRun(t, repo, "checkout", "-b", nonAgentBranch)
+	gitRun(t, repo, "push", "-u", "origin", nonAgentBranch)
+	gitRun(t, repo, "checkout", "main")
+	gitRun(t, repo, "branch", "-D", orphanedBranch)
+	gitRun(t, repo, "branch", "-D", nonAgentBranch)
+
+	stubDir := t.TempDir()
+	makeGHCleanupStateStub(t, stubDir, "MERGED 251")
+	prependPath(t, stubDir)
+
+	chdirTemp(t, repo)
+
+	if err := runCleanupAllMerged(); err != nil {
+		t.Fatalf("runCleanupAllMerged: %v", err)
+	}
+
+	if out := gitRun(t, repo, "branch", "-r", "--list", "origin/"+orphanedBranch); strings.TrimSpace(out) != "" {
+		t.Fatalf("expected remote branch %q to be deleted, still found %q", orphanedBranch, out)
+	}
+	if out := gitRun(t, repo, "branch", "-r", "--list", "origin/"+nonAgentBranch); strings.TrimSpace(out) == "" {
+		t.Fatalf("expected non-agent remote branch %q to be preserved", nonAgentBranch)
+	}
+}
+
+func TestRunCleanupAllMerged_skipsRemoteOnlyOpenBranch(t *testing.T) {
+	repo := initGitRepoWithBareOrigin(t)
+
+	createCommittedFile(t, repo, "tracked.txt", "initial\n")
+	gitRun(t, repo, "checkout", "-b", "main")
+	gitRun(t, repo, "add", ".")
+	gitRun(t, repo, "commit", "-m", "initial")
+	gitRun(t, repo, "push", "-u", "origin", "main")
+
+	const openBranch = "252-open-pr-branch"
+	gitRun(t, repo, "checkout", "-b", openBranch)
+	gitRun(t, repo, "push", "-u", "origin", openBranch)
+	gitRun(t, repo, "checkout", "main")
+	gitRun(t, repo, "branch", "-D", openBranch)
+
+	stubDir := t.TempDir()
+	makeGHCleanupStateStub(t, stubDir, "OPEN 252")
+	prependPath(t, stubDir)
+
+	chdirTemp(t, repo)
+
+	if err := runCleanupAllMerged(); err != nil {
+		t.Fatalf("runCleanupAllMerged: %v", err)
+	}
+
+	if out := gitRun(t, repo, "branch", "-r", "--list", "origin/"+openBranch); strings.TrimSpace(out) == "" {
+		t.Fatalf("expected remote branch %q to be preserved", openBranch)
+	}
+}
+
 func contains(s, sub string) bool {
 	return strings.Contains(s, sub)
 }
@@ -2353,7 +2422,6 @@ func TestAgentEnv_claudeJSONSymlinkReplacesStaleFile(t *testing.T) {
 	}
 }
 
-
 // TestAgentEnv_passesTokenToEnv verifies that a GITHUB_TOKEN already in the
 // process environment is forwarded to the agent env unchanged. Token injection
 // is now ensureGHToken's responsibility, not agentEnv's.
@@ -3817,6 +3885,26 @@ exit 0`,
 	return callsFile
 }
 
+func makeGHCleanupStateStub(t *testing.T, stubDir, prViewOutput string) {
+	t.Helper()
+
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '%%s\n' %q
+  exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf '[]\n'
+  exit 0
+fi
+exit 0
+`, prViewOutput)
+
+	if err := os.WriteFile(filepath.Join(stubDir, "gh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // prependPath prepends dir to the PATH for the duration of the test.
 func prependPath(t *testing.T, dir string) {
 	t.Helper()
@@ -4070,8 +4158,8 @@ func TestDiscardCmd_commaSplitAndURLNormalization(t *testing.T) {
 	chdirTemp(t, repo)
 
 	tests := []struct {
-		name      string
-		arg       string
+		name       string
+		arg        string
 		wantIssues []string // issue numbers expected in "Nothing to remove" output
 	}{
 		{

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -203,9 +203,11 @@ func DeleteRemoteBranch(repoRoot, branch string) (string, error) {
 	return strings.TrimSpace(out.String()), err
 }
 
-// ListRemoteBranches returns the short names of all branches on origin.
+// ListRemoteBranches returns the short names of all branches on origin by
+// querying the remote directly via git ls-remote, so the result is always
+// up-to-date and never includes refs from other remotes.
 func ListRemoteBranches(repoRoot string) ([]string, error) {
-	out, err := run(repoRoot, "-C", repoRoot, "branch", "-r", "--format=%(refname:short)")
+	out, err := run(repoRoot, "-C", repoRoot, "ls-remote", "--heads", "origin")
 	if err != nil {
 		return nil, err
 	}
@@ -213,14 +215,24 @@ func ListRemoteBranches(repoRoot string) ([]string, error) {
 		return nil, nil
 	}
 
+	const prefix = "refs/heads/"
 	var branches []string
 	for _, line := range strings.Split(out, "\n") {
-		name := strings.TrimSpace(line)
-		if name == "" || name == "origin/HEAD" {
+		line = strings.TrimSpace(line)
+		if line == "" {
 			continue
 		}
-		name = strings.TrimPrefix(name, "origin/")
-		if name == "" || name == "HEAD" {
+		// Each output line has the form: "<sha>\t<refname>"
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		ref := strings.TrimSpace(parts[1])
+		if !strings.HasPrefix(ref, prefix) {
+			continue
+		}
+		name := strings.TrimPrefix(ref, prefix)
+		if name == "" {
 			continue
 		}
 		branches = append(branches, name)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -203,6 +203,31 @@ func DeleteRemoteBranch(repoRoot, branch string) (string, error) {
 	return strings.TrimSpace(out.String()), err
 }
 
+// ListRemoteBranches returns the short names of all branches on origin.
+func ListRemoteBranches(repoRoot string) ([]string, error) {
+	out, err := run(repoRoot, "-C", repoRoot, "branch", "-r", "--format=%(refname:short)")
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(out) == "" {
+		return nil, nil
+	}
+
+	var branches []string
+	for _, line := range strings.Split(out, "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" || name == "origin/HEAD" {
+			continue
+		}
+		name = strings.TrimPrefix(name, "origin/")
+		if name == "" || name == "HEAD" {
+			continue
+		}
+		branches = append(branches, name)
+	}
+	return branches, nil
+}
+
 // FindBranchByIssuePrefix returns the first local branch whose name starts
 // with "<issue>-".
 func FindBranchByIssuePrefix(repoRoot, issue string) (string, error) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -213,6 +213,61 @@ func TestInferIssue(t *testing.T) {
 	}
 }
 
+func TestListRemoteBranches(t *testing.T) {
+	repo := initRepo(t)
+	origin := filepath.Join(t.TempDir(), "origin.git")
+
+	cmd := exec.Command("git", "init", "--bare", origin)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v\n%s", err, out)
+	}
+
+	cmd = exec.Command("git", "-C", repo, "remote", "add", "origin", origin)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v\n%s", err, out)
+	}
+
+	defaultBranch, err := CurrentBranch(repo)
+	if err != nil {
+		t.Fatalf("CurrentBranch: %v", err)
+	}
+
+	cmd = exec.Command("git", "-C", repo, "push", "-u", "origin", defaultBranch)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git push default branch: %v\n%s", err, out)
+	}
+
+	cmd = exec.Command("git", "-C", repo, "checkout", "-b", "42-feature")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git checkout -b: %v\n%s", err, out)
+	}
+
+	cmd = exec.Command("git", "-C", repo, "push", "-u", "origin", "42-feature")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git push feature branch: %v\n%s", err, out)
+	}
+
+	branches, err := ListRemoteBranches(repo)
+	if err != nil {
+		t.Fatalf("ListRemoteBranches: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, branch := range branches {
+		got[branch] = true
+	}
+
+	if !got[defaultBranch] {
+		t.Errorf("expected %q in remote branches, got %v", defaultBranch, branches)
+	}
+	if !got["42-feature"] {
+		t.Errorf("expected %q in remote branches, got %v", "42-feature", branches)
+	}
+	if got["HEAD"] {
+		t.Errorf("HEAD alias must be excluded, got %v", branches)
+	}
+}
+
 func TestLinkedWorktreesParserSmoke(t *testing.T) {
 	// Parse a synthetic --porcelain output without calling git.
 	// We exercise the parser indirectly by calling the unexported helper via


### PR DESCRIPTION
## Summary
- add remote branch enumeration in internal/git
- extend cleanup --all with an orphaned remote branch pruning pass
- cover merged/open remote-only branches and remote branch listing in tests

Closes #251