### PR TITLE
feat: support starting agent tasks without issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ agentctl start 42
 # Or from anywhere, using a full GitHub issue URL
 agentctl start https://github.com/owner/repo/issues/42
 
+# Or from your repo, using a free-form task
+agentctl start --task "Refactor the auth middleware to use JWT"
+
 # Back in your application repo's primary worktree
 cd /path/to/your/app-repo
 agentctl cleanup 42

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,28 +10,31 @@ Run `agentctl --help` or `agentctl <command> --help` for generated help from the
 
 ```bash
 agentctl start [--agent <name>] [--headless] [--notify] [--quiet] <issue-number-or-url> [slug] [--sdd=<name>]
+agentctl start [--agent <name>] [--headless] [--notify] [--quiet] [--sdd=<name>] --task "<description>" [--branch <branch-name>]
 ```
 
-Creates a linked worktree for a GitHub issue and launches the selected coding agent inside it.
+Creates a linked worktree for a GitHub issue or a free-form task and launches the selected coding agent inside it.
 
 - `--agent <name>`: adapter name; default is `claude`. See [adapters.md](adapters.md) for available adapters.
 - `--headless`: run the agent in the background and write agent output to `agent.log`.
 - `--notify`: send a native desktop notification when the headless agent finishes. No-op when `--headless` is not set. See [Desktop notifications](#desktop-notifications).
 - `--quiet`: suppress all agent log output in the terminal; the parent still waits for the agent to finish (foreground). Has no effect with `--headless`.
 - `--sdd=<name>`: opt into an SDD methodology (e.g. `--sdd=plain`, `--sdd=speckit`). Omit to skip SDD and work directly toward a PR. See [sdd.md](sdd.md).
+- `--task "<description>"`: start from a free-form task description instead of a GitHub issue.
+- `--branch <branch-name>`: explicit branch name for `--task`. Only valid with `--task`.
 - `<issue-number-or-url>`: a bare GitHub issue number (e.g. `42`) **or** a full GitHub issue URL (e.g. `https://github.com/owner/repo/issues/42`). When a URL is supplied, `agentctl` locates or clones the target repository automatically so you do not need to `cd` into it first.
 - `[slug]`: optional branch/worktree slug. If omitted, `agentctl` uses `gh issue view` to fetch the issue title and derive a slug.
 
 Side effects:
 
-- Creates a branch named `<issue>-<slug>`.
-- Creates a worktree at `../<repo>-<issue>-<slug>/`.
+- Issue mode: creates a branch named `<issue>-<slug>` and a worktree at `../<repo>-<issue>-<slug>/`.
+- Task mode: creates a branch named `task/<slug>` by default and a worktree at `../<repo>-task-<slug>/`. `--branch` overrides the branch name verbatim and uses the slash-replaced branch name in the worktree path.
 - Reserves a dev-server port in the `3010-3100` range.
 - Writes `.agent` metadata in the worktree.
 - Seeds `.env.local` from the primary worktree when present, stripping any existing `PORT=` lines (does not inject `PORT=<port>` itself).
 - Starts the dev server: if `.agentctl.yml` defines a `dev_server` command it is used (with `{port}` substituted); otherwise the step is silently skipped. Any project that needs a dev server must set `dev_server` explicitly in `.agentctl.yml`.
 - Launches the selected adapter.
-- When the agent exits, appends `Closes #<issue>` to the PR body retrieved via `gh pr view <branch>`, unless the body already contains `closes #<issue>` or `fixes #<issue>` (case-insensitive). Other closing keywords such as `resolves #<issue>` do not suppress the append.
+- In issue mode, when the agent exits, appends `Closes #<issue>` to the PR body retrieved via `gh pr view <branch>`, unless the body already contains `closes #<issue>` or `fixes #<issue>` (case-insensitive). Other closing keywords such as `resolves #<issue>` do not suppress the append.
 
 ### `agentctl resume`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -178,9 +178,7 @@ resume_cmd: my-bot --continue {prompt} --id {session_id}
 
 ## Worktree layout
 
-When `agentctl start <issue>` runs, it creates a linked worktree at `../<repo>-<issue>-<slug>/` containing:
-
-When `agentctl start --task "<description>"` runs, it creates a linked worktree at `../<repo>-task-<slug>/` by default (or `../<repo>-<branch-with-slashes-replaced>/` when `--branch` is supplied), containing:
+Both `agentctl start <issue>` and `agentctl start --task` create a linked worktree containing:
 
 ```
 .agent          ← key=value metadata (agent, port, session-id, agent-pid, dev-pid)
@@ -188,6 +186,11 @@ agent.log       ← agent stdout/stderr (always written; also streamed to termin
 dev.log         ← dev-server stdout/stderr
 specs/          ← SDD artefacts (spec.md, plan.md, tasks.md)
 ```
+
+The worktree is placed under the parent of the repository root:
+
+- **Issue mode** (`start <issue>`): `../<repo>-<issue>-<slug>/`
+- **Task mode** (`start --task "<description>"`): `../<repo>-task-<slug>/` by default, or `../<repo>-<branch>/` when `--branch` is supplied
 
 ## Testing strategy
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -180,6 +180,8 @@ resume_cmd: my-bot --continue {prompt} --id {session_id}
 
 When `agentctl start <issue>` runs, it creates a linked worktree at `../<repo>-<issue>-<slug>/` containing:
 
+When `agentctl start --task "<description>"` runs, it creates a linked worktree at `../<repo>-task-<slug>/` by default (or `../<repo>-<branch-with-slashes-replaced>/` when `--branch` is supplied), containing:
+
 ```
 .agent          ← key=value metadata (agent, port, session-id, agent-pid, dev-pid)
 agent.log       ← agent stdout/stderr (always written; also streamed to terminal in foreground mode unless --quiet)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -312,17 +312,18 @@ func startTask(task, branch, agentName, sddName string, headless, quiet, sendNot
 	wtPath := filepath.Join(parentDir, repoName+"-"+worktreeSlug)
 
 	if _, statErr := os.Stat(wtPath); statErr == nil {
-		return worktreeExistsError(wtPath, branch)
+		return taskWorktreeExistsError(wtPath, branch)
 	}
 	if err := git.AddWorktree(repoRoot, wtPath, branch); err != nil {
 		return fmt.Errorf("git worktree add: %w", err)
 	}
+	var devPID, portStr string
 	cleanupOnError := true
 	defer func() {
 		if !cleanupOnError {
 			return
 		}
-		if cleanupErr := cleanupFailedStart(repoRoot, wtPath, branch, ""); cleanupErr != nil {
+		if cleanupErr := cleanupFailedStart(repoRoot, wtPath, branch, devPID); cleanupErr != nil {
 			fmt.Fprintf(out, "Warning: failed to clean up worktree after start failure (path: %s, branch: %s): %v\n", wtPath, branch, cleanupErr)
 		}
 	}()
@@ -331,7 +332,7 @@ func startTask(task, branch, agentName, sddName string, headless, quiet, sendNot
 		return err
 	}
 
-	devPID, portStr, err := startDevServer(wtPath, out)
+	devPID, portStr, err = startDevServer(wtPath, out)
 	if err != nil {
 		return err
 	}
@@ -347,6 +348,7 @@ func startTask(task, branch, agentName, sddName string, headless, quiet, sendNot
 		DevPID:    devPID,
 		DevPort:   portStr,
 		SDD:       sddName,
+		TaskMode:  true,
 	}
 	if err := state.Write(wtPath, af); err != nil {
 		return err
@@ -536,11 +538,11 @@ func runReleasePausedSession(issue, feedback string, headless, quiet, sendNotify
 	}
 
 	// For SDD runs, require the spec pause to have been reached before resuming.
-	if af.SDD != "" && computeSpecState(wt.Path, specLookupKey(issue), af.SDD, af.SDDSet) == "no-spec" {
+	if af.SDD != "" && computeSpecState(wt.Path, effectiveSpecKey(issue, af), af.SDD, af.SDDSet) == "no-spec" {
 		return fmt.Errorf("spec not yet generated for issue %s; paused state not reached.\nTail %s/agent.log to confirm and retry once the pause is reported.", issue, wt.Path)
 	}
 
-	specPath := findSpecPath(wt.Path, specLookupKey(issue))
+	specPath := findSpecPath(wt.Path, effectiveSpecKey(issue, af))
 	prompt := buildResumePrompt(feedback, af.SDD, specPath)
 	if af.SDD != "" && strings.TrimSpace(feedback) == "" {
 		if err := state.AppendKey(wt.Path, "sdd-stage", "2"); err != nil {
@@ -762,7 +764,7 @@ func runRemoveWorktree(issue string) error {
 	if branch == "" && isNumericIssue(issue) {
 		branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
 	}
-	if branch == "" && strings.Contains(issue, "/") {
+	if branch == "" && !isNumericIssue(issue) && git.BranchExists(repoRoot, issue) {
 		branch = issue
 	}
 
@@ -882,7 +884,7 @@ func cleanupMerged(repoRoot, issue string) error {
 		if isNumericIssue(issue) {
 			branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
 		}
-		if branch == "" && strings.Contains(issue, "/") {
+		if branch == "" && !isNumericIssue(issue) && git.BranchExists(repoRoot, issue) {
 			branch = issue
 		}
 		if branch == "" {
@@ -1126,7 +1128,7 @@ func runStatus(verbose bool) error {
 
 		devPIDStr := pidStatus(af.DevPID)
 		agentPIDStr := pidStatus(af.AgentPID)
-		specState := computeSpecState(wt.Path, worktreeSpecLookupKey(wt), af.SDD, af.SDDSet)
+		specState := computeSpecState(wt.Path, worktreeSpecLookupKey(wt, af), af.SDD, af.SDDSet)
 
 		prState := "none"
 		if branch != "?" && branch != "HEAD" {
@@ -1679,7 +1681,21 @@ func specLookupKey(issue string) string {
 	return issue
 }
 
-func worktreeSpecLookupKey(wt git.Worktree) string {
+// effectiveSpecKey returns the spec lookup key for a worktree, using the
+// task-mode flag from the .agent file when available. If the worktree was
+// started with `agentctl start --task`, the key is always "task" regardless
+// of the branch name, matching the KickoffPrompt("task", ...) used at start.
+func effectiveSpecKey(issue string, af state.AgentFile) string {
+	if af.TaskMode {
+		return "task"
+	}
+	return specLookupKey(issue)
+}
+
+func worktreeSpecLookupKey(wt git.Worktree, af state.AgentFile) string {
+	if af.TaskMode {
+		return "task"
+	}
 	if wt.Issue != "" {
 		return wt.Issue
 	}
@@ -1989,6 +2005,19 @@ func worktreeExistsError(wtPath, issueNum string) error {
 		return fmt.Errorf("Worktree already exists for issue %s — agent has finished.\nWorktree: %s\n\n  agentctl cleanup %s   if the PR is merged\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, id, id)
 	}
 	return fmt.Errorf("Worktree already exists for issue %s.\nWorktree: %s\n\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, id)
+}
+
+// taskWorktreeExistsError is like worktreeExistsError but uses "task"/"branch"
+// wording instead of "issue" for task-mode worktrees.
+func taskWorktreeExistsError(wtPath, branch string) error {
+	af, readErr := state.Read(wtPath)
+	if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
+		return fmt.Errorf("Worktree already exists for task branch %s — agent is still running.\nWorktree: %s\n\n  agentctl attach %s   to follow its output\n  agentctl discard %s   to delete the worktree and start over", branch, wtPath, branch, branch)
+	}
+	if readErr == nil && af.AgentPID != "" {
+		return fmt.Errorf("Worktree already exists for task branch %s — agent has finished.\nWorktree: %s\n\n  agentctl cleanup %s   if the PR is merged\n  agentctl discard %s   to delete the worktree and start over", branch, wtPath, branch, branch)
+	}
+	return fmt.Errorf("Worktree already exists for task branch %s.\nWorktree: %s\n\n  agentctl discard %s   to delete the worktree and start over", branch, wtPath, branch)
 }
 
 // issueDisplayFor reads the issue-arg stored in the .agent state file and

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -40,14 +40,16 @@ import (
 func NewStartCmd() *cobra.Command {
 	var (
 		agentName  string
+		branch     string
 		headless   bool
 		quiet      bool
 		sddName    string
 		sendNotify bool
+		task       string
 	)
 	c := &cobra.Command{
-		Use:   "start <issue-number-or-url>[,<issue>...] [slug]",
-		Short: "Start work on a GitHub issue in an isolated worktree",
+		Use:   "start [<issue-number-or-url>[,<issue>...] [slug]]",
+		Short: "Start work in an isolated worktree",
 		Long: `Provision an isolated git worktree for a GitHub issue and launch a
 coding agent inside it. By default the agent works directly toward a PR
 with no spec-review pause.
@@ -64,8 +66,21 @@ not allowed in batch mode.
 
 Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 (e.g. plain, speckit, or a custom methodology).`,
-		Args: cobra.RangeArgs(1, 2),
+		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if task != "" && len(args) > 0 {
+				return fmt.Errorf("--task and a positional issue argument are mutually exclusive")
+			}
+			if branch != "" && task == "" {
+				return fmt.Errorf("--branch requires --task")
+			}
+			if task != "" {
+				return startTask(task, branch, agentName, sddName, headless, quiet, sendNotify, os.Stdout)
+			}
+			if len(args) == 0 {
+				return fmt.Errorf("accepts between 1 and 2 arg(s), received 0")
+			}
+
 			rawIssues := strings.Split(args[0], ",")
 			issues := make([]string, 0, len(rawIssues))
 			for _, iss := range rawIssues {
@@ -94,9 +109,11 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 		},
 	}
 	c.Flags().StringVar(&agentName, "agent", "claude", "Coding agent adapter to use")
+	c.Flags().StringVar(&branch, "branch", "", "Explicit branch name (only valid with --task)")
 	c.Flags().BoolVar(&headless, "headless", false, "Run agent in background (log -> agent.log)")
 	c.Flags().BoolVar(&quiet, "quiet", false, "Suppress agent log output; show spinner/heartbeat only")
 	c.Flags().StringVar(&sddName, "sdd", "", "SDD methodology to use (e.g. plain, speckit, or custom); omit to skip SDD")
+	c.Flags().StringVar(&task, "task", "", "Free-form task description (alternative to a GitHub issue)")
 	c.Flags().BoolVar(&sendNotify, "notify", false, "Send a desktop notification when the headless agent finishes")
 	return c
 }
@@ -128,6 +145,19 @@ func buildKickoff(issue, port string) string {
 		return strings.TrimRight(strings.Join(lines, "\n"), "\n")
 	}
 	return strings.ReplaceAll(s, "{port}", port)
+}
+
+// buildKickoffFromTask returns the default agent kickoff prompt for a
+// free-form task run. When port is empty, the dev-server line is omitted.
+func buildKickoffFromTask(task, port string) string {
+	s := "Work on the following task: " + task + "\n" +
+		"Make the changes directly, push the branch, and open a PR. Do not merge.\n" +
+		"You are the coding agent — implement changes using your own file-editing and bash tools.\n" +
+		"Do not run agentctl, claude, codex, or any other agent-launcher CLI."
+	if port != "" {
+		s += "\nDev server is running on port " + port + "."
+	}
+	return s
 }
 
 // startOne provisions a worktree for a single issue and launches the agent.
@@ -236,6 +266,104 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 	}
 
 	if err := launchAgent(agentName, wtPath, issueNum, portStr, sessionID, kickoff, sddName, headless, quiet, sendNotify, out); err != nil {
+		cleanupOnError = false
+		if cleanupErr := cleanupFailedStart(repoRoot, wtPath, branch, devPID); cleanupErr != nil {
+			return fmt.Errorf("%w\ncleanup warning: %v", err, cleanupErr)
+		}
+		return err
+	}
+
+	cleanupOnError = false
+	return nil
+}
+
+// startTask provisions a worktree for a free-form task and launches the agent.
+func startTask(task, branch, agentName, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+	if strings.TrimSpace(task) == "" {
+		return fmt.Errorf("--task requires a non-empty task description")
+	}
+	if err := validateAdapter(agentName); err != nil {
+		return err
+	}
+
+	repoRoot, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("cannot determine repo root: %w", err)
+	}
+	parentDir := filepath.Dir(repoRoot)
+	repoName := filepath.Base(repoRoot)
+
+	if !sendNotify {
+		if cfg, cfgErr := config.Read(repoRoot); cfgErr == nil && cfg.Notify {
+			sendNotify = true
+		}
+	}
+
+	if err := validateSDD(sddName, repoRoot); err != nil {
+		return err
+	}
+
+	if branch == "" {
+		branch = slugFromTask(task)
+		fmt.Fprintf(out, "Derived branch from task: %s\n", branch)
+	}
+
+	worktreeSlug := strings.ReplaceAll(branch, "/", "-")
+	wtPath := filepath.Join(parentDir, repoName+"-"+worktreeSlug)
+
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		return worktreeExistsError(wtPath, branch)
+	}
+	if err := git.AddWorktree(repoRoot, wtPath, branch); err != nil {
+		return fmt.Errorf("git worktree add: %w", err)
+	}
+	cleanupOnError := true
+	defer func() {
+		if !cleanupOnError {
+			return
+		}
+		if cleanupErr := cleanupFailedStart(repoRoot, wtPath, branch, ""); cleanupErr != nil {
+			fmt.Fprintf(out, "Warning: failed to clean up worktree after start failure (path: %s, branch: %s): %v\n", wtPath, branch, cleanupErr)
+		}
+	}()
+
+	if err := seedEnvLocal(filepath.Join(repoRoot, ".env.local"), filepath.Join(wtPath, ".env.local")); err != nil {
+		return err
+	}
+
+	devPID, portStr, err := startDevServer(wtPath, out)
+	if err != nil {
+		return err
+	}
+
+	sessionID, err := generateUUID()
+	if err != nil {
+		return fmt.Errorf("generate session ID: %w", err)
+	}
+
+	af := state.AgentFile{
+		Agent:     agentName,
+		SessionID: sessionID,
+		DevPID:    devPID,
+		DevPort:   portStr,
+		SDD:       sddName,
+	}
+	if err := state.Write(wtPath, af); err != nil {
+		return err
+	}
+
+	var kickoff string
+	if sddName == "" {
+		kickoff = buildKickoffFromTask(task, portStr)
+	} else {
+		m, sddErr := sdd.Get(sddName)
+		if sddErr != nil {
+			return sddErr
+		}
+		kickoff = m.KickoffPrompt("task", portStr) + "\n\nTask description: " + task
+	}
+
+	if err := launchAgent(agentName, wtPath, branch, portStr, sessionID, kickoff, sddName, headless, quiet, sendNotify, out); err != nil {
 		cleanupOnError = false
 		if cleanupErr := cleanupFailedStart(repoRoot, wtPath, branch, devPID); cleanupErr != nil {
 			return fmt.Errorf("%w\ncleanup warning: %v", err, cleanupErr)
@@ -390,7 +518,7 @@ func runReleasePausedSession(issue, feedback string, headless, quiet, sendNotify
 		}
 	}
 
-	wt, found, err := git.FindWorktreeByIssue(repoRoot, issue)
+	wt, found, err := findLinkedWorktree(repoRoot, issue)
 	if err != nil {
 		return err
 	}
@@ -408,11 +536,11 @@ func runReleasePausedSession(issue, feedback string, headless, quiet, sendNotify
 	}
 
 	// For SDD runs, require the spec pause to have been reached before resuming.
-	if af.SDD != "" && computeSpecState(wt.Path, issue, af.SDD, af.SDDSet) == "no-spec" {
+	if af.SDD != "" && computeSpecState(wt.Path, specLookupKey(issue), af.SDD, af.SDDSet) == "no-spec" {
 		return fmt.Errorf("spec not yet generated for issue %s; paused state not reached.\nTail %s/agent.log to confirm and retry once the pause is reported.", issue, wt.Path)
 	}
 
-	specPath := findSpecPath(wt.Path, issue)
+	specPath := findSpecPath(wt.Path, specLookupKey(issue))
 	prompt := buildResumePrompt(feedback, af.SDD, specPath)
 	if af.SDD != "" && strings.TrimSpace(feedback) == "" {
 		if err := state.AppendKey(wt.Path, "sdd-stage", "2"); err != nil {
@@ -620,7 +748,7 @@ func runRemoveWorktree(issue string) error {
 		return fmt.Errorf("cannot determine repo root: %w", err)
 	}
 
-	wt, found, err := git.FindWorktreeByIssue(repoRoot, issue)
+	wt, found, err := findLinkedWorktree(repoRoot, issue)
 	var wtPath, branch string
 	if err != nil {
 		return err
@@ -631,8 +759,11 @@ func runRemoveWorktree(issue string) error {
 	}
 
 	// If no registered worktree, try to find a local branch.
-	if branch == "" {
+	if branch == "" && isNumericIssue(issue) {
 		branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
+	}
+	if branch == "" && strings.Contains(issue, "/") {
+		branch = issue
 	}
 
 	if wtPath == "" && branch == "" {
@@ -733,7 +864,7 @@ func runCleanupMerged(issue string) error {
 }
 
 func cleanupMerged(repoRoot, issue string) error {
-	wt, found, err := git.FindWorktreeByIssue(repoRoot, issue)
+	wt, found, err := findLinkedWorktree(repoRoot, issue)
 	var wtPath, branch string
 	wtRegistered := found
 
@@ -748,13 +879,18 @@ func cleanupMerged(repoRoot, issue string) error {
 		}
 	} else {
 		// Recovery path: worktree is no longer registered.
-		branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
+		if isNumericIssue(issue) {
+			branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
+		}
+		if branch == "" && strings.Contains(issue, "/") {
+			branch = issue
+		}
 		if branch == "" {
 			return fmt.Errorf("no worktree or local branch found for issue %s", issue)
 		}
 		repoName := filepath.Base(repoRoot)
 		parentDir := filepath.Dir(repoRoot)
-		candidate := filepath.Join(parentDir, repoName+"-"+branch)
+		candidate := filepath.Join(parentDir, repoName+"-"+strings.ReplaceAll(branch, "/", "-"))
 		if _, statErr := os.Stat(candidate); statErr == nil {
 			fmt.Printf("Detected orphaned worktree dir at %s (not registered with git); recovering.\n", candidate)
 			wtPath = candidate
@@ -967,7 +1103,7 @@ func runStatus(verbose bool) error {
 	for _, wt := range wts {
 		issue := wt.Issue
 		if issue == "" {
-			issue = "?"
+			issue = "-"
 		}
 		branch := wt.Branch
 		if branch == "" {
@@ -990,7 +1126,7 @@ func runStatus(verbose bool) error {
 
 		devPIDStr := pidStatus(af.DevPID)
 		agentPIDStr := pidStatus(af.AgentPID)
-		specState := computeSpecState(wt.Path, wt.Issue, af.SDD, af.SDDSet)
+		specState := computeSpecState(wt.Path, worktreeSpecLookupKey(wt), af.SDD, af.SDDSet)
 
 		prState := "none"
 		if branch != "?" && branch != "HEAD" {
@@ -1482,9 +1618,6 @@ func pidStatus(pid string) string {
 //   - plain-style:   specs/spec.md (flat); always "paused" — no lifecycle files
 //   - speckit-style: specs/<issue>-*/spec.md with optional plan.md / tasks.md
 func computeSpecState(wtPath, issue, sddName string, sddSet bool) string {
-	if issue == "" {
-		return "no-spec"
-	}
 	// New worktree explicitly created without --sdd.
 	if sddSet && sddName == "" {
 		return "no-spec"
@@ -1492,6 +1625,9 @@ func computeSpecState(wtPath, issue, sddName string, sddSet bool) string {
 	// Plain-style: flat specs/spec.md with no lifecycle subdirectory.
 	if _, err := os.Stat(filepath.Join(wtPath, "specs", "spec.md")); err == nil {
 		return "paused"
+	}
+	if issue == "" {
+		return "no-spec"
 	}
 	// Speckit-style: specs/<issue>-<slug>/ with lifecycle artefacts.
 	specGlob := filepath.Join(wtPath, "specs", issue+"-*", "spec.md")
@@ -1518,11 +1654,46 @@ func findSpecPath(wtPath, issue string) string {
 	if _, err := os.Stat(plain); err == nil {
 		return plain
 	}
+	if issue == "" {
+		return ""
+	}
 	matches, _ := filepath.Glob(filepath.Join(wtPath, "specs", issue+"-*", "spec.md"))
 	if len(matches) > 0 {
 		return matches[0]
 	}
 	return ""
+}
+
+func isNumericIssue(issue string) bool {
+	if issue == "" {
+		return false
+	}
+	_, err := strconv.Atoi(issue)
+	return err == nil
+}
+
+func specLookupKey(issue string) string {
+	if strings.HasPrefix(issue, "task/") {
+		return "task"
+	}
+	return issue
+}
+
+func worktreeSpecLookupKey(wt git.Worktree) string {
+	if wt.Issue != "" {
+		return wt.Issue
+	}
+	return specLookupKey(wt.Branch)
+}
+
+func findLinkedWorktree(repoRoot, ref string) (git.Worktree, bool, error) {
+	if isNumericIssue(ref) {
+		wt, found, err := git.FindWorktreeByIssue(repoRoot, ref)
+		if err != nil || found {
+			return wt, found, err
+		}
+	}
+	return git.FindWorktreeByBranch(repoRoot, ref)
 }
 
 // ghPRInfo calls `gh pr view <branch>` in repoRoot and returns the PR state
@@ -1627,6 +1798,9 @@ func linkPRToIssue(dir, branch, issueNum string) (*prInfo, error) {
 	var pr prInfo
 	if err := json.Unmarshal(out.Bytes(), &pr); err != nil {
 		return nil, nil
+	}
+	if !isNumericIssue(issueNum) {
+		return &pr, nil
 	}
 
 	lower := strings.ToLower(pr.Body)
@@ -1903,6 +2077,20 @@ func slugFromIssue(issueArg string) (string, error) {
 	return slug, nil
 }
 
+// slugFromTask derives a task branch name from the first six words of the
+// task description using the same slugging rules as GitHub issue titles.
+func slugFromTask(description string) string {
+	words := strings.Fields(description)
+	if len(words) > 6 {
+		words = words[:6]
+	}
+	slug := titleToSlug(strings.Join(words, " "))
+	if slug == "" {
+		slug = "task"
+	}
+	return "task/" + slug
+}
+
 // titleToSlug converts a GitHub issue title to a URL-safe branch slug:
 // lowercase, non-alphanum replaced by '-', collapsed and trimmed, max 40 chars.
 func titleToSlug(title string) string {
@@ -2036,6 +2224,9 @@ func resolveIssueArg(flag string, args []string) (string, error) {
 	}
 	if issue == "" {
 		branch, _ := git.CurrentBranch("")
+		if branch != "" && branch != "HEAD" {
+			return branch, nil
+		}
 		return "", fmt.Errorf("cannot infer issue number from branch %q (expected prefix matching ^[0-9]+-).\nRe-run with an explicit issue number:\n  agentctl %s <issue>", branch, flag)
 	}
 	return issue, nil
@@ -2078,7 +2269,7 @@ func findWorktreePath(issue string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("cannot determine repo root: %w", err)
 	}
-	wt, found, err := git.FindWorktreeByIssue(repoRoot, issue)
+	wt, found, err := findLinkedWorktree(repoRoot, issue)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -338,6 +338,19 @@ func TestBuildKickoff_isAgentNeutral(t *testing.T) {
 	}
 }
 
+func TestBuildKickoffFromTask_noPortUsesTaskDescription(t *testing.T) {
+	kickoff := buildKickoffFromTask("Refactor the auth middleware to use JWT", "")
+	if !strings.Contains(kickoff, "Refactor the auth middleware to use JWT") {
+		t.Fatalf("task kickoff must include the task description, got:\n%s", kickoff)
+	}
+	if strings.Contains(kickoff, "GitHub issue #") {
+		t.Fatalf("task kickoff must not mention a GitHub issue, got:\n%s", kickoff)
+	}
+	if strings.Contains(kickoff, "port") {
+		t.Fatalf("task kickoff with empty port must not mention a port, got:\n%s", kickoff)
+	}
+}
+
 func TestStartCmd_noSDDFlagRemoved(t *testing.T) {
 	c := NewStartCmd()
 	if f := c.Flags().Lookup("no-sdd"); f != nil {
@@ -353,6 +366,44 @@ func TestStartCmd_sddFlagExists(t *testing.T) {
 	}
 	if f.DefValue != "" {
 		t.Errorf("--sdd default should be '' (empty), got %q", f.DefValue)
+	}
+}
+
+func TestStartCmd_taskAndBranchFlagsExist(t *testing.T) {
+	c := NewStartCmd()
+	if f := c.Flags().Lookup("task"); f == nil {
+		t.Fatal("--task flag must be registered")
+	}
+	if f := c.Flags().Lookup("branch"); f == nil {
+		t.Fatal("--branch flag must be registered")
+	}
+}
+
+func TestStartCmd_taskMutuallyExclusiveWithIssue(t *testing.T) {
+	c := NewStartCmd()
+	c.SilenceUsage = true
+	c.SetArgs([]string{"42", "--task", "Refactor auth middleware"})
+
+	err := c.Execute()
+	if err == nil {
+		t.Fatal("expected mutual exclusivity error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected mutual exclusivity error, got: %v", err)
+	}
+}
+
+func TestStartCmd_branchRequiresTask(t *testing.T) {
+	c := NewStartCmd()
+	c.SilenceUsage = true
+	c.SetArgs([]string{"42", "--branch", "task/refactor-auth"})
+
+	err := c.Execute()
+	if err == nil {
+		t.Fatal("expected --branch requires --task error")
+	}
+	if !strings.Contains(err.Error(), "--branch requires --task") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -421,12 +472,44 @@ func TestResolveIssueArg_acceptsURL(t *testing.T) {
 	}
 }
 
+func TestResolveIssueArg_infersTaskBranchInsideLinkedWorktree(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	wtPath := filepath.Join(t.TempDir(), "repo-task-refactor-auth")
+	addWorktree(t, repo, wtPath, "task/refactor-auth")
+	chdirTemp(t, wtPath)
+
+	issue, err := resolveIssueArg("discard", []string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if issue != "task/refactor-auth" {
+		t.Fatalf("got %q, want %q", issue, "task/refactor-auth")
+	}
+}
+
 func TestResolveIssueArg_noArgs_notLinked(t *testing.T) {
 	// Running from the primary worktree (not a linked one) must return an error.
 	chdirTemp(t, t.TempDir())
 	_, err := resolveIssueArg("test", []string{})
 	if err == nil {
 		t.Error("expected error when no arg given and not inside a linked worktree")
+	}
+}
+
+func TestFindWorktreePath_acceptsTaskBranch(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	wtPath := filepath.Join(t.TempDir(), "repo-task-refactor-auth")
+	addWorktree(t, repo, wtPath, "task/refactor-auth")
+	chdirTemp(t, repo)
+
+	got, err := findWorktreePath("task/refactor-auth")
+	if err != nil {
+		t.Fatalf("findWorktreePath: %v", err)
+	}
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	wantResolved, _ := filepath.EvalSymlinks(wtPath)
+	if gotResolved != wantResolved {
+		t.Fatalf("got %q, want %q", got, wtPath)
 	}
 }
 
@@ -859,6 +942,38 @@ func TestGenerateUUID(t *testing.T) {
 	}
 	if uuid != strings.ToLower(uuid) {
 		t.Errorf("UUID not lowercase: %q", uuid)
+	}
+}
+
+func TestSlugFromTask(t *testing.T) {
+	tests := []struct {
+		name string
+		task string
+		want string
+	}{
+		{
+			name: "first six words",
+			task: "Refactor the auth middleware to use JWT tokens everywhere",
+			want: "task/refactor-the-auth-middleware-to-use",
+		},
+		{
+			name: "punctuation stripped and capped",
+			task: "Clean up auth!!! middleware??? now; please, thanks.",
+			want: "task/clean-up-auth-middleware-now-please",
+		},
+		{
+			name: "empty falls back to task",
+			task: "!!!",
+			want: "task/task",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := slugFromTask(tt.task); got != tt.want {
+				t.Fatalf("slugFromTask(%q) = %q, want %q", tt.task, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -1843,6 +1958,48 @@ func TestStartOne_headlessImmediateExitCleansUpWorktree(t *testing.T) {
 	}
 }
 
+func TestStartTask_headlessCreatesTaskBranchAndOmitsIssueArg(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	writeLocalAdapter(t, repo, "echoagent", "binary: echo\nsession: --session\n")
+	chdirTemp(t, repo)
+
+	task := "Refactor the auth middleware to use JWT tokens everywhere"
+	wantBranch := "task/refactor-the-auth-middleware-to-use"
+	wantWorktree := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-task-refactor-the-auth-middleware-to-use")
+
+	var out bytes.Buffer
+	if err := startTask(task, "", "echoagent", "", true, false, false, &out); err != nil {
+		t.Fatalf("startTask: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = git.RemoveWorktree(repo, wantWorktree)
+		_ = git.DeleteLocalBranch(repo, wantBranch)
+	})
+
+	if _, err := os.Stat(wantWorktree); err != nil {
+		t.Fatalf("worktree not created: %v", err)
+	}
+
+	af, err := state.Read(wantWorktree)
+	if err != nil {
+		t.Fatalf("state.Read: %v", err)
+	}
+	if af.IssueArg != "" {
+		t.Fatalf("IssueArg = %q, want empty", af.IssueArg)
+	}
+	if af.Agent != "echoagent" {
+		t.Fatalf("Agent = %q, want %q", af.Agent, "echoagent")
+	}
+
+	branch, err := git.CurrentBranch(wantWorktree)
+	if err != nil {
+		t.Fatalf("CurrentBranch: %v", err)
+	}
+	if branch != wantBranch {
+		t.Fatalf("branch = %q, want %q", branch, wantBranch)
+	}
+}
+
 func TestAgentResume_headless_success(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "test-token")
 	dir := t.TempDir()
@@ -2359,7 +2516,6 @@ func TestAgentEnv_claudeJSONSymlinkReplacesStaleFile(t *testing.T) {
 		t.Errorf(".agent-home/.claude.json contents = %q; want %q", string(got), string(want))
 	}
 }
-
 
 // TestAgentEnv_passesTokenToEnv verifies that a GITHUB_TOKEN already in the
 // process environment is forwarded to the agent env unchanged. Token injection
@@ -4106,8 +4262,8 @@ func TestDiscardCmd_commaSplitAndURLNormalization(t *testing.T) {
 	chdirTemp(t, repo)
 
 	tests := []struct {
-		name      string
-		arg       string
+		name       string
+		arg        string
 		wantIssues []string // issue numbers expected in "Nothing to remove" output
 	}{
 		{

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2000,6 +2000,57 @@ func TestStartTask_headlessCreatesTaskBranchAndOmitsIssueArg(t *testing.T) {
 	}
 }
 
+func TestStartTask_writeTaskModeFlag(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	writeLocalAdapter(t, repo, "echoagent", "binary: echo\nsession: --session\n")
+	chdirTemp(t, repo)
+
+	task := "Add OAuth2 login flow"
+	wantBranch := "task/add-oauth2-login-flow"
+	wantWorktree := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-task-add-oauth2-login-flow")
+
+	var out bytes.Buffer
+	if err := startTask(task, "", "echoagent", "", true, false, false, &out); err != nil {
+		t.Fatalf("startTask: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = git.RemoveWorktree(repo, wantWorktree)
+		_ = git.DeleteLocalBranch(repo, wantBranch)
+	})
+
+	af, err := state.Read(wantWorktree)
+	if err != nil {
+		t.Fatalf("state.Read: %v", err)
+	}
+	if !af.TaskMode {
+		t.Fatalf("TaskMode = false, want true in task-mode worktree")
+	}
+}
+
+// TestEffectiveSpecKey verifies that effectiveSpecKey returns "task" for task-mode
+// worktrees regardless of the branch name, and falls back to specLookupKey otherwise.
+func TestEffectiveSpecKey(t *testing.T) {
+	tests := []struct {
+		issue    string
+		taskMode bool
+		want     string
+	}{
+		{issue: "42", taskMode: false, want: "42"},
+		{issue: "task/refactor-auth", taskMode: false, want: "task"},
+		{issue: "refactor-auth", taskMode: false, want: "refactor-auth"},
+		{issue: "refactor-auth", taskMode: true, want: "task"},
+		{issue: "my-feature", taskMode: true, want: "task"},
+		{issue: "task/my-feature", taskMode: true, want: "task"},
+	}
+	for _, tt := range tests {
+		af := state.AgentFile{TaskMode: tt.taskMode}
+		got := effectiveSpecKey(tt.issue, af)
+		if got != tt.want {
+			t.Errorf("effectiveSpecKey(%q, taskMode=%v) = %q, want %q", tt.issue, tt.taskMode, got, tt.want)
+		}
+	}
+}
+
 func TestAgentResume_headless_success(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "test-token")
 	dir := t.TempDir()

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -130,6 +130,21 @@ func FindWorktreeByIssue(repoRoot, issue string) (Worktree, bool, error) {
 	return Worktree{}, false, nil
 }
 
+// FindWorktreeByBranch returns the first linked worktree whose branch exactly
+// matches branch.
+func FindWorktreeByBranch(repoRoot, branch string) (Worktree, bool, error) {
+	wts, err := LinkedWorktrees(repoRoot)
+	if err != nil {
+		return Worktree{}, false, err
+	}
+	for _, wt := range wts {
+		if wt.Branch == branch {
+			return wt, true, nil
+		}
+	}
+	return Worktree{}, false, nil
+}
+
 // CurrentBranch returns the abbreviated branch name for the given directory.
 func CurrentBranch(dir string) (string, error) {
 	return run(dir, "rev-parse", "--abbrev-ref", "HEAD")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -191,6 +191,34 @@ func TestFindWorktreeByIssue(t *testing.T) {
 	}
 }
 
+func TestFindWorktreeByBranch(t *testing.T) {
+	repo := initRepo(t)
+	wtPath := filepath.Join(t.TempDir(), "repo-task-refactor-auth")
+
+	if err := AddWorktree(repo, wtPath, "task/refactor-auth"); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+
+	wt, found, err := FindWorktreeByBranch(repo, "task/refactor-auth")
+	if err != nil {
+		t.Fatalf("FindWorktreeByBranch: %v", err)
+	}
+	if !found {
+		t.Fatal("expected worktree to be found for branch task/refactor-auth")
+	}
+	if wt.Branch != "task/refactor-auth" {
+		t.Errorf("branch = %q, want %q", wt.Branch, "task/refactor-auth")
+	}
+
+	_, found, err = FindWorktreeByBranch(repo, "task/missing")
+	if err != nil {
+		t.Fatalf("FindWorktreeByBranch (miss): %v", err)
+	}
+	if found {
+		t.Error("expected not-found for missing task branch")
+	}
+}
+
 func TestInferIssue(t *testing.T) {
 	tests := []struct {
 		branch string

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -32,6 +32,10 @@ type AgentFile struct {
 	// without --sdd (SDDSet=true, SDD="") from legacy worktrees written before the
 	// sdd key was introduced (SDDSet=false).
 	SDDSet bool
+	// TaskMode is true when this worktree was started with `agentctl start --task`
+	// rather than for a GitHub issue. It is persisted as task-mode=true in .agent
+	// so that spec-lookup can use "task" as the key regardless of the branch name.
+	TaskMode bool
 	// Extra holds any additional key=value pairs not explicitly modelled above.
 	Extra map[string]string
 }
@@ -83,6 +87,8 @@ func Read(worktreePath string) (AgentFile, error) {
 			af.PRNumber = v
 		case "pr-url":
 			af.PRURL = v
+		case "task-mode":
+			af.TaskMode = v == "true"
 		default:
 			af.Extra[k] = v
 		}
@@ -155,6 +161,9 @@ func Write(worktreePath string, af AgentFile) error {
 	}
 	if af.PRURL != "" {
 		lines = append(lines, "pr-url="+af.PRURL)
+	}
+	if af.TaskMode {
+		lines = append(lines, "task-mode=true")
 	}
 	for k, v := range af.Extra {
 		lines = append(lines, k+"="+v)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -313,6 +313,43 @@ func TestSDDStageOmittedWhenZero(t *testing.T) {
 	}
 }
 
+func TestTaskModeRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	af := AgentFile{Agent: "claude", SessionID: "s1", DevPID: "1", TaskMode: true}
+	if err := Write(dir, af); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !got.TaskMode {
+		t.Error("TaskMode should be true after round-trip")
+	}
+}
+
+func TestTaskModeOmittedWhenFalse(t *testing.T) {
+	dir := t.TempDir()
+	af := AgentFile{Agent: "claude", SessionID: "s1", DevPID: "1", TaskMode: false}
+	if err := Write(dir, af); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, FileName))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(raw), "task-mode=") {
+		t.Errorf("expected no task-mode= line when TaskMode is false, got:\n%s", raw)
+	}
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.TaskMode {
+		t.Error("TaskMode should be false when not written")
+	}
+}
+
 func contains(s, sub string) bool {
 	return strings.Contains(s, sub)
 }


### PR DESCRIPTION
## Summary
- add `agentctl start --task` and optional `--branch` for free-form work that is not tied to a GitHub issue
- resolve task worktrees by branch name across start/resume/logs/discard/cleanup/status paths
- document the new task-start workflow and add regression coverage for task branch lookup and kickoff behavior

## Testing
- go test ./...
- go build ./...
- go build -o agentctl ./cmd/agentctl
- go vet ./...

Closes #189