### PR TITLE
fix: handle read-only Go module cache in .agent-home during cleanup

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1023,11 +1023,17 @@ func cleanupMerged(repoRoot, issue string) error {
 // removeAllWritable removes the directory tree at path, first making all
 // entries writable. This is required when .agent-home contains a Go module
 // cache (go/pkg/mod) whose files are intentionally read-only (0444).
+// Symlinks are skipped during chmod to avoid modifying permissions on targets
+// outside the worktree (e.g. ~/.ssh, ~/.gitconfig linked into .agent-home).
 func removeAllWritable(path string) error {
 	_ = filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
-		if err == nil {
-			_ = os.Chmod(p, 0o700)
+		if err != nil {
+			return nil
 		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		_ = os.Chmod(p, 0o700)
 		return nil
 	})
 	return os.RemoveAll(path)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"os"
 	"os/exec"
@@ -999,12 +1000,12 @@ func cleanupMerged(repoRoot, issue string) error {
 					return fmt.Errorf("git worktree remove failed and the worktree is still registered; aborting")
 				}
 				fmt.Printf("git worktree remove left an orphan dir at %s; removing it now.\n", wtPath)
-				if err2 := os.RemoveAll(wtPath); err2 != nil {
+				if err2 := removeAllWritable(wtPath); err2 != nil {
 					return err2
 				}
 			}
 		} else if _, statErr := os.Stat(wtPath); statErr == nil {
-			if err := os.RemoveAll(wtPath); err != nil {
+			if err := removeAllWritable(wtPath); err != nil {
 				return err
 			}
 		}
@@ -1017,6 +1018,19 @@ func cleanupMerged(repoRoot, issue string) error {
 	}
 
 	return nil
+}
+
+// removeAllWritable removes the directory tree at path, first making all
+// entries writable. This is required when .agent-home contains a Go module
+// cache (go/pkg/mod) whose files are intentionally read-only (0444).
+func removeAllWritable(path string) error {
+	_ = filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err == nil {
+			_ = os.Chmod(p, 0o700)
+		}
+		return nil
+	})
+	return os.RemoveAll(path)
 }
 
 func removeBranchRefs(repoRoot, branch string) error {
@@ -2090,7 +2104,7 @@ func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
 				}
 				if registered {
 					errs = append(errs, rmErr.Error())
-				} else if removeErr := os.RemoveAll(wtPath); removeErr != nil {
+				} else if removeErr := removeAllWritable(wtPath); removeErr != nil {
 					errs = append(errs, removeErr.Error())
 				}
 			}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -4916,3 +4916,60 @@ func TestGhPRInfoWithURL_noPR(t *testing.T) {
 		t.Errorf("expected zero values on error, got prState=%q number=%d url=%q", prState, number, url)
 	}
 }
+
+// ─── removeAllWritable ────────────────────────────────────────────────────────
+
+// TestRemoveAllWritable_readOnlyFiles verifies that removeAllWritable can delete
+// a directory tree containing read-only files (like Go module cache files).
+func TestRemoveAllWritable_readOnlyFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a nested structure with read-only files.
+	subDir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	readOnlyFile := filepath.Join(subDir, "readonly.txt")
+	if err := os.WriteFile(readOnlyFile, []byte("data"), 0o444); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := removeAllWritable(dir); err != nil {
+		t.Fatalf("removeAllWritable: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("expected dir to be removed, but it still exists")
+	}
+}
+
+// TestRemoveAllWritable_symlinkTargetPermissionsUnchanged verifies that
+// removeAllWritable does not chmod symlink targets outside the tree.
+func TestRemoveAllWritable_symlinkTargetPermissionsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a target file outside the tree with restrictive permissions.
+	targetDir := t.TempDir()
+	targetFile := filepath.Join(targetDir, "outside.txt")
+	if err := os.WriteFile(targetFile, []byte("secret"), 0o400); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Create a symlink inside the tree pointing to the outside file.
+	symlinkPath := filepath.Join(dir, "link")
+	if err := os.Symlink(targetFile, symlinkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	if err := removeAllWritable(dir); err != nil {
+		t.Fatalf("removeAllWritable: %v", err)
+	}
+
+	// The target outside the tree must retain its original permissions.
+	info, err := os.Stat(targetFile)
+	if err != nil {
+		t.Fatalf("Stat target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o400 {
+		t.Errorf("target permissions changed: got %04o, want 0400", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `agentctl cleanup --all` was failing with `permission denied` on Go module cache files inside `.agent-home/go/pkg/mod/`
- Go intentionally marks module cache files as read-only (`0444`); `os.RemoveAll` cannot delete them without a prior `chmod`
- Adds `removeAllWritable` helper that walks the tree with `chmod 0700` before calling `os.RemoveAll`
- Replaces all three `os.RemoveAll(wtPath)` call sites in `cleanupMerged` and the discard path

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./...`
- [ ] Manual: run `agentctl cleanup --all` on worktrees where the agent ran Go commands — confirm cleanup succeeds and remote branches are deleted

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)