### PR TITLE
feat: agentctl diff — show what an agent changed in a worktree

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -11,6 +11,7 @@
 //	agentctl status     [--verbose]
 //	agentctl logs       [--lines N] [--no-follow] <issue>
 //	agentctl attach     <issue>
+//	agentctl diff       [--stat] [--base branch] [--no-pager] <issue>
 //	agentctl dev start  [--quiet] [issue]
 package main
 
@@ -51,6 +52,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewStatusCmd(),
 		cmd.NewLogsCmd(),
 		cmd.NewAttachCmd(),
+		cmd.NewDiffCmd(),
 		cmd.NewDevCmd(),
 		cmd.NewStreamLogCmd(),
 		cmd.NewStreamLogOpenHandsCmd(),

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1708,6 +1708,81 @@ func attachLog(wtPath, issue string, w io.Writer, logWait time.Duration) error {
 	return nil
 }
 
+// NewDiffCmd creates the `diff` subcommand.
+func NewDiffCmd() *cobra.Command {
+	var stat bool
+	var base string
+	var noPager bool
+	c := &cobra.Command{
+		Use:   "diff <issue>",
+		Short: "Show what the agent has changed in a worktree",
+		Long: `Show the git diff for the agent's worktree.
+
+By default prints all uncommitted changes (staged + unstaged) and pipes the
+output through the configured pager ($PAGER, defaulting to less -R).
+
+Use --base to compare against a branch, e.g. --base main shows everything the
+agent added since branching from main.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDiff(args[0], base, stat, noPager)
+		},
+	}
+	c.Flags().BoolVar(&stat, "stat", false, "Show changed-file summary instead of full diff")
+	c.Flags().StringVar(&base, "base", "", "Diff base branch (default: show uncommitted changes)")
+	c.Flags().BoolVar(&noPager, "no-pager", false, "Print to stdout without paging")
+	return c
+}
+
+func runDiff(issue, base string, stat, noPager bool) error {
+	if _, _, num, ok := parseIssueURL(issue); ok {
+		issue = num
+	}
+	wtPath, err := findWorktreePath(issue)
+	if err != nil {
+		return err
+	}
+
+	args := []string{"diff", "--color=always"}
+	if stat {
+		args = append(args, "--stat")
+	}
+	if base != "" {
+		args = append(args, base+"...HEAD")
+	} else {
+		args = append(args, "HEAD")
+	}
+
+	gitCmd := exec.Command("git", args...)
+	gitCmd.Dir = wtPath
+	gitCmd.Stderr = os.Stderr
+
+	if noPager || stat || !isTerminal(os.Stdout) {
+		gitCmd.Stdout = os.Stdout
+		return gitCmd.Run()
+	}
+
+	pager := os.Getenv("PAGER")
+	if pager == "" {
+		pager = "less"
+	}
+	pagerCmd := exec.Command(pager, "-R")
+	pagerCmd.Stdin, _ = gitCmd.StdoutPipe()
+	pagerCmd.Stdout = os.Stdout
+	pagerCmd.Stderr = os.Stderr
+	if err := pagerCmd.Start(); err != nil {
+		gitCmd.Stdout = os.Stdout
+		return gitCmd.Run()
+	}
+	_ = gitCmd.Run()
+	return pagerCmd.Wait()
+}
+
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	return err == nil && (fi.Mode()&os.ModeCharDevice) != 0
+}
+
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 func dash(s string) string {

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1887,7 +1887,16 @@ func runDiff(issue, base string, stat, noPager bool) error {
 		return err
 	}
 
-	args := []string{"diff", "--color=always"}
+	// Use --color=always only when piping to the pager: git detects a pipe
+	// and disables colour on its own, but we want colour in the pager.
+	// For all other paths (--no-pager, --stat, non-TTY) let git auto-detect.
+	usePager := !noPager && !stat && isTerminal(os.Stdout)
+	colorFlag := "--color=auto"
+	if usePager {
+		colorFlag = "--color=always"
+	}
+
+	args := []string{"diff", colorFlag}
 	if stat {
 		args = append(args, "--stat")
 	}
@@ -1901,25 +1910,54 @@ func runDiff(issue, base string, stat, noPager bool) error {
 	gitCmd.Dir = wtPath
 	gitCmd.Stderr = os.Stderr
 
-	if noPager || stat || !isTerminal(os.Stdout) {
+	if !usePager {
 		gitCmd.Stdout = os.Stdout
 		return gitCmd.Run()
 	}
 
-	pager := os.Getenv("PAGER")
-	if pager == "" {
-		pager = "less"
+	// Build the pager command.  When $PAGER is set, invoke it via "sh -c" so
+	// complex values like "less -FRSX" or "delta" are handled correctly.
+	// When $PAGER is unset, default to "less -R".
+	var pagerCmd *exec.Cmd
+	if pagerEnv := os.Getenv("PAGER"); pagerEnv != "" {
+		pagerCmd = exec.Command("sh", "-c", pagerEnv)
+	} else {
+		pagerCmd = exec.Command("less", "-R")
 	}
-	pagerCmd := exec.Command(pager, "-R")
-	pagerCmd.Stdin, _ = gitCmd.StdoutPipe()
+
+	pipe, err := gitCmd.StdoutPipe()
+	if err != nil {
+		gitCmd.Stdout = os.Stdout
+		return gitCmd.Run()
+	}
+	pagerCmd.Stdin = pipe
 	pagerCmd.Stdout = os.Stdout
 	pagerCmd.Stderr = os.Stderr
 	if err := pagerCmd.Start(); err != nil {
 		gitCmd.Stdout = os.Stdout
 		return gitCmd.Run()
 	}
-	_ = gitCmd.Run()
-	return pagerCmd.Wait()
+	gitErr := gitCmd.Run()
+	pagerErr := pagerCmd.Wait()
+	// git exits with SIGPIPE when the pager quits early (user pressed 'q');
+	// treat that as success and surface the pager exit status instead.
+	if gitErr != nil && !isSignalError(gitErr, syscall.SIGPIPE) {
+		return gitErr
+	}
+	return pagerErr
+}
+
+// isSignalError reports whether err is an *exec.ExitError caused by the given
+// Unix signal.  Returns false on non-Unix platforms or when err is not an
+// ExitError.
+func isSignalError(err error, sig syscall.Signal) bool {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			return ws.Signaled() && ws.Signal() == sig
+		}
+	}
+	return false
 }
 
 func isTerminal(f *os.File) bool {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -4916,3 +4916,60 @@ func TestGhPRInfoWithURL_noPR(t *testing.T) {
 		t.Errorf("expected zero values on error, got prState=%q number=%d url=%q", prState, number, url)
 	}
 }
+
+// ─── runDiff ──────────────────────────────────────────────────────────────────
+
+func TestRunDiff_unknownIssue(t *testing.T) {
+	err := runDiff("99999", "", false, true)
+	if err == nil {
+		t.Fatal("expected error for unknown issue")
+	}
+	if !strings.Contains(err.Error(), "no worktree found") {
+		t.Errorf("error should contain 'no worktree found'; got: %v", err)
+	}
+}
+
+func TestRunDiff_issueURL(t *testing.T) {
+	// A full GitHub URL should be resolved to a bare issue number and then
+	// fail with the same "no worktree found" error (not a URL-parsing error).
+	err := runDiff("https://github.com/owner/repo/issues/99999", "", false, true)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no worktree found") {
+		t.Errorf("expected 'no worktree found'; got: %v", err)
+	}
+}
+
+func TestRunDiff_statFlag_unknownIssue(t *testing.T) {
+	// --stat with unknown issue should fail at worktree lookup, not panic.
+	err := runDiff("99999", "", true, true)
+	if err == nil {
+		t.Fatal("expected error for unknown issue")
+	}
+	if !strings.Contains(err.Error(), "no worktree found") {
+		t.Errorf("unexpected error; got: %v", err)
+	}
+}
+
+func TestRunDiff_withBase_unknownIssue(t *testing.T) {
+	// --base with unknown issue should fail at worktree lookup.
+	err := runDiff("99999", "main", false, true)
+	if err == nil {
+		t.Fatal("expected error for unknown issue")
+	}
+	if !strings.Contains(err.Error(), "no worktree found") {
+		t.Errorf("unexpected error; got: %v", err)
+	}
+}
+
+func TestIsTerminal_pipe(t *testing.T) {
+	// A pipe is not a terminal — os.Stdin in tests is a pipe.
+	if isTerminal(os.Stdin) {
+		t.Log("stdin appears to be a terminal — skipping assertion (running interactively?)")
+		return
+	}
+	if isTerminal(os.Stdin) {
+		t.Error("expected isTerminal(os.Stdin) == false in test environment")
+	}
+}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5171,14 +5171,88 @@ func TestRunDiff_withBase_unknownIssue(t *testing.T) {
 	}
 }
 
-func TestIsTerminal_pipe(t *testing.T) {
-	// A pipe is not a terminal — os.Stdin in tests is a pipe.
-	if isTerminal(os.Stdin) {
-		t.Log("stdin appears to be a terminal — skipping assertion (running interactively?)")
-		return
+// initDiffTestRepo creates a git repo with a linked worktree named so that
+// findWorktreePath can locate it by issue number, and cd's into the repo root.
+// Returns the issue number (as string) and the repo root path.
+func initDiffTestRepo(t *testing.T) (issue string, root string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
 	}
-	if isTerminal(os.Stdin) {
-		t.Error("expected isTerminal(os.Stdin) == false in test environment")
+	root = t.TempDir()
+	issue = "191"
+
+	gitAt := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	gitAt(root, "init")
+	gitAt(root, "config", "user.email", "test@example.com")
+	gitAt(root, "config", "user.name", "Test")
+	gitAt(root, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitAt(root, "add", ".")
+	gitAt(root, "commit", "-m", "init")
+
+	// The worktree path must contain "-<issue>-" so FindWorktreeByIssue matches.
+	wtPath := filepath.Join(t.TempDir(), "repo-"+issue+"-diff-test")
+	gitAt(root, "worktree", "add", "-b", issue+"-diff-test", wtPath)
+
+	chdirTemp(t, root)
+	return issue, root
+}
+
+func TestRunDiff_noPager_noBase(t *testing.T) {
+	// runDiff with --no-pager and no --base should succeed on a real worktree
+	// and produce output on stdout (we only check for no error here).
+	issue, _ := initDiffTestRepo(t)
+	if err := runDiff(issue, "", false, true); err != nil {
+		t.Fatalf("runDiff noPager: %v", err)
+	}
+}
+
+func TestRunDiff_stat_noPager(t *testing.T) {
+	// --stat implies no pager; should succeed without error.
+	issue, _ := initDiffTestRepo(t)
+	if err := runDiff(issue, "", true, true); err != nil {
+		t.Fatalf("runDiff --stat: %v", err)
+	}
+}
+
+func TestRunDiff_withBase_noPager(t *testing.T) {
+	// --base should produce a three-dot diff; no error expected on a real repo.
+	issue, root := initDiffTestRepo(t)
+	// Detect default branch name (main or master) using the repo root we already have.
+	out, err := exec.Command("git", "-C", root, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	defaultBranchName := "main"
+	if err == nil {
+		defaultBranchName = strings.TrimSpace(string(out))
+	}
+	if err := runDiff(issue, defaultBranchName, false, true); err != nil {
+		t.Fatalf("runDiff --base %s: %v", defaultBranchName, err)
+	}
+}
+
+func TestIsTerminal_pipe(t *testing.T) {
+	// Create a real OS pipe and verify that neither end is reported as a terminal.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+	if isTerminal(r) {
+		t.Error("expected isTerminal(pipe read-end) == false, got true")
+	}
+	if isTerminal(w) {
+		t.Error("expected isTerminal(pipe write-end) == false, got true")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `agentctl diff <issue>` subcommand (closes #191)
- Pipes output through `$PAGER` (default `less -R`) with `--color=always` when stdout is a TTY
- `--stat` prints a changed-file summary and skips the pager
- `--base <branch>` uses `<branch>...HEAD` three-dot diff to show only the agent's commits
- `--no-pager` prints raw diff to stdout

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `agentctl diff --help` shows the new command
- [ ] `agentctl diff <active-issue>` pages through the worktree diff
- [ ] `agentctl diff <active-issue> --stat` prints file summary without pager
- [ ] `agentctl diff <active-issue> --no-pager` prints raw diff to stdout
- [ ] `agentctl diff <active-issue> --base main` diffs against main

🤖 Generated with [Claude Code](https://claude.com/claude-code)