### PR TITLE
fix: fall back to gh auth token when GITHUB_TOKEN env var is absent

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2198,12 +2198,13 @@ func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
 	return nil
 }
 
-// ensureGHToken ensures GITHUB_TOKEN is set in the environment so that gh
-// subprocesses never need to touch the macOS keychain. Resolution order:
+// ensureGHToken ensures GITHUB_TOKEN is set in the environment before agents
+// are launched. It checks env vars first; only when both are absent does it
+// shell out to `gh auth token` as a convenience fallback. Resolution order:
 //  1. GITHUB_TOKEN already set — use it.
 //  2. GH_TOKEN set — copy to GITHUB_TOKEN.
 //  3. `gh auth token` succeeds — set GITHUB_TOKEN from its output.
-//  4. All fail — return an actionable error.
+//  4. All fail — return an actionable error that includes any `gh` diagnostic.
 func ensureGHToken() error {
 	if os.Getenv("GITHUB_TOKEN") != "" {
 		return nil
@@ -2212,15 +2213,22 @@ func ensureGHToken() error {
 		os.Setenv("GITHUB_TOKEN", tok)
 		return nil
 	}
-	// Try gh auth token silently; works for users with a configured gh CLI.
-	out, err := exec.Command("gh", "auth", "token").Output()
-	if err == nil {
-		if tok := strings.TrimSpace(string(out)); tok != "" {
+	// Try gh auth token as a convenience fallback for users with a configured gh CLI.
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("gh", "auth", "token")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		if tok := strings.TrimSpace(stdout.String()); tok != "" {
 			os.Setenv("GITHUB_TOKEN", tok)
 			return nil
 		}
 	}
-	return fmt.Errorf("GITHUB_TOKEN is not set\n\nSet it in your current shell (or shell profile) and re-run:\n  export GITHUB_TOKEN=<your-token>\n\nBoth GITHUB_TOKEN and GH_TOKEN are accepted. To obtain a token, run:\n  gh auth token")
+	msg := "GITHUB_TOKEN is not set\n\nSet it in your current shell (or shell profile) and re-run:\n  export GITHUB_TOKEN=<your-token>\n\nBoth GITHUB_TOKEN and GH_TOKEN are accepted. To obtain a token, run:\n  gh auth token"
+	if ghErr := strings.TrimSpace(stderr.String()); ghErr != "" {
+		msg += "\n\n`gh auth token` reported: " + ghErr
+	}
+	return fmt.Errorf("%s", msg)
 }
 
 // slugFromIssue fetches the GitHub issue title and converts it to a slug.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2198,10 +2198,12 @@ func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
 	return nil
 }
 
-// ensureGHToken verifies that GITHUB_TOKEN (or GH_TOKEN) is present in the
-// environment. It never calls gh or touches the macOS keychain. If GH_TOKEN
-// is set it is normalised to GITHUB_TOKEN so the agent subprocess sees it
-// under the conventional name. Returns an actionable error when neither is set.
+// ensureGHToken ensures GITHUB_TOKEN is set in the environment so that gh
+// subprocesses never need to touch the macOS keychain. Resolution order:
+//  1. GITHUB_TOKEN already set — use it.
+//  2. GH_TOKEN set — copy to GITHUB_TOKEN.
+//  3. `gh auth token` succeeds — set GITHUB_TOKEN from its output.
+//  4. All fail — return an actionable error.
 func ensureGHToken() error {
 	if os.Getenv("GITHUB_TOKEN") != "" {
 		return nil
@@ -2209,6 +2211,14 @@ func ensureGHToken() error {
 	if tok := os.Getenv("GH_TOKEN"); tok != "" {
 		os.Setenv("GITHUB_TOKEN", tok)
 		return nil
+	}
+	// Try gh auth token silently; works for users with a configured gh CLI.
+	out, err := exec.Command("gh", "auth", "token").Output()
+	if err == nil {
+		if tok := strings.TrimSpace(string(out)); tok != "" {
+			os.Setenv("GITHUB_TOKEN", tok)
+			return nil
+		}
 	}
 	return fmt.Errorf("GITHUB_TOKEN is not set\n\nSet it in your current shell (or shell profile) and re-run:\n  export GITHUB_TOKEN=<your-token>\n\nBoth GITHUB_TOKEN and GH_TOKEN are accepted. To obtain a token, run:\n  gh auth token")
 }

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2471,10 +2471,11 @@ func TestAgentEnv_preservesExistingToken(t *testing.T) {
 
 // TestEnsureGHToken_failsWhenAbsent verifies that ensureGHToken returns an
 // error when neither GITHUB_TOKEN nor GH_TOKEN is set and gh auth token fails.
+// It also checks that gh's stderr diagnostic is included in the error message.
 func TestEnsureGHToken_failsWhenAbsent(t *testing.T) {
-	// Stub gh to exit non-zero so the fallback also fails.
+	// Stub gh to exit non-zero with a diagnostic on stderr so the fallback fails.
 	stubDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(stubDir, "gh"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(stubDir, "gh"), []byte("#!/bin/sh\necho 'not logged in' >&2\nexit 1\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	prependPath(t, stubDir)
@@ -2496,8 +2497,12 @@ func TestEnsureGHToken_failsWhenAbsent(t *testing.T) {
 		}
 	})
 
-	if err := ensureGHToken(); err == nil {
+	err := ensureGHToken()
+	if err == nil {
 		t.Fatal("expected error when GITHUB_TOKEN, GH_TOKEN, and gh auth token are all absent/failing")
+	}
+	if !strings.Contains(err.Error(), "not logged in") {
+		t.Errorf("error should include gh stderr diagnostic; got: %v", err)
 	}
 }
 
@@ -2561,6 +2566,68 @@ func TestEnsureGHToken_normalizesGHToken(t *testing.T) {
 	}
 	if got := os.Getenv("GITHUB_TOKEN"); got != "gh-token-value" {
 		t.Errorf("GITHUB_TOKEN = %q; want %q", got, "gh-token-value")
+	}
+}
+
+// TestEnsureGHToken_githubTokenWinsOverGHAuthToken verifies that when GITHUB_TOKEN
+// is already set, ensureGHToken does NOT call `gh auth token` and leaves the token
+// unchanged, so explicit env always wins over the fallback.
+func TestEnsureGHToken_githubTokenWinsOverGHAuthToken(t *testing.T) {
+	// Stub gh: write a marker file when called so we can assert it was never invoked.
+	stubDir := t.TempDir()
+	markerFile := filepath.Join(stubDir, "gh-was-called")
+	stubScript := "#!/bin/sh\ntouch " + markerFile + "\necho 'ghp_should_not_be_used'\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "gh"), []byte(stubScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prependPath(t, stubDir)
+
+	t.Setenv("GITHUB_TOKEN", "explicit-github-token")
+	t.Setenv("GH_TOKEN", "")
+
+	if err := ensureGHToken(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv("GITHUB_TOKEN"); got != "explicit-github-token" {
+		t.Errorf("GITHUB_TOKEN = %q; want %q (explicit GITHUB_TOKEN must not be overwritten)", got, "explicit-github-token")
+	}
+	if _, err := os.Stat(markerFile); err == nil {
+		t.Error("gh stub was invoked; GITHUB_TOKEN env var should have short-circuited the fallback")
+	}
+}
+
+// TestEnsureGHToken_ghTokenWinsOverGHAuthToken verifies that when GH_TOKEN is set
+// but GITHUB_TOKEN is not, ensureGHToken copies GH_TOKEN without invoking `gh auth
+// token`, so the explicit env still wins over the fallback.
+func TestEnsureGHToken_ghTokenWinsOverGHAuthToken(t *testing.T) {
+	// Stub gh: write a marker file when called so we can assert it was never invoked.
+	stubDir := t.TempDir()
+	markerFile := filepath.Join(stubDir, "gh-was-called")
+	stubScript := "#!/bin/sh\ntouch " + markerFile + "\necho 'ghp_should_not_be_used'\n"
+	if err := os.WriteFile(filepath.Join(stubDir, "gh"), []byte(stubScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prependPath(t, stubDir)
+
+	origGH, hadGH := os.LookupEnv("GITHUB_TOKEN")
+	os.Unsetenv("GITHUB_TOKEN")
+	t.Cleanup(func() {
+		if hadGH {
+			os.Setenv("GITHUB_TOKEN", origGH)
+		} else {
+			os.Unsetenv("GITHUB_TOKEN")
+		}
+	})
+	t.Setenv("GH_TOKEN", "explicit-gh-token")
+
+	if err := ensureGHToken(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv("GITHUB_TOKEN"); got != "explicit-gh-token" {
+		t.Errorf("GITHUB_TOKEN = %q; want %q (GH_TOKEN must win over gh auth token fallback)", got, "explicit-gh-token")
+	}
+	if _, err := os.Stat(markerFile); err == nil {
+		t.Error("gh stub was invoked; GH_TOKEN env var should have short-circuited the fallback")
 	}
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2470,9 +2470,15 @@ func TestAgentEnv_preservesExistingToken(t *testing.T) {
 }
 
 // TestEnsureGHToken_failsWhenAbsent verifies that ensureGHToken returns an
-// error when neither GITHUB_TOKEN nor GH_TOKEN is set, rather than falling
-// back to the macOS keychain via `gh auth token`.
+// error when neither GITHUB_TOKEN nor GH_TOKEN is set and gh auth token fails.
 func TestEnsureGHToken_failsWhenAbsent(t *testing.T) {
+	// Stub gh to exit non-zero so the fallback also fails.
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "gh"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prependPath(t, stubDir)
+
 	origGH, hadGH := os.LookupEnv("GITHUB_TOKEN")
 	origGHT, hadGHT := os.LookupEnv("GH_TOKEN")
 	os.Unsetenv("GITHUB_TOKEN")
@@ -2491,7 +2497,41 @@ func TestEnsureGHToken_failsWhenAbsent(t *testing.T) {
 	})
 
 	if err := ensureGHToken(); err == nil {
-		t.Fatal("expected error when GITHUB_TOKEN and GH_TOKEN are both absent")
+		t.Fatal("expected error when GITHUB_TOKEN, GH_TOKEN, and gh auth token are all absent/failing")
+	}
+}
+
+// TestEnsureGHToken_fallsBackToGHAuthToken verifies that ensureGHToken uses
+// `gh auth token` when env vars are absent, and sets GITHUB_TOKEN from its output.
+func TestEnsureGHToken_fallsBackToGHAuthToken(t *testing.T) {
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "gh"), []byte("#!/bin/sh\necho 'ghp_stubtoken'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prependPath(t, stubDir)
+
+	origGH, hadGH := os.LookupEnv("GITHUB_TOKEN")
+	origGHT, hadGHT := os.LookupEnv("GH_TOKEN")
+	os.Unsetenv("GITHUB_TOKEN")
+	os.Unsetenv("GH_TOKEN")
+	t.Cleanup(func() {
+		if hadGH {
+			os.Setenv("GITHUB_TOKEN", origGH)
+		} else {
+			os.Unsetenv("GITHUB_TOKEN")
+		}
+		if hadGHT {
+			os.Setenv("GH_TOKEN", origGHT)
+		} else {
+			os.Unsetenv("GH_TOKEN")
+		}
+	})
+
+	if err := ensureGHToken(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := os.Getenv("GITHUB_TOKEN"); got != "ghp_stubtoken" {
+		t.Errorf("GITHUB_TOKEN = %q; want %q", got, "ghp_stubtoken")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Removes the hard requirement to set `GITHUB_TOKEN` manually before using agentctl
- `ensureGHToken` now tries `gh auth token` silently as a fallback before failing
- Resolution order: `GITHUB_TOKEN` env → `GH_TOKEN` env → `gh auth token` → error
- Users with a configured `gh` CLI get zero-friction auth; explicit error is last resort only

## Test plan

- [ ] `go test ./...` passes
- [ ] `agentctl start <issue>` works without `GITHUB_TOKEN` set (uses `gh auth token` fallback)
- [ ] Setting `GITHUB_TOKEN` explicitly still takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)