### PR TITLE
feat: parallel agents on the same issue for model comparison

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -84,6 +84,21 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 				slug = args[1]
 			}
 
+			// Multi-agent mode: --agent claude,codex with a single issue.
+			agents := strings.Split(agentName, ",")
+			for i, ag := range agents {
+				agents[i] = strings.TrimSpace(ag)
+			}
+			if len(agents) > 1 {
+				if len(issues) > 1 {
+					return fmt.Errorf("cannot combine multiple issues with multiple agents; specify a single issue")
+				}
+				if slug != "" {
+					return fmt.Errorf("[slug] argument is not supported when starting multiple agents")
+				}
+				return runMultiAgent(issues[0], agents, sddName, quiet, sendNotify, os.Stdout, os.Stderr)
+			}
+
 			if len(issues) > 1 {
 				if slug != "" {
 					return fmt.Errorf("[slug] argument is not supported when starting multiple issues")
@@ -91,7 +106,7 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 				return runBatch(issues, agentName, sddName, quiet, sendNotify, startOne, os.Stdout, os.Stderr)
 			}
 
-			return startOne(issues[0], slug, agentName, sddName, headless, quiet, sendNotify, os.Stdout)
+			return startOne(issues[0], slug, agentName, sddName, "", headless, quiet, sendNotify, os.Stdout)
 		},
 	}
 	c.Flags().StringVar(&agentName, "agent", "claude", "Coding agent adapter to use")
@@ -133,7 +148,9 @@ func buildKickoff(issue, port string) string {
 
 // startOne provisions a worktree for a single issue and launches the agent.
 // It is the per-issue unit used by both single-issue and batch invocations.
-func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+// agentSuffix is non-empty only in multi-agent mode (--agent claude,codex);
+// it is appended to the branch name and worktree path to avoid collisions.
+func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, quiet, sendNotify bool, out io.Writer) error {
 	// Verify GITHUB_TOKEN is set before any gh calls. Never touches the keychain.
 	if err := ensureGHToken(); err != nil {
 		return err
@@ -175,8 +192,7 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 		fmt.Fprintf(out, "Derived slug from issue title: %s\n", slug)
 	}
 
-	branch := issueNum + "-" + slug
-	wtPath := filepath.Join(parentDir, repoName+"-"+issueNum+"-"+slug)
+	branch, wtPath := worktreeNames(repoName, issueNum, slug, agentSuffix, parentDir)
 
 	// Create the worktree.
 	if _, statErr := os.Stat(wtPath); statErr == nil {
@@ -253,7 +269,7 @@ func startOne(issue, slug, agentName, sddName string, headless, quiet, sendNotif
 // collected and printed in the original issue order. If any issue fails the
 // remaining issues are still attempted and a combined error is returned.
 func runBatch(issues []string, agentName, sddName string, quiet, sendNotify bool,
-	fn func(issue, slug, agentName, sddName string, headless, quiet, sendNotify bool, out io.Writer) error,
+	fn func(issue, slug, agentName, sddName, agentSuffix string, headless, quiet, sendNotify bool, out io.Writer) error,
 	out io.Writer, errOut io.Writer) error {
 
 	type batchResult struct {
@@ -269,7 +285,7 @@ func runBatch(issues []string, agentName, sddName string, quiet, sendNotify bool
 		go func(i int, iss string) {
 			defer wg.Done()
 			var buf strings.Builder
-			err := fn(iss, "", agentName, sddName, true, quiet, sendNotify, &buf)
+			err := fn(iss, "", agentName, sddName, "", true, quiet, sendNotify, &buf)
 			results[i] = batchResult{issue: iss, output: buf.String(), err: err}
 		}(i, iss)
 	}
@@ -285,6 +301,43 @@ func runBatch(issues []string, agentName, sddName string, quiet, sendNotify bool
 	}
 	if hasErr {
 		return fmt.Errorf("one or more issues failed to start")
+	}
+	return nil
+}
+
+// runMultiAgent starts multiple agents on the same issue concurrently, each in
+// its own worktree with an agent-name suffix (e.g. repo-42-slug-claude).
+// All agents always run in headless mode; foreground is not supported here.
+func runMultiAgent(issue string, agents []string, sddName string, quiet, sendNotify bool, out, errOut io.Writer) error {
+	type agentResult struct {
+		agent  string
+		output string
+		err    error
+	}
+	results := make([]agentResult, len(agents))
+
+	var wg sync.WaitGroup
+	for i, ag := range agents {
+		wg.Add(1)
+		go func(i int, ag string) {
+			defer wg.Done()
+			var buf strings.Builder
+			err := startOne(issue, "", ag, sddName, ag, true, quiet, sendNotify, &buf)
+			results[i] = agentResult{agent: ag, output: buf.String(), err: err}
+		}(i, ag)
+	}
+	wg.Wait()
+
+	var hasErr bool
+	for _, r := range results {
+		fmt.Fprint(out, r.output)
+		if r.err != nil {
+			fmt.Fprintf(errOut, "[%s] error: %v\n", r.agent, r.err)
+			hasErr = true
+		}
+	}
+	if hasErr {
+		return fmt.Errorf("one or more agents failed to start")
 	}
 	return nil
 }
@@ -327,9 +380,10 @@ func buildResumePrompt(feedback, sddName, specPath string) string {
 // NewResumeCmd creates the `resume` subcommand.
 func NewResumeCmd() *cobra.Command {
 	var (
-		headless   bool
-		quiet      bool
-		sendNotify bool
+		headless    bool
+		quiet       bool
+		sendNotify  bool
+		agentSuffix string
 	)
 	c := &cobra.Command{
 		Use:   "resume <issue> [feedback]",
@@ -357,22 +411,17 @@ Use --headless to run it in the background and write output to agent.log.`,
 			if len(args) == 2 {
 				feedback = args[1]
 			}
-			return runReleasePausedSession(args[0], feedback, headless, quiet, sendNotify)
+			return runReleasePausedSession(args[0], feedback, agentSuffix, headless, quiet, sendNotify)
 		},
 	}
 	c.Flags().BoolVar(&headless, "headless", false, "Run agent in background (log -> agent.log)")
 	c.Flags().BoolVar(&quiet, "quiet", false, "Suppress agent log output; show spinner/heartbeat only")
 	c.Flags().BoolVar(&sendNotify, "notify", false, "Send a desktop notification when the headless agent finishes")
-	c.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
-		if strings.Contains(err.Error(), "--agent") {
-			return fmt.Errorf("resume does not accept --agent: the agent is recorded in .agent when the worktree is created and reused automatically")
-		}
-		return err
-	})
+	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to disambiguate when multiple worktrees exist for the same issue")
 	return c
 }
 
-func runReleasePausedSession(issue, feedback string, headless, quiet, sendNotify bool) error {
+func runReleasePausedSession(issue, feedback, agentSuffix string, headless, quiet, sendNotify bool) error {
 	// Accept full GitHub issue URLs; extract the bare number for local lookup.
 	if _, _, num, ok := parseIssueURL(issue); ok {
 		issue = num
@@ -391,12 +440,9 @@ func runReleasePausedSession(issue, feedback string, headless, quiet, sendNotify
 		}
 	}
 
-	wt, found, err := git.FindWorktreeByIssue(repoRoot, issue)
+	wt, err := resolveWorktree(repoRoot, issue, agentSuffix)
 	if err != nil {
 		return err
-	}
-	if !found {
-		return fmt.Errorf("no worktree found for issue %s", issue)
 	}
 
 	af, err := state.Read(wt.Path)
@@ -428,6 +474,7 @@ func runReleasePausedSession(issue, feedback string, headless, quiet, sendNotify
 // NewDiscardCmd creates the `discard` subcommand.
 func NewDiscardCmd() *cobra.Command {
 	var stale bool
+	var agentSuffix string
 	c := &cobra.Command{
 		Use:   "discard [issue[,issue...]]",
 		Short: "Permanently delete a worktree and its local/remote branches",
@@ -460,7 +507,7 @@ Use --stale to discard all worktrees that have no running agent and no PR.`,
 				if err != nil {
 					return err
 				}
-				return runRemoveWorktree(issue)
+				return runRemoveWorktree(issue, agentSuffix)
 			}
 			rawIssues := strings.Split(args[0], ",")
 			issues := make([]string, 0, len(rawIssues))
@@ -476,7 +523,7 @@ Use --stale to discard all worktrees that have no running agent and no PR.`,
 				return fmt.Errorf("no valid issue tokens found in %q", args[0])
 			}
 			for _, issue := range issues {
-				if err := runRemoveWorktree(issue); err != nil {
+				if err := runRemoveWorktree(issue, agentSuffix); err != nil {
 					return err
 				}
 			}
@@ -484,6 +531,7 @@ Use --stale to discard all worktrees that have no running agent and no PR.`,
 		},
 	}
 	c.Flags().BoolVar(&stale, "stale", false, "Discard all worktrees with no running agent and no PR")
+	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to target a specific worktree when multiple agents ran on the same issue")
 	return c
 }
 
@@ -615,20 +663,19 @@ func runDiscardStale() error {
 	return nil
 }
 
-func runRemoveWorktree(issue string) error {
+func runRemoveWorktree(issue, agentSuffix string) error {
 	repoRoot, err := git.RepoRoot()
 	if err != nil {
 		return fmt.Errorf("cannot determine repo root: %w", err)
 	}
 
-	wt, found, err := git.FindWorktreeByIssue(repoRoot, issue)
 	var wtPath, branch string
-	if err != nil {
-		return err
-	}
-	if found {
+	wt, resolveErr := resolveWorktree(repoRoot, issue, agentSuffix)
+	if resolveErr == nil {
 		wtPath = wt.Path
 		branch = wt.Branch
+	} else if errors.Is(resolveErr, errAmbiguousWorktree) {
+		return resolveErr
 	}
 
 	// If no registered worktree, try to find a local branch.
@@ -697,6 +744,7 @@ func NewMergeCmd() *cobra.Command {
 	var strategy string
 	var noDelete bool
 	var dryRun bool
+	var agentSuffix string
 	c := &cobra.Command{
 		Use:   "merge [issue]",
 		Short: "Merge an approved PR and clean up the worktree",
@@ -711,12 +759,13 @@ from the current branch.`,
 			if err != nil {
 				return err
 			}
-			return runMerge(issue, strategy, noDelete, dryRun)
+			return runMerge(issue, strategy, agentSuffix, noDelete, dryRun)
 		},
 	}
 	c.Flags().StringVar(&strategy, "strategy", "", "Merge strategy: squash (default), merge, or rebase")
 	c.Flags().BoolVar(&noDelete, "no-delete", false, "Skip worktree deletion after merge")
 	c.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would happen without doing it")
+	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to target a specific worktree when multiple agents ran on the same issue")
 	return c
 }
 
@@ -741,7 +790,7 @@ func validateMergeStrategy(s string) error {
 	}
 }
 
-func runMerge(issue, strategy string, noDelete, dryRun bool) error {
+func runMerge(issue, strategy, agentSuffix string, noDelete, dryRun bool) error {
 	repoRoot, err := git.RepoRoot()
 	if err != nil {
 		return fmt.Errorf("cannot determine repo root: %w", err)
@@ -758,12 +807,9 @@ func runMerge(issue, strategy string, noDelete, dryRun bool) error {
 	}
 
 	// Locate the worktree and branch for the issue.
-	wt, found, err := git.FindWorktreeByIssue(repoRoot, issue)
-	if err != nil {
-		return err
-	}
 	var branch string
-	if found {
+	wt, resolveErr := resolveWorktree(repoRoot, issue, agentSuffix)
+	if resolveErr == nil {
 		if wt.Branch != "" && wt.Branch != "HEAD" {
 			branch = wt.Branch
 		} else {
@@ -772,6 +818,8 @@ func runMerge(issue, strategy string, noDelete, dryRun bool) error {
 				return fmt.Errorf("could not determine branch for %s", wt.Path)
 			}
 		}
+	} else if errors.Is(resolveErr, errAmbiguousWorktree) {
+		return resolveErr
 	} else {
 		branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
 		if branch == "" {
@@ -830,7 +878,7 @@ func runMerge(issue, strategy string, noDelete, dryRun bool) error {
 		return git.PullFFOnly(repoRoot)
 	}
 
-	return cleanupMerged(repoRoot, issue)
+	return cleanupMerged(repoRoot, issue, agentSuffix)
 }
 
 // ghPRMergeInfo calls `gh pr view <branch>` and returns the PR state,
@@ -888,6 +936,7 @@ func ghPRMerge(repoRoot, branch, strategy string) error {
 // With --all it sweeps all merged worktrees; otherwise it cleans up a single issue.
 func NewCleanupCmd() *cobra.Command {
 	var all bool
+	var agentSuffix string
 	c := &cobra.Command{
 		Use:   "cleanup [issue]",
 		Short: "Remove a merged worktree and its branches",
@@ -910,35 +959,37 @@ Use --all to sweep every linked worktree whose PR is MERGED in one pass.`,
 			if err != nil {
 				return err
 			}
-			return runCleanupMerged(issue)
+			return runCleanupMerged(issue, agentSuffix)
 		},
 	}
 	c.Flags().BoolVar(&all, "all", false, "Clean up all worktrees whose PR is MERGED")
+	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to target a specific worktree when multiple agents ran on the same issue")
 	return c
 }
 
-func runCleanupMerged(issue string) error {
+func runCleanupMerged(issue, agentSuffix string) error {
 	repoRoot, err := git.RepoRoot()
 	if err != nil {
 		return fmt.Errorf("cannot determine repo root: %w", err)
 	}
-	return cleanupMerged(repoRoot, issue)
+	return cleanupMerged(repoRoot, issue, agentSuffix)
 }
 
-func cleanupMerged(repoRoot, issue string) error {
-	wt, found, err := git.FindWorktreeByIssue(repoRoot, issue)
+func cleanupMerged(repoRoot, issue, agentSuffix string) error {
 	var wtPath, branch string
-	wtRegistered := found
+	var wtRegistered bool
 
-	if err != nil {
-		return err
-	}
-	if found {
+	wt, resolveErr := resolveWorktree(repoRoot, issue, agentSuffix)
+	if resolveErr == nil {
+		wtRegistered = true
 		wtPath = wt.Path
-		branch, err = git.CurrentBranch(wtPath)
-		if err != nil || branch == "" || branch == "HEAD" {
+		var branchErr error
+		branch, branchErr = git.CurrentBranch(wtPath)
+		if branchErr != nil || branch == "" || branch == "HEAD" {
 			return fmt.Errorf("could not determine branch for %s", wtPath)
 		}
+	} else if errors.Is(resolveErr, errAmbiguousWorktree) {
+		return resolveErr
 	} else {
 		// Recovery path: worktree is no longer registered.
 		branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
@@ -1109,8 +1160,16 @@ func runCleanupAllMerged() error {
 			skipped++
 			continue
 		}
+		// Derive agent suffix from path+.agent so multi-agent worktrees are
+		// cleaned up correctly without triggering the ambiguity error.
+		agentSuffix := ""
+		if af, afErr := state.Read(wt.Path); afErr == nil && af.Agent != "" {
+			if strings.HasSuffix(wt.Path, "-"+af.Agent) {
+				agentSuffix = af.Agent
+			}
+		}
 		fmt.Printf("--- Cleaning issue %s (%s) ---\n", issue, branch)
-		if err := cleanupMerged(repoRoot, issue); err != nil {
+		if err := cleanupMerged(repoRoot, issue, agentSuffix); err != nil {
 			fmt.Fprintf(os.Stderr, "FAILED to clean issue %s (%s): %v\n", issue, branch, err)
 			failed++
 		} else {
@@ -1306,8 +1365,9 @@ func runStatus(verbose bool) error {
 // NewLogsCmd creates the `logs` subcommand.
 func NewLogsCmd() *cobra.Command {
 	var (
-		lines    int
-		noFollow bool
+		lines      int
+		noFollow   bool
+		agentSuffix string
 	)
 	c := &cobra.Command{
 		Use:   "logs <issue>",
@@ -1318,20 +1378,21 @@ By default the last 50 lines are printed and new output is followed until
 Ctrl+C. Use --no-follow to print history and exit immediately.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLogs(args[0], lines, noFollow, os.Stdout)
+			return runLogs(args[0], lines, noFollow, agentSuffix, os.Stdout)
 		},
 	}
 	c.Flags().IntVar(&lines, "lines", 50, "Lines of history to show before following")
 	c.Flags().BoolVar(&noFollow, "no-follow", false, "Print history and exit without following")
+	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to disambiguate when multiple worktrees exist for the same issue")
 	return c
 }
 
 // runLogs resolves the worktree for issue and streams its agent.log.
-func runLogs(issue string, lines int, noFollow bool, w io.Writer) error {
+func runLogs(issue string, lines int, noFollow bool, agentSuffix string, w io.Writer) error {
 	if _, _, num, ok := parseIssueURL(issue); ok {
 		issue = num
 	}
-	wtPath, err := findWorktreePath(issue)
+	wtPath, err := findWorktreePath(issue, agentSuffix)
 	if err != nil {
 		return err
 	}
@@ -1441,6 +1502,7 @@ func NewDevCmd() *cobra.Command {
 // NewDevStartCmd creates the `dev start` subcommand.
 func NewDevStartCmd() *cobra.Command {
 	var quiet bool
+	var agentSuffix string
 	c := &cobra.Command{
 		Use:   "start [issue]",
 		Short: "Start the dev server in the current worktree",
@@ -1458,7 +1520,7 @@ real time. Use --quiet to suppress log streaming and only print the URL.`,
 			if err != nil {
 				return err
 			}
-			wtPath, err := findWorktreePath(issue)
+			wtPath, err := findWorktreePath(issue, agentSuffix)
 			if err != nil {
 				return err
 			}
@@ -1466,6 +1528,7 @@ real time. Use --quiet to suppress log streaming and only print the URL.`,
 		},
 	}
 	c.Flags().BoolVar(&quiet, "quiet", false, "Suppress log streaming; only print the ready URL")
+	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to disambiguate when multiple worktrees exist for the same issue")
 	return c
 }
 
@@ -1619,7 +1682,8 @@ func streamDevLog(wtPath, devPID string, w io.Writer) error {
 
 // NewAttachCmd creates the `attach` subcommand.
 func NewAttachCmd() *cobra.Command {
-	return &cobra.Command{
+	var agentSuffix string
+	c := &cobra.Command{
 		Use:   "attach <issue>",
 		Short: "Follow a running headless agent and exit when it finishes",
 		Long: `Attach to a running headless agent: stream agent.log to stdout and exit
@@ -1635,13 +1699,15 @@ Press Ctrl+C to detach without stopping the agent.`,
 			if _, _, num, ok := parseIssueURL(arg); ok {
 				arg = num
 			}
-			wtPath, err := findWorktreePath(arg)
+			wtPath, err := findWorktreePath(arg, agentSuffix)
 			if err != nil {
 				return err
 			}
 			return attachLog(wtPath, arg, os.Stdout, 10*time.Second)
 		},
 	}
+	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to disambiguate when multiple worktrees exist for the same issue")
+	return c
 }
 
 // attachLog is the inner implementation of the attach command.
@@ -1713,6 +1779,7 @@ func NewDiffCmd() *cobra.Command {
 	var stat bool
 	var base string
 	var noPager bool
+	var agentSuffix string
 	c := &cobra.Command{
 		Use:   "diff <issue>",
 		Short: "Show what the agent has changed in a worktree",
@@ -1725,20 +1792,21 @@ Use --base to compare against a branch, e.g. --base main shows everything the
 agent added since branching from main.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDiff(args[0], base, stat, noPager)
+			return runDiff(args[0], base, agentSuffix, stat, noPager)
 		},
 	}
 	c.Flags().BoolVar(&stat, "stat", false, "Show changed-file summary instead of full diff")
 	c.Flags().StringVar(&base, "base", "", "Diff base branch (default: show uncommitted changes)")
 	c.Flags().BoolVar(&noPager, "no-pager", false, "Print to stdout without paging")
+	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to disambiguate when multiple worktrees exist for the same issue")
 	return c
 }
 
-func runDiff(issue, base string, stat, noPager bool) error {
+func runDiff(issue, base, agentSuffix string, stat, noPager bool) error {
 	if _, _, num, ok := parseIssueURL(issue); ok {
 		issue = num
 	}
-	wtPath, err := findWorktreePath(issue)
+	wtPath, err := findWorktreePath(issue, agentSuffix)
 	if err != nil {
 		return err
 	}
@@ -2404,18 +2472,77 @@ func validateSDD(sddName, repoRoot string) error {
 	return nil
 }
 
-// findWorktreePath resolves the linked worktree path for the given issue number.
-func findWorktreePath(issue string) (string, error) {
+// errAmbiguousWorktree is returned by resolveWorktree when multiple worktrees
+// exist for an issue and no --agent flag was supplied to disambiguate.
+var errAmbiguousWorktree = errors.New("ambiguous worktree")
+
+// worktreeNames computes the branch name and filesystem path for a worktree.
+// When agentSuffix is non-empty (multi-agent mode) it is appended to both so
+// each agent gets an isolated workspace: <issue>-<slug>-<agent> / <repo>-<issue>-<slug>-<agent>.
+func worktreeNames(repoName, issueNum, slug, agentSuffix, parentDir string) (branch, wtPath string) {
+	branch = issueNum + "-" + slug
+	wtPath = filepath.Join(parentDir, repoName+"-"+issueNum+"-"+slug)
+	if agentSuffix != "" {
+		branch += "-" + agentSuffix
+		wtPath += "-" + agentSuffix
+	}
+	return
+}
+
+// resolveWorktree finds the linked worktree for an issue, handling the
+// single-agent (no suffix) and multi-agent (suffix) cases.
+//
+//   - agentSuffix non-empty: find the worktree whose path ends with "-<agentSuffix>".
+//   - agentSuffix empty, exactly one match: return it (unchanged single-agent behaviour).
+//   - agentSuffix empty, multiple matches: return errAmbiguousWorktree so the
+//     caller can ask the user to supply --agent.
+func resolveWorktree(repoRoot, issue, agentSuffix string) (git.Worktree, error) {
+	wts, err := git.FindWorktreesByIssue(repoRoot, issue)
+	if err != nil {
+		return git.Worktree{}, err
+	}
+
+	if agentSuffix != "" {
+		suffix := "-" + agentSuffix
+		for _, wt := range wts {
+			if strings.HasSuffix(wt.Path, suffix) {
+				return wt, nil
+			}
+		}
+		return git.Worktree{}, fmt.Errorf("no worktree found for issue %s (agent: %s) — has it been started?", issue, agentSuffix)
+	}
+
+	switch len(wts) {
+	case 0:
+		return git.Worktree{}, fmt.Errorf("no worktree found for issue %s — has it been started?", issue)
+	case 1:
+		return wts[0], nil
+	default:
+		var agents []string
+		for _, wt := range wts {
+			af, _ := state.Read(wt.Path)
+			if af.Agent != "" {
+				agents = append(agents, af.Agent)
+			} else {
+				agents = append(agents, filepath.Base(wt.Path))
+			}
+		}
+		return git.Worktree{}, fmt.Errorf("multiple worktrees found for issue %s; specify --agent (%s): %w",
+			issue, strings.Join(agents, ", "), errAmbiguousWorktree)
+	}
+}
+
+// findWorktreePath resolves the linked worktree path for the given issue.
+// agentSuffix disambiguates when multiple worktrees exist for the same issue
+// (created with --agent claude,codex). Pass "" for the original single-agent behaviour.
+func findWorktreePath(issue, agentSuffix string) (string, error) {
 	repoRoot, err := git.RepoRoot()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine repo root: %w", err)
 	}
-	wt, found, err := git.FindWorktreeByIssue(repoRoot, issue)
+	wt, err := resolveWorktree(repoRoot, issue, agentSuffix)
 	if err != nil {
 		return "", err
-	}
-	if !found {
-		return "", fmt.Errorf("no worktree found for issue %s — has it been started?", issue)
 	}
 	return wt.Path, nil
 }

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -104,7 +104,28 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 			for i, ag := range agents {
 				agents[i] = strings.TrimSpace(ag)
 			}
+			// Drop empty entries (e.g. from trailing commas like "claude,").
+			{
+				filtered := agents[:0]
+				for _, ag := range agents {
+					if ag != "" {
+						filtered = append(filtered, ag)
+					}
+				}
+				agents = filtered
+			}
+			if len(agents) == 0 {
+				return fmt.Errorf("--agent flag requires at least one agent name")
+			}
 			if len(agents) > 1 {
+				// Reject duplicate agent names to avoid racing to create the same worktree.
+				seen := make(map[string]struct{}, len(agents))
+				for _, ag := range agents {
+					if _, dup := seen[ag]; dup {
+						return fmt.Errorf("duplicate agent %q in --agent flag", ag)
+					}
+					seen[ag] = struct{}{}
+				}
 				if len(issues) > 1 {
 					return fmt.Errorf("cannot combine multiple issues with multiple agents; specify a single issue")
 				}
@@ -220,6 +241,11 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 			return err
 		}
 		fmt.Fprintf(out, "Derived slug from issue title: %s\n", slug)
+	}
+
+	// Validate agentSuffix before using it in branch/path construction.
+	if err := validateAgentSuffix(agentSuffix); err != nil {
+		return err
 	}
 
 	branch, wtPath := worktreeNames(repoName, issueNum, slug, agentSuffix, parentDir)
@@ -439,6 +465,24 @@ func runBatch(issues []string, agentName, sddName string, quiet, sendNotify bool
 // its own worktree with an agent-name suffix (e.g. repo-42-slug-claude).
 // All agents always run in headless mode; foreground is not supported here.
 func runMultiAgent(issue string, agents []string, sddName string, quiet, sendNotify bool, out, errOut io.Writer) error {
+	// Validate all adapters and resolve (possibly clone) the repo once before
+	// spawning goroutines. This prevents concurrent `gh repo clone` races when
+	// issue is a GitHub URL, and surfaces adapter/token errors early.
+	if err := ensureGHToken(); err != nil {
+		return err
+	}
+	for _, ag := range agents {
+		if err := validateAdapter(ag); err != nil {
+			return err
+		}
+		if err := validateAgentSuffix(ag); err != nil {
+			return err
+		}
+	}
+	if _, _, _, err := repoRootForIssue(issue, out); err != nil {
+		return err
+	}
+
 	type agentResult struct {
 		agent  string
 		output string
@@ -806,6 +850,9 @@ func runRemoveWorktree(issue, agentSuffix string) error {
 		branch = wt.Branch
 	} else if errors.Is(resolveErr, errAmbiguousWorktree) {
 		return resolveErr
+	} else if !errors.Is(resolveErr, errWorktreeNotFound) {
+		// Real error (e.g. git worktree list failure) — don't silently fall through.
+		return resolveErr
 	}
 
 	// If no registered worktree, try to find a local branch.
@@ -952,6 +999,8 @@ func runMerge(issue, strategy, agentSuffix string, noDelete, dryRun bool) error 
 			}
 		}
 	} else if errors.Is(resolveErr, errAmbiguousWorktree) {
+		return resolveErr
+	} else if !errors.Is(resolveErr, errWorktreeNotFound) {
 		return resolveErr
 	} else {
 		branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
@@ -1123,8 +1172,11 @@ func cleanupMerged(repoRoot, issue, agentSuffix string) error {
 		}
 	} else if errors.Is(resolveErr, errAmbiguousWorktree) {
 		return resolveErr
+	} else if !errors.Is(resolveErr, errWorktreeNotFound) {
+		// Real error (e.g. git worktree list failure) — don't silently fall through.
+		return resolveErr
 	} else {
-		// Recovery path: worktree is no longer registered.
+		// Recovery path: worktree is no longer registered but branches may exist.
 		if isNumericIssue(issue) {
 			branch, _ = git.FindBranchByIssuePrefix(repoRoot, issue)
 		}
@@ -2758,6 +2810,28 @@ func validateSDD(sddName, repoRoot string) error {
 // exist for an issue and no --agent flag was supplied to disambiguate.
 var errAmbiguousWorktree = errors.New("ambiguous worktree")
 
+// errWorktreeNotFound is returned by resolveWorktree when no worktree matches
+// the given issue (and optional agent suffix), as distinct from a real git error.
+var errWorktreeNotFound = errors.New("worktree not found")
+
+// agentSuffixRe restricts agent names used as worktree/branch suffixes to safe
+// characters. Slashes, spaces, and other special chars would create nested
+// directories or invalid git branch names.
+var agentSuffixRe = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+// validateAgentSuffix returns an error when suffix contains characters that
+// would create an invalid git branch name or unexpected filesystem path.
+// An empty suffix is always valid (single-agent mode).
+func validateAgentSuffix(suffix string) error {
+	if suffix == "" {
+		return nil
+	}
+	if !agentSuffixRe.MatchString(suffix) {
+		return fmt.Errorf("invalid agent name %q: must match [a-z0-9_-]+", suffix)
+	}
+	return nil
+}
+
 // worktreeNames computes the branch name and filesystem path for a worktree.
 // When agentSuffix is non-empty (multi-agent mode) it is appended to both so
 // each agent gets an isolated workspace: <issue>-<slug>-<agent> / <repo>-<issue>-<slug>-<agent>.
@@ -2781,6 +2855,8 @@ func worktreeNames(repoName, issueNum, slug, agentSuffix, parentDir string) (bra
 //
 // For non-numeric refs (e.g. task-mode branch names like "task/refactor-auth"),
 // falls back to an exact branch lookup via FindWorktreeByBranch.
+//
+// Returns errWorktreeNotFound (wrapped) when no matching worktree exists.
 func resolveWorktree(repoRoot, issue, agentSuffix string) (git.Worktree, error) {
 	wts, err := git.FindWorktreesByIssue(repoRoot, issue)
 	if err != nil {
@@ -2797,7 +2873,7 @@ func resolveWorktree(repoRoot, issue, agentSuffix string) (git.Worktree, error) 
 		if found {
 			return wt, nil
 		}
-		return git.Worktree{}, fmt.Errorf("no worktree found for issue %s — has it been started?", issue)
+		return git.Worktree{}, fmt.Errorf("no worktree found for issue %s — has it been started?: %w", issue, errWorktreeNotFound)
 	}
 
 	if agentSuffix != "" {
@@ -2807,12 +2883,12 @@ func resolveWorktree(repoRoot, issue, agentSuffix string) (git.Worktree, error) 
 				return wt, nil
 			}
 		}
-		return git.Worktree{}, fmt.Errorf("no worktree found for issue %s (agent: %s) — has it been started?", issue, agentSuffix)
+		return git.Worktree{}, fmt.Errorf("no worktree found for issue %s (agent: %s) — has it been started?: %w", issue, agentSuffix, errWorktreeNotFound)
 	}
 
 	switch len(wts) {
 	case 0:
-		return git.Worktree{}, fmt.Errorf("no worktree found for issue %s — has it been started?", issue)
+		return git.Worktree{}, fmt.Errorf("no worktree found for issue %s — has it been started?: %w", issue, errWorktreeNotFound)
 	case 1:
 		return wts[0], nil
 	default:

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5594,14 +5594,19 @@ func TestCleanupCmd_agentFlagExists(t *testing.T) {
 
 func TestStartCmd_multiAgent_rejectsSlug(t *testing.T) {
 	c := NewStartCmd()
+	if err := c.Flags().Set("agent", "claude,codex"); err != nil {
+		t.Fatalf("set --agent: %v", err)
+	}
 	c.SilenceUsage = true
 	c.SilenceErrors = true
-	// Multi-agent + slug should error.
+	// Multi-agent + slug should be rejected before any network calls.
 	err := c.RunE(c, []string{"42", "my-slug"})
-	// Note: with "--agent claude,codex", slug is rejected. But here agentName
-	// defaults to "claude" (single agent), so no error expected for slug alone.
-	// We test the multi-agent + slug rejection by checking the logic directly.
-	_ = err // just verifying no panic
+	if err == nil {
+		t.Error("expected error when slug is given with multiple agents")
+	}
+	if !strings.Contains(err.Error(), "slug") {
+		t.Errorf("unexpected error: %v", err)
+	}
 }
 
 func TestStartCmd_multiAgent_rejectsMultipleIssues(t *testing.T) {
@@ -5622,4 +5627,58 @@ func TestStartCmd_multiAgent_rejectsMultipleIssues(t *testing.T) {
 	if !strings.Contains(err.Error(), "multiple issues") && !strings.Contains(err.Error(), "single issue") {
 		t.Errorf("unexpected error: %v", err)
 	}
+}
+
+func TestValidateAgentSuffix(t *testing.T) {
+	valid := []string{"", "claude", "codex", "gpt-4", "my_agent", "agent-1"}
+	for _, s := range valid {
+		t.Run("valid/"+s, func(t *testing.T) {
+			if err := validateAgentSuffix(s); err != nil {
+				t.Errorf("validateAgentSuffix(%q) unexpected error: %v", s, err)
+			}
+		})
+	}
+
+	invalid := []string{"Claude", "CLAUDE", "gpt/4", "my agent", "bad@name", "../evil"}
+	for _, s := range invalid {
+		t.Run("invalid/"+s, func(t *testing.T) {
+			if err := validateAgentSuffix(s); err == nil {
+				t.Errorf("validateAgentSuffix(%q) expected error, got nil", s)
+			}
+		})
+	}
+}
+
+func TestStartCmd_agentFlag_filtersEmptyAndRejectsDuplicates(t *testing.T) {
+	t.Run("trailing comma does not trigger duplicate error", func(t *testing.T) {
+		c := NewStartCmd()
+		c.SilenceUsage = true
+		c.SilenceErrors = true
+		if err := c.Flags().Set("agent", "claude,"); err != nil {
+			t.Fatalf("set --agent: %v", err)
+		}
+		// After filtering the empty token we have only "claude" — single-agent path,
+		// which will fail on ensureGHToken (expected in unit test, not a panic).
+		// Verify no "duplicate" error for this case.
+		err := c.RunE(c, []string{"42"})
+		if err != nil && strings.Contains(err.Error(), "duplicate") {
+			t.Errorf("trailing comma should not trigger duplicate error: %v", err)
+		}
+	})
+
+	t.Run("duplicate agent rejected", func(t *testing.T) {
+		c := NewStartCmd()
+		c.SilenceUsage = true
+		c.SilenceErrors = true
+		if err := c.Flags().Set("agent", "claude,claude"); err != nil {
+			t.Fatalf("set --agent: %v", err)
+		}
+		err := c.RunE(c, []string{"42"})
+		if err == nil {
+			t.Error("expected error for duplicate agents")
+		}
+		if err != nil && !strings.Contains(err.Error(), "duplicate") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
 }

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5321,6 +5321,7 @@ func TestRunDiff_noPager_noBase(t *testing.T) {
 	// and produce output on stdout (we only check for no error here).
 	issue, _ := initDiffTestRepo(t)
 	if err := runDiff(issue, "", "", false, true); err != nil {
+		t.Fatalf("runDiff noPager: %v", err)
 	}
 }
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1720,7 +1720,7 @@ func TestRunReleasePausedSession_nonSDD_noSpec(t *testing.T) {
 	})
 	chdirTemp(t, repo)
 
-	err := runReleasePausedSession("42", "", false, false, false)
+	err := runReleasePausedSession("42", "", "", false, false, false)
 
 	// Must NOT block with "spec not yet generated" — the spec gate does not
 	// apply to non-SDD worktrees.
@@ -1739,7 +1739,7 @@ func TestRunReleasePausedSession_SDD_noSpec(t *testing.T) {
 	})
 	chdirTemp(t, repo)
 
-	err := runReleasePausedSession("43", "", false, false, false)
+	err := runReleasePausedSession("43", "", "", false, false, false)
 
 	if err == nil {
 		t.Fatal("expected 'spec not yet generated' error for SDD run without spec, got nil")
@@ -1767,7 +1767,7 @@ func TestRunReleasePausedSession_SDD_withSpec(t *testing.T) {
 	}
 	chdirTemp(t, repo)
 
-	err := runReleasePausedSession("44", "", false, false, false)
+	err := runReleasePausedSession("44", "", "", false, false, false)
 
 	// Must NOT block with "spec not yet generated" once spec exists.
 	if err != nil && strings.Contains(err.Error(), "spec not yet generated") {
@@ -1884,7 +1884,7 @@ func TestStartOne_headlessImmediateExitCleansUpWorktree(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "test-token")
 
 	var out bytes.Buffer
-	err := startOne("42", "plain-fails", "falseagent", "", true, false, false, &out)
+	err := startOne("42", "plain-fails", "falseagent", "", "", true, false, false, &out)
 	if err == nil {
 		t.Fatal("expected startOne to fail when headless agent exits immediately")
 	}
@@ -2904,7 +2904,7 @@ func TestStreamLog_followExitsWhenPIDAppearsLate(t *testing.T) {
 
 func TestRunLogs_unknownIssue(t *testing.T) {
 	var buf bytes.Buffer
-	err := runLogs("99999", 50, true, &buf)
+	err := runLogs("99999", 50, true, "", &buf)
 	if err == nil {
 		t.Fatal("expected error for unknown issue")
 	}
@@ -4628,7 +4628,7 @@ func TestRunBatch_allSucceed(t *testing.T) {
 	var mu sync.Mutex
 	called := map[string]bool{}
 
-	mockFn := func(issue, slug, agentName, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+	mockFn := func(issue, slug, agentName, sddName, agentSuffix string, headless, quiet, sendNotify bool, out io.Writer) error {
 		mu.Lock()
 		called[issue] = true
 		mu.Unlock()
@@ -4661,7 +4661,7 @@ func TestRunBatch_oneFailureContinuesOthers(t *testing.T) {
 	var mu sync.Mutex
 	called := map[string]bool{}
 
-	mockFn := func(issue, slug, agentName, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+	mockFn := func(issue, slug, agentName, sddName, agentSuffix string, headless, quiet, sendNotify bool, out io.Writer) error {
 		mu.Lock()
 		called[issue] = true
 		mu.Unlock()
@@ -4709,7 +4709,7 @@ func TestRunBatch_oneFailureContinuesOthers(t *testing.T) {
 // TestRunBatch_resultsInOrder verifies that output is printed in the original
 // issue order even when goroutines finish out of order.
 func TestRunBatch_resultsInOrder(t *testing.T) {
-	mockFn := func(issue, slug, agentName, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+	mockFn := func(issue, slug, agentName, sddName, agentSuffix string, headless, quiet, sendNotify bool, out io.Writer) error {
 		if issue == "42" {
 			time.Sleep(50 * time.Millisecond) // finish last
 		}
@@ -4920,7 +4920,7 @@ func TestGhPRInfoWithURL_noPR(t *testing.T) {
 // ─── runDiff ──────────────────────────────────────────────────────────────────
 
 func TestRunDiff_unknownIssue(t *testing.T) {
-	err := runDiff("99999", "", false, true)
+	err := runDiff("99999", "", "", false, true)
 	if err == nil {
 		t.Fatal("expected error for unknown issue")
 	}
@@ -4932,7 +4932,7 @@ func TestRunDiff_unknownIssue(t *testing.T) {
 func TestRunDiff_issueURL(t *testing.T) {
 	// A full GitHub URL should be resolved to a bare issue number and then
 	// fail with the same "no worktree found" error (not a URL-parsing error).
-	err := runDiff("https://github.com/owner/repo/issues/99999", "", false, true)
+	err := runDiff("https://github.com/owner/repo/issues/99999", "", "", false, true)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -4943,7 +4943,7 @@ func TestRunDiff_issueURL(t *testing.T) {
 
 func TestRunDiff_statFlag_unknownIssue(t *testing.T) {
 	// --stat with unknown issue should fail at worktree lookup, not panic.
-	err := runDiff("99999", "", true, true)
+	err := runDiff("99999", "", "", true, true)
 	if err == nil {
 		t.Fatal("expected error for unknown issue")
 	}
@@ -4954,7 +4954,7 @@ func TestRunDiff_statFlag_unknownIssue(t *testing.T) {
 
 func TestRunDiff_withBase_unknownIssue(t *testing.T) {
 	// --base with unknown issue should fail at worktree lookup.
-	err := runDiff("99999", "main", false, true)
+	err := runDiff("99999", "main", "", false, true)
 	if err == nil {
 		t.Fatal("expected error for unknown issue")
 	}
@@ -4971,5 +4971,209 @@ func TestIsTerminal_pipe(t *testing.T) {
 	}
 	if isTerminal(os.Stdin) {
 		t.Error("expected isTerminal(os.Stdin) == false in test environment")
+	}
+}
+
+// ─── worktreeNames ────────────────────────────────────────────────────────────
+
+func TestWorktreeNames_noSuffix(t *testing.T) {
+	branch, path := worktreeNames("myrepo", "42", "auth-fix", "", "/home/user")
+	if branch != "42-auth-fix" {
+		t.Errorf("branch = %q, want %q", branch, "42-auth-fix")
+	}
+	want := filepath.Join("/home/user", "myrepo-42-auth-fix")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+}
+
+func TestWorktreeNames_withSuffix(t *testing.T) {
+	branch, path := worktreeNames("myrepo", "42", "auth-fix", "claude", "/home/user")
+	if branch != "42-auth-fix-claude" {
+		t.Errorf("branch = %q, want %q", branch, "42-auth-fix-claude")
+	}
+	want := filepath.Join("/home/user", "myrepo-42-auth-fix-claude")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+}
+
+// ─── resolveWorktree ──────────────────────────────────────────────────────────
+
+func TestResolveWorktree_singleWorktree(t *testing.T) {
+	repo := initGitRepoWithBareOrigin(t)
+	createCommittedFile(t, repo, "file.txt", "content\n")
+	gitRun(t, repo, "checkout", "-b", "main")
+	gitRun(t, repo, "add", ".")
+	gitRun(t, repo, "commit", "-m", "initial")
+
+	parent := filepath.Dir(repo)
+	wt1 := filepath.Join(parent, filepath.Base(repo)+"-42-auth-fix")
+	gitRun(t, repo, "worktree", "add", "-b", "42-auth-fix", wt1)
+	t.Cleanup(func() { _ = os.RemoveAll(wt1) })
+	chdirTemp(t, repo)
+
+	wt, err := resolveWorktree(repo, "42", "")
+	if err != nil {
+		t.Fatalf("resolveWorktree: %v", err)
+	}
+	gotResolved, _ := filepath.EvalSymlinks(wt.Path)
+	wantResolved, _ := filepath.EvalSymlinks(wt1)
+	if gotResolved != wantResolved {
+		t.Errorf("path = %q, want %q", wt.Path, wt1)
+	}
+}
+
+func TestResolveWorktree_multiWorktree_noAgent_errors(t *testing.T) {
+	repo := initGitRepoWithBareOrigin(t)
+	createCommittedFile(t, repo, "file.txt", "content\n")
+	gitRun(t, repo, "checkout", "-b", "main")
+	gitRun(t, repo, "add", ".")
+	gitRun(t, repo, "commit", "-m", "initial")
+
+	parent := filepath.Dir(repo)
+	repoName := filepath.Base(repo)
+	wt1 := filepath.Join(parent, repoName+"-42-auth-fix-claude")
+	wt2 := filepath.Join(parent, repoName+"-42-auth-fix-codex")
+	gitRun(t, repo, "worktree", "add", "-b", "42-auth-fix-claude", wt1)
+	gitRun(t, repo, "worktree", "add", "-b", "42-auth-fix-codex", wt2)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(wt1)
+		_ = os.RemoveAll(wt2)
+	})
+
+	if err := state.Write(wt1, state.AgentFile{Agent: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(wt2, state.AgentFile{Agent: "codex"}); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, repo)
+
+	_, err := resolveWorktree(repo, "42", "")
+	if err == nil {
+		t.Fatal("expected ambiguity error, got nil")
+	}
+	if !strings.Contains(err.Error(), "multiple worktrees") {
+		t.Errorf("error should mention 'multiple worktrees', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error should mention agent 'claude', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "codex") {
+		t.Errorf("error should mention agent 'codex', got: %v", err)
+	}
+}
+
+func TestResolveWorktree_multiWorktree_withAgent(t *testing.T) {
+	repo := initGitRepoWithBareOrigin(t)
+	createCommittedFile(t, repo, "file.txt", "content\n")
+	gitRun(t, repo, "checkout", "-b", "main")
+	gitRun(t, repo, "add", ".")
+	gitRun(t, repo, "commit", "-m", "initial")
+
+	parent := filepath.Dir(repo)
+	repoName := filepath.Base(repo)
+	wt1 := filepath.Join(parent, repoName+"-42-auth-fix-claude")
+	wt2 := filepath.Join(parent, repoName+"-42-auth-fix-codex")
+	gitRun(t, repo, "worktree", "add", "-b", "42-auth-fix-claude", wt1)
+	gitRun(t, repo, "worktree", "add", "-b", "42-auth-fix-codex", wt2)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(wt1)
+		_ = os.RemoveAll(wt2)
+	})
+	chdirTemp(t, repo)
+
+	wt, err := resolveWorktree(repo, "42", "claude")
+	if err != nil {
+		t.Fatalf("resolveWorktree with agent=claude: %v", err)
+	}
+	gotResolved, _ := filepath.EvalSymlinks(wt.Path)
+	wantResolved, _ := filepath.EvalSymlinks(wt1)
+	if gotResolved != wantResolved {
+		t.Errorf("path = %q, want %q", wt.Path, wt1)
+	}
+}
+
+// ─── --agent flag presence ────────────────────────────────────────────────────
+
+func TestLogsCmd_agentFlagExists(t *testing.T) {
+	c := NewLogsCmd()
+	if f := c.Flags().Lookup("agent"); f == nil {
+		t.Error("--agent flag must be registered on logs command")
+	}
+}
+
+func TestAttachCmd_agentFlagExists(t *testing.T) {
+	c := NewAttachCmd()
+	if f := c.Flags().Lookup("agent"); f == nil {
+		t.Error("--agent flag must be registered on attach command")
+	}
+}
+
+func TestDiffCmd_agentFlagExists(t *testing.T) {
+	c := NewDiffCmd()
+	if f := c.Flags().Lookup("agent"); f == nil {
+		t.Error("--agent flag must be registered on diff command")
+	}
+}
+
+func TestDiscardCmd_agentFlagExists(t *testing.T) {
+	c := NewDiscardCmd()
+	if f := c.Flags().Lookup("agent"); f == nil {
+		t.Error("--agent flag must be registered on discard command")
+	}
+}
+
+func TestMergeCmd_agentFlagExists(t *testing.T) {
+	c := NewMergeCmd()
+	if f := c.Flags().Lookup("agent"); f == nil {
+		t.Error("--agent flag must be registered on merge command")
+	}
+}
+
+func TestResumeCmd_agentFlagExists(t *testing.T) {
+	c := NewResumeCmd()
+	if f := c.Flags().Lookup("agent"); f == nil {
+		t.Error("--agent flag must be registered on resume command")
+	}
+}
+
+func TestCleanupCmd_agentFlagExists(t *testing.T) {
+	c := NewCleanupCmd()
+	if f := c.Flags().Lookup("agent"); f == nil {
+		t.Error("--agent flag must be registered on cleanup command")
+	}
+}
+
+func TestStartCmd_multiAgent_rejectsSlug(t *testing.T) {
+	c := NewStartCmd()
+	c.SilenceUsage = true
+	c.SilenceErrors = true
+	// Multi-agent + slug should error.
+	err := c.RunE(c, []string{"42", "my-slug"})
+	// Note: with "--agent claude,codex", slug is rejected. But here agentName
+	// defaults to "claude" (single agent), so no error expected for slug alone.
+	// We test the multi-agent + slug rejection by checking the logic directly.
+	_ = err // just verifying no panic
+}
+
+func TestStartCmd_multiAgent_rejectsMultipleIssues(t *testing.T) {
+	// When multiple agents are requested, only a single issue is allowed.
+	// This is enforced in RunE before any network calls, so we can test it
+	// by checking that the multi-agent path correctly requires a single issue.
+	// (Full integration would need a GitHub stub; this verifies flag wiring.)
+	c := NewStartCmd()
+	if err := c.Flags().Set("agent", "claude,codex"); err != nil {
+		t.Fatalf("set --agent: %v", err)
+	}
+	c.SilenceUsage = true
+	c.SilenceErrors = true
+	err := c.RunE(c, []string{"42,43"})
+	if err == nil {
+		t.Error("expected error when multiple issues given with multiple agents")
+	}
+	if !strings.Contains(err.Error(), "multiple issues") && !strings.Contains(err.Error(), "single issue") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -114,8 +114,11 @@ func LinkedWorktrees(repoRoot string) ([]Worktree, error) {
 	return result, nil
 }
 
-// FindWorktreeByIssue returns the first linked worktree whose path contains
-// "-<issue>-" (matching the naming convention "<repo>-<issue>-<slug>").
+// FindWorktreeByIssue returns the first linked worktree for the given issue.
+// It prefers an exact match on the parsed Issue field (e.g. wt.Issue == "42"),
+// falling back to a path substring match ("-<issue>-") only for worktrees
+// where the Issue field is empty (detached HEAD). This prevents issue "42"
+// from incorrectly matching paths that contain "-142-".
 func FindWorktreeByIssue(repoRoot, issue string) (Worktree, bool, error) {
 	wts, err := LinkedWorktrees(repoRoot)
 	if err != nil {
@@ -123,15 +126,22 @@ func FindWorktreeByIssue(repoRoot, issue string) (Worktree, bool, error) {
 	}
 	needle := "-" + issue + "-"
 	for _, wt := range wts {
-		if strings.Contains(wt.Path, needle) {
+		if wt.Issue != "" {
+			if wt.Issue == issue {
+				return wt, true, nil
+			}
+		} else if strings.Contains(wt.Path, needle) {
 			return wt, true, nil
 		}
 	}
 	return Worktree{}, false, nil
 }
 
-// FindWorktreesByIssue returns all linked worktrees whose path contains
-// "-<issue>-" (matching the naming convention "<repo>-<issue>-<slug>[-agent]").
+// FindWorktreesByIssue returns all linked worktrees for the given issue.
+// It prefers an exact match on the parsed Issue field (e.g. wt.Issue == "42"),
+// falling back to a path substring match ("-<issue>-") only for worktrees
+// where the Issue field is empty (detached HEAD). This prevents issue "42"
+// from incorrectly matching paths that contain "-142-".
 // Unlike FindWorktreeByIssue, this returns all matches, enabling callers to
 // detect multi-agent worktrees created with --agent claude,codex.
 func FindWorktreesByIssue(repoRoot, issue string) ([]Worktree, error) {
@@ -142,7 +152,11 @@ func FindWorktreesByIssue(repoRoot, issue string) ([]Worktree, error) {
 	needle := "-" + issue + "-"
 	var result []Worktree
 	for _, wt := range wts {
-		if strings.Contains(wt.Path, needle) {
+		if wt.Issue != "" {
+			if wt.Issue == issue {
+				result = append(result, wt)
+			}
+		} else if strings.Contains(wt.Path, needle) {
 			result = append(result, wt)
 		}
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -130,6 +130,25 @@ func FindWorktreeByIssue(repoRoot, issue string) (Worktree, bool, error) {
 	return Worktree{}, false, nil
 }
 
+// FindWorktreesByIssue returns all linked worktrees whose path contains
+// "-<issue>-" (matching the naming convention "<repo>-<issue>-<slug>[-agent]").
+// Unlike FindWorktreeByIssue, this returns all matches, enabling callers to
+// detect multi-agent worktrees created with --agent claude,codex.
+func FindWorktreesByIssue(repoRoot, issue string) ([]Worktree, error) {
+	wts, err := LinkedWorktrees(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	needle := "-" + issue + "-"
+	var result []Worktree
+	for _, wt := range wts {
+		if strings.Contains(wt.Path, needle) {
+			result = append(result, wt)
+		}
+	}
+	return result, nil
+}
+
 // CurrentBranch returns the abbreviated branch name for the given directory.
 func CurrentBranch(dir string) (string, error) {
 	return run(dir, "rev-parse", "--abbrev-ref", "HEAD")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -324,3 +324,40 @@ func TestLinkedWorktreesParserSmoke(t *testing.T) {
 		}
 	}
 }
+
+// TestFindWorktreeByIssue_noFalsePositive verifies that issue "42" does not
+// match a worktree for issue "142" (which would contain "-142-" in its path).
+func TestFindWorktreeByIssue_noFalsePositive(t *testing.T) {
+repo := initRepo(t)
+wt142Path := filepath.Join(t.TempDir(), "repo-142-some-feature")
+if err := AddWorktree(repo, wt142Path, "142-some-feature"); err != nil {
+t.Fatalf("AddWorktree: %v", err)
+}
+
+// issue "42" must NOT match the "-142-" worktree.
+_, found, err := FindWorktreeByIssue(repo, "42")
+if err != nil {
+t.Fatalf("FindWorktreeByIssue: %v", err)
+}
+if found {
+t.Error("issue 42 should not match a worktree for issue 142")
+}
+}
+
+// TestFindWorktreesByIssue_noFalsePositive verifies the same guard for the
+// multi-result variant.
+func TestFindWorktreesByIssue_noFalsePositive(t *testing.T) {
+repo := initRepo(t)
+wt142Path := filepath.Join(t.TempDir(), "repo-142-some-feature")
+if err := AddWorktree(repo, wt142Path, "142-some-feature"); err != nil {
+t.Fatalf("AddWorktree: %v", err)
+}
+
+wts, err := FindWorktreesByIssue(repo, "42")
+if err != nil {
+t.Fatalf("FindWorktreesByIssue: %v", err)
+}
+if len(wts) != 0 {
+t.Errorf("issue 42 should not match worktrees for issue 142, got %v", wts)
+}
+}


### PR DESCRIPTION
## Summary

- Add `agentctl start <issue> --agent claude,codex` to create two isolated worktrees (one per agent) and run them concurrently in headless mode
- Add `--agent` disambiguation flag to `discard`, `merge`, `logs`, `attach`, `diff`, `resume`, `cleanup`, and `dev start` so users can target specific agent worktrees when multiple exist for the same issue
- Add `resolveWorktree` helper with `errAmbiguousWorktree` sentinel: when one worktree exists it succeeds; when multiple exist it requires `--agent`; when zero exist it gives a clear error

## Key changes

- `internal/git/git.go`: add `FindWorktreesByIssue` (returns all matching worktrees vs. `FindWorktreeByIssue` which returns first only)
- `internal/cmd/commands.go`:
  - `worktreeNames(repoName, issueNum, slug, agentSuffix, parentDir)` — pure naming helper; appends `-<agent>` suffix to branch and path when provided
  - `resolveWorktree(repoRoot, issue, agentSuffix)` — central lookup; propagates `errAmbiguousWorktree` for callers to detect
  - `runMultiAgent` — spawns one goroutine per agent via `sync.WaitGroup`, collects ordered results
  - All per-issue command handlers updated to accept and pass `agentSuffix`
  - `cleanup --all` sweep derives `agentSuffix` from `.agent` file so it can target each worktree individually

## Test plan

- [ ] `go test ./...` — all packages pass
- [ ] `go vet ./...` — no issues
- [ ] `TestWorktreeNames_noSuffix` — branch/path unchanged when no suffix
- [ ] `TestWorktreeNames_withSuffix` — `-<agent>` appended correctly
- [ ] `TestResolveWorktree_singleWorktree` — single worktree resolves without `--agent`
- [ ] `TestResolveWorktree_multiWorktree_noAgent_errors` — two worktrees → ambiguity error listing both agent names
- [ ] `TestResolveWorktree_multiWorktree_withAgent` — two worktrees + `--agent claude` → resolves claude worktree
- [ ] Flag existence tests for `--agent` on all affected commands
- [ ] `TestStartCmd_multiAgent_rejectsMultipleIssues` — multi-agent + multi-issue combination is rejected

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)