### PR TITLE
feat: abstract VCS layer so agentctl lifecycle works with GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agentctl
 
-**agentctl** is a **Go** CLI that combines [git worktrees](https://git-scm.com/docs/git-worktree), coding agents, and optional spec-driven development (SDD) methodologies to tackle GitHub issues in isolated workspaces, with pluggability across both agents and SDD workflows.
+**agentctl** is a **Go** CLI that combines [git worktrees](https://git-scm.com/docs/git-worktree), coding agents, and optional spec-driven development (SDD) methodologies to tackle GitHub and GitLab issues in isolated workspaces, with pluggability across both agents and SDD workflows.
 
 | Coding agents | SDD methodologies |
 |---|---|
@@ -41,8 +41,9 @@ brew update && brew upgrade agentctl
 cd /path/to/your/app-repo
 agentctl start 42
 
-# Or from anywhere, using a full GitHub issue URL
+# Or from anywhere, using a full issue URL (GitHub or GitLab)
 agentctl start https://github.com/owner/repo/issues/42
+agentctl start https://gitlab.com/owner/repo/-/issues/42
 
 # Or from your repo, using a free-form task
 agentctl start --task "Refactor the auth middleware to use JWT"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ flowchart TD
     C --> D{Review PR}
     D -- changes needed --> E[agentctl resume 42 feedback]
     E --> B
-    D -- approved --> F[Merge PR on GitHub]
+    D -- approved --> F[Merge PR/MR on GitHub/GitLab]
     F --> G[agentctl cleanup 42]
 ```
 
@@ -52,8 +52,9 @@ flowchart TD
 # Start — agent streams output to your terminal
 agentctl start 42
 
-# Or using a full GitHub issue URL (works from any directory)
+# Or using a full issue URL (works from any directory — GitHub or GitLab)
 agentctl start https://github.com/owner/repo/issues/42
+agentctl start https://gitlab.com/owner/repo/-/issues/42
 
 # Suppress log output but still wait for the agent to finish
 agentctl start --quiet 42
@@ -81,7 +82,7 @@ flowchart TD
     E --> F{Review PR}
     F -- changes needed --> G[agentctl resume --headless 42 feedback]
     G --> B
-    F -- approved --> H[Merge PR on GitHub]
+    F -- approved --> H[Merge PR/MR on GitHub/GitLab]
     H --> I[agentctl cleanup 42]
 ```
 
@@ -117,7 +118,7 @@ flowchart TD
     B2 --> C2[PR 211 opened]
     B3 --> C3[PR 212 opened]
     C1 & C2 & C3 --> D[agentctl status]
-    D --> E[Review and merge PRs on GitHub]
+    D --> E[Review and merge PRs/MRs on GitHub/GitLab]
     E --> F[agentctl cleanup --all]
 ```
 
@@ -156,7 +157,7 @@ flowchart TD
     G --> H{Review PR}
     H -- changes needed --> I[agentctl resume 42 feedback]
     I --> G
-    H -- approved --> J[Merge PR on GitHub]
+    H -- approved --> J[Merge PR/MR on GitHub/GitLab]
     J --> K[agentctl cleanup 42]
 ```
 
@@ -208,17 +209,17 @@ agentctl start [--agent <name>] [--headless] [--notify] [--quiet] <issue-number-
 agentctl start [--agent <name>] [--headless] [--notify] [--quiet] [--sdd=<name>] --task "<description>" [--branch <branch-name>]
 ```
 
-Creates a linked worktree for a GitHub issue or a free-form task and launches the selected coding agent inside it.
+Creates a linked worktree for a GitHub or GitLab issue (or a free-form task) and launches the selected coding agent inside it.
 
 - `--agent <name>`: adapter name; default is `claude`. See [adapters.md](adapters.md) for available adapters.
 - `--headless`: run the agent in the background and write agent output to `agent.log`.
 - `--notify`: send a native desktop notification when the headless agent finishes. No-op when `--headless` is not set. See [Desktop notifications](#desktop-notifications).
 - `--quiet`: suppress all agent log output in the terminal; the parent still waits for the agent to finish (foreground). Has no effect with `--headless`.
 - `--sdd=<name>`: opt into an SDD methodology (e.g. `--sdd=plain`, `--sdd=speckit`). Omit to skip SDD and work directly toward a PR. See [sdd.md](sdd.md).
-- `--task "<description>"`: start from a free-form task description instead of a GitHub issue.
+- `--task "<description>"`: start from a free-form task description instead of an issue.
 - `--branch <branch-name>`: explicit branch name for `--task`. Only valid with `--task`.
-- `<issue-number-or-url>`: a bare GitHub issue number (e.g. `42`) **or** a full GitHub issue URL (e.g. `https://github.com/owner/repo/issues/42`). When a URL is supplied, `agentctl` locates or clones the target repository automatically so you do not need to `cd` into it first.
-- `[slug]`: optional branch/worktree slug. If omitted, `agentctl` uses `gh issue view` to fetch the issue title and derive a slug.
+- `<issue-number-or-url>`: a bare issue number (e.g. `42`) **or** a full issue URL from GitHub (`https://github.com/owner/repo/issues/42`) or GitLab (`https://gitlab.com/owner/repo/-/issues/42`). When a URL is supplied, `agentctl` locates or clones the target repository automatically so you do not need to `cd` into it first. The VCS provider is detected from the repository's git origin.
+- `[slug]`: optional branch/worktree slug. If omitted, `agentctl` fetches the issue title from the VCS provider (via `gh` for GitHub, `glab` for GitLab) and derives a slug.
 
 Side effects:
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -32,6 +32,7 @@ import (
 	"github.com/arun-gupta/agentctl/internal/process"
 	"github.com/arun-gupta/agentctl/internal/sdd"
 	"github.com/arun-gupta/agentctl/internal/state"
+	"github.com/arun-gupta/agentctl/internal/vcs"
 	"github.com/arun-gupta/agentctl/internal/xdg"
 )
 
@@ -160,18 +161,21 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 const resumeHintFmt = "agentctl resume %s [feedback]   # no feedback approves; add feedback to request changes\n"
 
 // kickoffTemplate is the default prompt sent to the agent when no --sdd
-// methodology is specified. {issue} and {port} are substituted at call time.
-const kickoffTemplate = `Work on GitHub issue #{issue}. Read AGENTS.md or README.md for project conventions if present.
-Make the changes directly, push the branch, and open a PR. Do not merge.
+// methodology is specified. {platform}, {issue}, {prTerm}, and {port} are
+// substituted at call time.
+const kickoffTemplate = `Work on {platform} issue #{issue}. Read AGENTS.md or README.md for project conventions if present.
+Make the changes directly, push the branch, and open a {prTerm}. Do not merge.
 You are the coding agent — implement changes using your own file-editing and bash tools.
 Do not run agentctl, claude, codex, or any other agent-launcher CLI.
 Dev server is running on port {port}.`
 
 // buildKickoff returns the default agent kickoff prompt for a plain
-// (non-SDD) run with {issue} and {port} substituted. When port is empty,
-// the dev-server line is omitted entirely.
-func buildKickoff(issue, port string) string {
+// (non-SDD) run with {issue}, {platform}, {prTerm}, and {port} substituted.
+// When port is empty, the dev-server line is omitted entirely.
+func buildKickoff(issue, port, platform, prTerm string) string {
 	s := strings.ReplaceAll(kickoffTemplate, "{issue}", issue)
+	s = strings.ReplaceAll(s, "{platform}", platform)
+	s = strings.ReplaceAll(s, "{prTerm}", prTerm)
 	if port == "" {
 		var lines []string
 		for _, line := range strings.Split(s, "\n") {
@@ -186,9 +190,10 @@ func buildKickoff(issue, port string) string {
 
 // buildKickoffFromTask returns the default agent kickoff prompt for a
 // free-form task run. When port is empty, the dev-server line is omitted.
-func buildKickoffFromTask(task, port string) string {
+// prTerm is "PR" or "MR" depending on the VCS provider.
+func buildKickoffFromTask(task, port, prTerm string) string {
 	s := "Work on the following task: " + task + "\n" +
-		"Make the changes directly, push the branch, and open a PR. Do not merge.\n" +
+		"Make the changes directly, push the branch, and open a " + prTerm + ". Do not merge.\n" +
 		"You are the coding agent — implement changes using your own file-editing and bash tools.\n" +
 		"Do not run agentctl, claude, codex, or any other agent-launcher CLI."
 	if port != "" {
@@ -197,27 +202,33 @@ func buildKickoffFromTask(task, port string) string {
 	return s
 }
 
+// resolveProvider returns the VCS provider for the repository at repoRoot.
+func resolveProvider(repoRoot string) (vcs.Provider, error) {
+	return vcs.Detect(repoRoot)
+}
+
 // startOne provisions a worktree for a single issue and launches the agent.
 // It is the per-issue unit used by both single-issue and batch invocations.
 // agentSuffix is non-empty only in multi-agent mode (--agent claude,codex);
 // it is appended to the branch name and worktree path to avoid collisions.
 func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, quiet, sendNotify bool, out io.Writer) error {
-	// Verify GITHUB_TOKEN is set before any gh calls. Never touches the keychain.
-	if err := ensureGHToken(); err != nil {
-		return err
-	}
-
 	// Validate the adapter exists before doing any setup work.
 	if err := validateAdapter(agentName); err != nil {
 		return err
 	}
 
-	// Resolve the repo root and issue number.  issue may be a bare number
-	// ("42") or a full GitHub issue URL ("https://github.com/owner/repo/issues/42").
-	repoRoot, issueNum, ghIssueArg, err := repoRootForIssue(issue, out)
+	// Resolve the repo root, issue number, and VCS provider.
+	// issue may be a bare number ("42") or a full issue URL.
+	repoRoot, issueNum, issueArg, p, err := repoRootForIssue(issue, out)
 	if err != nil {
 		return err
 	}
+
+	// Verify VCS credentials are available before any provider calls.
+	if err := p.AuthCheck(); err != nil {
+		return err
+	}
+
 	parentDir := filepath.Dir(repoRoot)
 	repoName := filepath.Base(repoRoot)
 
@@ -234,11 +245,15 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 		return err
 	}
 
-	// Derive slug from GitHub issue title if not supplied.
+	// Derive slug from issue title if not supplied.
 	if slug == "" {
-		slug, err = slugFromIssue(ghIssueArg)
-		if err != nil {
-			return err
+		title, titleErr := p.FetchIssueTitle(issueArg)
+		if titleErr != nil {
+			return titleErr
+		}
+		slug = titleToSlug(title)
+		if slug == "" {
+			slug = "work"
 		}
 		fmt.Fprintf(out, "Derived slug from issue title: %s\n", slug)
 	}
@@ -291,7 +306,7 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 		DevPID:    devPID,
 		DevPort:   portStr,
 		SDD:       sddName,
-		IssueArg:  ghIssueArg,
+		IssueArg:  issueArg,
 	}
 	if err := state.Write(wtPath, af); err != nil {
 		return err
@@ -299,7 +314,7 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 
 	var kickoff string
 	if sddName == "" {
-		kickoff = buildKickoff(issueNum, portStr)
+		kickoff = buildKickoff(issueNum, portStr, p.CLI()+" platform", p.PRTerm())
 	} else {
 		m, sddErr := sdd.Get(sddName)
 		if sddErr != nil {
@@ -333,6 +348,15 @@ func startTask(task, branch, agentName, sddName string, headless, quiet, sendNot
 	if err != nil {
 		return fmt.Errorf("cannot determine repo root: %w", err)
 	}
+
+	p, err := resolveProvider(repoRoot)
+	if err != nil {
+		return err
+	}
+	if err := p.AuthCheck(); err != nil {
+		return err
+	}
+
 	parentDir := filepath.Dir(repoRoot)
 	repoName := filepath.Base(repoRoot)
 
@@ -399,7 +423,7 @@ func startTask(task, branch, agentName, sddName string, headless, quiet, sendNot
 
 	var kickoff string
 	if sddName == "" {
-		kickoff = buildKickoffFromTask(task, portStr)
+		kickoff = buildKickoffFromTask(task, portStr, p.PRTerm())
 	} else {
 		m, sddErr := sdd.Get(sddName)
 		if sddErr != nil {
@@ -466,11 +490,8 @@ func runBatch(issues []string, agentName, sddName string, quiet, sendNotify bool
 // All agents always run in headless mode; foreground is not supported here.
 func runMultiAgent(issue string, agents []string, sddName string, quiet, sendNotify bool, out, errOut io.Writer) error {
 	// Validate all adapters and resolve (possibly clone) the repo once before
-	// spawning goroutines. This prevents concurrent `gh repo clone` races when
-	// issue is a GitHub URL, and surfaces adapter/token errors early.
-	if err := ensureGHToken(); err != nil {
-		return err
-	}
+	// spawning goroutines. This prevents concurrent clone races when issue is a
+	// URL, and surfaces adapter/token errors early.
 	for _, ag := range agents {
 		if err := validateAdapter(ag); err != nil {
 			return err
@@ -479,7 +500,11 @@ func runMultiAgent(issue string, agents []string, sddName string, quiet, sendNot
 			return err
 		}
 	}
-	if _, _, _, err := repoRootForIssue(issue, out); err != nil {
+	_, _, _, p, err := repoRootForIssue(issue, out)
+	if err != nil {
+		return err
+	}
+	if err := p.AuthCheck(); err != nil {
 		return err
 	}
 
@@ -722,7 +747,7 @@ func isAgentRunning(wtPath string) bool {
 	return af.AgentPID != "" && process.IsAlive(af.AgentPID)
 }
 
-// isStaleWorktree returns true when no agent is running and no PR of any state
+// isStaleWorktree returns true when no agent is running and no PR/MR of any state
 // exists for the branch. Returns false conservatively when PR status cannot be
 // reliably determined (e.g. auth or network failures) to avoid discarding
 // potentially active worktrees.
@@ -730,7 +755,11 @@ func isStaleWorktree(repoRoot, branch, wtPath string) bool {
 	if isAgentRunning(wtPath) {
 		return false
 	}
-	hasPR, err := ghHasPR(repoRoot, branch)
+	p, err := resolveProvider(repoRoot)
+	if err != nil {
+		return false
+	}
+	hasPR, err := p.HasPR(repoRoot, branch)
 	if err != nil {
 		return false // conservative: can't confirm no PR, skip
 	}
@@ -1009,28 +1038,33 @@ func runMerge(issue, strategy, agentSuffix string, noDelete, dryRun bool) error 
 		}
 	}
 
-	// Validate the PR is open and not conflicting.
-	prState, mergeable, reviewDecision, err := ghPRMergeInfo(repoRoot, branch)
+	p, err := resolveProvider(repoRoot)
 	if err != nil {
-		return fmt.Errorf("could not determine PR state for %s: %w\nIs gh installed and authenticated?", branch, err)
+		return fmt.Errorf("cannot detect VCS provider: %w", err)
+	}
+
+	// Validate the PR/MR is open and not conflicting.
+	prState, mergeable, reviewDecision, err := p.PRMergeInfo(repoRoot, branch)
+	if err != nil {
+		return fmt.Errorf("could not determine %s state for %s: %w\nIs %s installed and authenticated?", p.PRTerm(), branch, err, p.CLI())
 	}
 	switch prState {
 	case "MERGED":
-		return fmt.Errorf("PR for %s is already MERGED — use: agentctl cleanup %s", branch, issue)
+		return fmt.Errorf("%s for %s is already MERGED — use: agentctl cleanup %s", p.PRTerm(), branch, issue)
 	case "CLOSED":
-		return fmt.Errorf("PR for %s is CLOSED and cannot be merged", branch)
+		return fmt.Errorf("%s for %s is CLOSED and cannot be merged", p.PRTerm(), branch)
 	case "":
-		return fmt.Errorf("no open PR found for branch %s", branch)
+		return fmt.Errorf("no open %s found for branch %s", p.PRTerm(), branch)
 	}
 	if mergeable == "CONFLICTING" {
-		return fmt.Errorf("PR for %s has merge conflicts; resolve them before merging", branch)
+		return fmt.Errorf("%s for %s has merge conflicts; resolve them before merging", p.PRTerm(), branch)
 	}
 	if reviewDecision == "CHANGES_REQUESTED" {
-		return fmt.Errorf("PR for %s has changes requested; resolve review feedback before merging", branch)
+		return fmt.Errorf("%s for %s has changes requested; resolve review feedback before merging", p.PRTerm(), branch)
 	}
 
 	if dryRun {
-		fmt.Printf("[dry-run] Would merge PR for issue %s (branch: %s, strategy: %s)\n", issue, branch, strategy)
+		fmt.Printf("[dry-run] Would merge %s for issue %s (branch: %s, strategy: %s)\n", p.PRTerm(), issue, branch, strategy)
 		if !noDelete {
 			fmt.Printf("[dry-run] Would pull main and remove worktree after merge\n")
 		} else {
@@ -1039,11 +1073,11 @@ func runMerge(issue, strategy, agentSuffix string, noDelete, dryRun bool) error 
 		return nil
 	}
 
-	fmt.Printf("Merging PR for issue %s (branch: %s, strategy: %s)...\n", issue, branch, strategy)
-	if err := ghPRMerge(repoRoot, branch, strategy); err != nil {
-		return fmt.Errorf("gh pr merge failed: %w", err)
+	fmt.Printf("Merging %s for issue %s (branch: %s, strategy: %s)...\n", p.PRTerm(), issue, branch, strategy)
+	if err := p.MergePR(repoRoot, branch, strategy); err != nil {
+		return fmt.Errorf("%s %s merge failed: %w", p.CLI(), p.PRTerm(), err)
 	}
-	fmt.Println("PR merged.")
+	fmt.Printf("%s merged.\n", p.PRTerm())
 
 	if noDelete {
 		currentBranch, err := git.CurrentBranch(repoRoot)
@@ -1063,53 +1097,6 @@ func runMerge(issue, strategy, agentSuffix string, noDelete, dryRun bool) error 
 	return cleanupMerged(repoRoot, issue, agentSuffix)
 }
 
-// ghPRMergeInfo calls `gh pr view <branch>` and returns the PR state,
-// mergeability (MERGEABLE, CONFLICTING, UNKNOWN), and review decision.
-func ghPRMergeInfo(repoRoot, branch string) (prState, mergeable, reviewDecision string, err error) {
-	cmd := exec.Command("gh", "pr", "view", branch,
-		"--json", "state,mergeable,reviewDecision",
-		"-q", ".state+\" \"+.mergeable+\" \"+.reviewDecision")
-	cmd.Dir = repoRoot
-	var out, errBuf bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errBuf
-	if err := cmd.Run(); err != nil {
-		return "", "", "", fmt.Errorf("%s", strings.TrimSpace(errBuf.String()))
-	}
-	parts := strings.Fields(strings.TrimSpace(out.String()))
-	if len(parts) >= 3 {
-		return parts[0], parts[1], parts[2], nil
-	}
-	if len(parts) >= 2 {
-		return parts[0], parts[1], "", nil
-	}
-	if len(parts) == 1 {
-		return parts[0], "", "", nil
-	}
-	return "", "", "", nil
-}
-
-// ghPRMerge calls `gh pr merge <branch>` with the given strategy.
-func ghPRMerge(repoRoot, branch, strategy string) error {
-	args := []string{"pr", "merge", branch, "--yes"}
-	switch strategy {
-	case "squash":
-		args = append(args, "--squash")
-	case "merge":
-		args = append(args, "--merge")
-	case "rebase":
-		args = append(args, "--rebase")
-	}
-	cmd := exec.Command("gh", args...)
-	cmd.Dir = repoRoot
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%s", strings.TrimSpace(out.String()))
-	}
-	return nil
-}
 
 // ─── cleanup-merged ───────────────────────────────────────────────────────────
 
@@ -1207,13 +1194,17 @@ func cleanupMerged(repoRoot, issue, agentSuffix string) error {
 		}
 	}
 
-	// Verify merge via gh CLI.
-	prState, err := ghPRState(repoRoot, branch)
-	if err != nil {
-		return fmt.Errorf("could not determine PR state for %s.\nIs gh installed and authenticated? If this branch has no PR, use:\n  agentctl discard %s", branch, issue)
+	// Verify merge via VCS CLI.
+	p, detErr := resolveProvider(repoRoot)
+	if detErr != nil {
+		return fmt.Errorf("cannot detect VCS provider: %w", detErr)
+	}
+	prState, _, _, prErr := p.PRForBranch(repoRoot, branch)
+	if prErr != nil {
+		return fmt.Errorf("could not determine %s state for %s.\nIs %s installed and authenticated? If this branch has no %s, use:\n  agentctl discard %s", p.PRTerm(), branch, p.CLI(), p.PRTerm(), issue)
 	}
 	if prState != "MERGED" {
-		return fmt.Errorf("PR for %s is %s, not MERGED.\nUse: agentctl discard %s", branch, prState, issue)
+		return fmt.Errorf("%s for %s is %s, not MERGED.\nUse: agentctl discard %s", p.PRTerm(), branch, prState, issue)
 	}
 
 	fmt.Printf("Pulling main in %s ...\n", repoRoot)
@@ -1326,6 +1317,11 @@ func runCleanupAllMerged() error {
 		return err
 	}
 
+	p, err := resolveProvider(repoRoot)
+	if err != nil {
+		return fmt.Errorf("cannot detect VCS provider: %w", err)
+	}
+
 	cleaned, skipped, failed, staleCount := 0, 0, 0, 0
 	handledBranches := make(map[string]struct{}, len(wts))
 	for _, wt := range wts {
@@ -1336,7 +1332,7 @@ func runCleanupAllMerged() error {
 			continue
 		}
 		handledBranches[branch] = struct{}{}
-		prState, err := ghPRState(repoRoot, branch)
+		prState, _, _, err := p.PRForBranch(repoRoot, branch)
 		if err != nil || prState == "" {
 			if !isAgentRunning(wt.Path) {
 				staleCount++
@@ -1389,19 +1385,19 @@ func runCleanupAllMerged() error {
 				continue
 			}
 
-			prState, err := ghPRState(repoRoot, branch)
+			prState, _, _, err := p.PRForBranch(repoRoot, branch)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "WARNING: could not get PR state for remote branch %s: %v\n", branch, err)
+				fmt.Fprintf(os.Stderr, "WARNING: could not get %s state for remote branch %s: %v\n", p.PRTerm(), branch, err)
 				failed++
 				continue
 			}
 			if prState == "" {
-				fmt.Printf("Skipping orphaned remote branch %s: no PR found\n", branch)
+				fmt.Printf("Skipping orphaned remote branch %s: no %s found\n", branch, p.PRTerm())
 				skipped++
 				continue
 			}
 			if prState != "MERGED" && prState != "CLOSED" {
-				fmt.Printf("Skipping orphaned remote branch %s: PR is %s\n", branch, prState)
+				fmt.Printf("Skipping orphaned remote branch %s: %s is %s\n", branch, p.PRTerm(), prState)
 				skipped++
 				continue
 			}
@@ -1506,9 +1502,13 @@ func runStatus(verbose bool) error {
 
 		prState := "none"
 		if branch != "?" && branch != "HEAD" {
+			statusProvider, _ := resolveProvider(repoRoot)
+			if statusProvider == nil {
+				statusProvider, _ = vcs.ProviderForName("github")
+			}
 			if af.PRNumber != "" {
-				// Cache hit — use stored number, call gh live for current state.
-				if ps, _, prURL, err := ghPRInfoWithURL(repoRoot, af.PRNumber); err == nil && ps != "" {
+				// Cache hit — use stored number, call VCS CLI live for current state.
+				if ps, _, prURL, err := statusProvider.PRForBranch(repoRoot, af.PRNumber); err == nil && ps != "" {
 					prState = fmt.Sprintf("#%s %s", af.PRNumber, ps)
 					// Backfill pr-url if it was missing (partial write or manually edited .agent).
 					if af.PRURL == "" && prURL != "" {
@@ -1518,8 +1518,8 @@ func runStatus(verbose bool) error {
 					}
 				}
 			} else {
-				// Cache miss — discover PR via branch name.
-				if ps, n, prURL, err := ghPRInfoWithURL(repoRoot, branch); err == nil && ps != "" {
+				// Cache miss — discover PR/MR via branch name.
+				if ps, n, prURL, err := statusProvider.PRForBranch(repoRoot, branch); err == nil && ps != "" {
 					if n > 0 {
 						prState = fmt.Sprintf("#%d %s", n, ps)
 						if appendErr := state.AppendKeyIfExists(wt.Path, "pr", strconv.Itoa(n)); appendErr != nil {
@@ -2208,78 +2208,6 @@ func findLinkedWorktree(repoRoot, ref string) (git.Worktree, bool, error) {
 	return git.FindWorktreeByBranch(repoRoot, ref)
 }
 
-// ghPRInfo calls `gh pr view <branch>` in repoRoot and returns the PR state
-// (e.g. "MERGED") and number (e.g. 42). Both are zero-values on error.
-func ghPRInfo(repoRoot, branch string) (state string, number int, err error) {
-	cmd := exec.Command("gh", "pr", "view", branch, "--json", "state,number", "-q", ".state+\" \"+(.number|tostring)")
-	cmd.Dir = repoRoot
-	var out, errBuf bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errBuf
-	if err = cmd.Run(); err != nil {
-		return "", 0, fmt.Errorf("%w: %s", err, strings.TrimSpace(errBuf.String()))
-	}
-	parts := strings.Fields(strings.TrimSpace(out.String()))
-	if len(parts) != 2 {
-		return "", 0, fmt.Errorf("unexpected gh output: %q", out.String())
-	}
-	n, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return "", 0, fmt.Errorf("unexpected gh PR number %q in output %q: %w", parts[1], out.String(), err)
-	}
-	return parts[0], n, nil
-}
-
-// ghHasPR uses `gh pr list --head <branch> --state all` to check whether any
-// PR (open, closed, or merged) exists for the branch. It returns (true, nil)
-// when at least one PR exists, (false, nil) when none exist, and (false, err)
-// when the GH CLI call fails (e.g. auth or network failure) so callers can
-// treat the result conservatively.
-func ghHasPR(repoRoot, branch string) (bool, error) {
-	cmd := exec.Command("gh", "pr", "list", "--head", branch, "--state", "all", "--json", "number")
-	cmd.Dir = repoRoot
-	var out, errBuf bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errBuf
-	if err := cmd.Run(); err != nil {
-		return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(errBuf.String()))
-	}
-	return strings.TrimSpace(out.String()) != "[]", nil
-}
-
-// ghPRState is a convenience wrapper that returns only the state string.
-func ghPRState(repoRoot, branch string) (string, error) {
-	state, _, err := ghPRInfo(repoRoot, branch)
-	return state, err
-}
-
-// ghPRInfoWithURL calls `gh pr view <ref>` in repoRoot and returns the PR state,
-// number, and URL. ref can be a branch name or a PR number string — gh accepts both.
-// All are zero-values on error.
-func ghPRInfoWithURL(repoRoot, ref string) (prState string, number int, url string, err error) {
-	cmd := exec.Command("gh", "pr", "view", ref, "--json", "state,number,url")
-	cmd.Dir = repoRoot
-	var out, errBuf bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errBuf
-	if err = cmd.Run(); err != nil {
-		return "", 0, "", fmt.Errorf("%w: %s", err, strings.TrimSpace(errBuf.String()))
-	}
-	var result struct {
-		State  string `json:"state"`
-		Number int    `json:"number"`
-		URL    string `json:"url"`
-	}
-	if err = json.Unmarshal(out.Bytes(), &result); err != nil {
-		snippet := strings.TrimSpace(out.String())
-		runes := []rune(snippet)
-		if len(runes) > 200 {
-			snippet = string(runes[:200]) + "..."
-		}
-		return "", 0, "", fmt.Errorf("unexpected gh output: %w (output: %q)", err, snippet)
-	}
-	return result.State, result.Number, result.URL, nil
-}
 
 type prInfo struct {
 	Number int    `json:"number"`
@@ -2287,48 +2215,62 @@ type prInfo struct {
 	URL    string `json:"url"`
 }
 
-// linkPRToIssue appends "Closes #<issueNum>" to the open PR for branch,
+// linkPRToIssue appends "Closes #<issueNum>" to the open PR/MR for branch,
 // unless the body already contains a closing keyword (closes/fixes).
 // Returns the PR info (including URL) so callers can display it.
-// Silently returns nil, nil when no PR exists.
+// Silently returns nil, nil when no PR/MR exists.
 func linkPRToIssue(dir, branch, issueNum string) (*prInfo, error) {
-	cmd := exec.Command("gh", "pr", "view", branch, "--json", "number,body,url")
-	cmd.Dir = dir
-	var out, errBuf bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errBuf
-	if err := cmd.Run(); err != nil {
-		// "no pull request(s) found" means the branch exists but has no PR — not an error.
-		// Any other failure (auth, gh not installed, etc.) is a real error.
-		errMsg := strings.ToLower(errBuf.String())
-		if strings.Contains(errMsg, "no pull request") {
+	p, err := resolveProvider(dir)
+	if err != nil {
+		p, _ = vcs.ProviderForName("github")
+	}
+
+	prState, number, url, err := p.PRForBranch(dir, branch)
+	if err != nil {
+		// "no pull request(s) found" or equivalent — not an error.
+		errMsg := strings.ToLower(err.Error())
+		if strings.Contains(errMsg, "no pull request") || strings.Contains(errMsg, "no merge request") || strings.Contains(errMsg, "404") {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(errBuf.String()))
+		return nil, fmt.Errorf("%s pr view: %w", p.CLI(), err)
 	}
-
-	var pr prInfo
-	if err := json.Unmarshal(out.Bytes(), &pr); err != nil {
+	if number == 0 || prState == "" {
 		return nil, nil
 	}
-	if !isNumericIssue(issueNum) {
-		return &pr, nil
+
+	// We don't have the body from PRForBranch, so construct a minimal prInfo.
+	pr := &prInfo{Number: number, URL: url}
+
+	if !isNumericIssue(issueNum) || prState != "OPEN" {
+		return pr, nil
 	}
 
-	lower := strings.ToLower(pr.Body)
-	if strings.Contains(lower, "closes #"+issueNum) || strings.Contains(lower, "fixes #"+issueNum) {
-		return &pr, nil
+	// For GitHub, append a "Closes #N" line so the issue is linked.
+	// GitLab handles issue linking differently (via the MR description or
+	// project settings), so we skip the body edit for non-GitHub providers.
+	if p.CLI() == "gh" {
+		// Re-fetch to get body (GitHub provider only).
+		cmd := exec.Command("gh", "pr", "view", branch, "--json", "number,body,url")
+		cmd.Dir = dir
+		var out, errBuf bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &errBuf
+		if cmdErr := cmd.Run(); cmdErr == nil {
+			var full prInfo
+			if jsonErr := json.Unmarshal(out.Bytes(), &full); jsonErr == nil {
+				lower := strings.ToLower(full.Body)
+				if !strings.Contains(lower, "closes #"+issueNum) && !strings.Contains(lower, "fixes #"+issueNum) {
+					newBody := strings.TrimRight(full.Body, "\n") + "\n\nCloses #" + issueNum
+					if editErr := p.EditPRBody(dir, full.Number, newBody); editErr != nil {
+						return &full, fmt.Errorf("gh pr edit: %w", editErr)
+					}
+				}
+				return &full, nil
+			}
+		}
 	}
 
-	newBody := strings.TrimRight(pr.Body, "\n") + "\n\nCloses #" + issueNum
-	editCmd := exec.Command("gh", "pr", "edit", strconv.Itoa(pr.Number), "--body", newBody)
-	editCmd.Dir = dir
-	var editErr bytes.Buffer
-	editCmd.Stderr = &editErr
-	if err := editCmd.Run(); err != nil {
-		return &pr, fmt.Errorf("gh pr edit: %w: %s", err, strings.TrimSpace(editErr.String()))
-	}
-	return &pr, nil
+	return pr, nil
 }
 
 // reportPRStatus links the PR to the issue and prints the PR URL to w.
@@ -2358,73 +2300,25 @@ func reportPRStatus(w io.Writer, dir, branch, issueNum string, quietOnNone bool)
 	return false
 }
 
-// parseIssueURL checks whether arg is a full GitHub issue URL of the form
-// https://github.com/<owner>/<repo>/issues/<number>.
+// parseIssueURL checks whether arg is a full GitHub or GitLab issue URL.
 // If so it returns the owner, repo name, issue number string, and true.
 // Otherwise it returns the original arg as the issue and false (bare number path).
 func parseIssueURL(arg string) (owner, repo, issueNum string, ok bool) {
-	const prefix = "https://github.com/"
-	if !strings.HasPrefix(arg, prefix) {
-		return "", "", arg, false
-	}
-	tail := strings.TrimSuffix(strings.TrimPrefix(arg, prefix), "/")
-	parts := strings.Split(tail, "/")
-	if len(parts) != 4 || parts[2] != "issues" {
-		return "", "", arg, false
-	}
-	if _, err := strconv.Atoi(parts[3]); err != nil {
-		return "", "", arg, false
-	}
-	return parts[0], parts[1], parts[3], true
+	var prov string
+	owner, repo, issueNum, prov, ok = vcs.ParseIssueURL(arg)
+	_ = prov
+	return
 }
 
-// matchesGitHubOrigin reports whether the "origin" remote of repoRoot points
-// to github.com/<owner>/<repoName>. Both HTTPS and SSH remote URL formats are
-// handled, and a trailing ".git" suffix is ignored.
-func matchesGitHubOrigin(repoRoot, owner, repoName string) bool {
-	u, err := git.OriginURL(repoRoot)
-	if err != nil {
-		return false
-	}
-	u = strings.TrimSuffix(u, ".git")
-	suffix := owner + "/" + repoName
-	return strings.HasSuffix(u, "/"+suffix) || strings.HasSuffix(u, ":"+suffix)
-}
-
-// githubIssueURL builds the canonical https://github.com/<owner>/<repo>/issues/<num>
-// URL from the git origin of repoRoot. Returns "" when the origin is not a
-// recognised GitHub remote (so callers can fall back gracefully).
-func githubIssueURL(repoRoot, issueNum string) string {
-	u, err := git.OriginURL(repoRoot)
-	if err != nil {
-		return ""
-	}
-	u = strings.TrimSuffix(strings.TrimSpace(u), ".git")
-	// HTTPS: https://github.com/owner/repo
-	if strings.HasPrefix(u, "https://github.com/") {
-		return u + "/issues/" + issueNum
-	}
-	// SSH scp-style: git@github.com:owner/repo
-	const sshPrefix = "git@github.com:"
-	if strings.HasPrefix(u, sshPrefix) {
-		return "https://github.com/" + strings.TrimPrefix(u, sshPrefix) + "/issues/" + issueNum
-	}
-	// SSH URL-style: ssh://git@github.com/owner/repo
-	const sshURLPrefix = "ssh://git@github.com/"
-	if strings.HasPrefix(u, sshURLPrefix) {
-		return "https://github.com/" + strings.TrimPrefix(u, sshURLPrefix) + "/issues/" + issueNum
-	}
-	return ""
-}
-
-// locateOrCloneRepo returns the local git repo root for github.com/<owner>/<repoName>.
+// locateOrCloneRepo returns the local git repo root for the given owner/repoName,
+// using p for cloning when the repo is not found locally.
 // It searches in order:
 //  1. The repo that contains the current working directory.
 //  2. A sibling directory named <repoName> (i.e. "../<repoName>").
-//  3. Clones the repo into "../<repoName>" via `gh repo clone`.
-func locateOrCloneRepo(owner, repoName string, out io.Writer) (string, error) {
+//  3. Clones the repo into "../<repoName>" via the provider CLI.
+func locateOrCloneRepo(owner, repoName string, p vcs.Provider, out io.Writer) (string, error) {
 	// 1. Current working directory.
-	if root, err := git.RepoRoot(); err == nil && matchesGitHubOrigin(root, owner, repoName) {
+	if root, err := git.RepoRoot(); err == nil && vcs.MatchesOrigin(root, owner, repoName, p) {
 		return root, nil
 	}
 
@@ -2436,52 +2330,61 @@ func locateOrCloneRepo(owner, repoName string, out io.Writer) (string, error) {
 	// 2. Sibling directory.
 	sibling := filepath.Join(filepath.Dir(cwd), repoName)
 	if info, statErr := os.Stat(sibling); statErr == nil && info.IsDir() {
-		if matchesGitHubOrigin(sibling, owner, repoName) {
+		if vcs.MatchesOrigin(sibling, owner, repoName, p) {
 			return sibling, nil
 		}
 		return "", fmt.Errorf("directory %s exists but does not match %s/%s", sibling, owner, repoName)
 	}
 
-	// 3. Clone via gh repo clone.
+	// 3. Clone via provider CLI.
 	target := filepath.Join(filepath.Dir(cwd), repoName)
 	fmt.Fprintf(out, "Cloning %s/%s into %s ...\n", owner, repoName, target)
-	cloneCmd := exec.Command("gh", "repo", "clone", owner+"/"+repoName, target)
-	cloneCmd.Stdout = out
-	cloneCmd.Stderr = out
-	if err := cloneCmd.Run(); err != nil {
-		return "", fmt.Errorf("gh repo clone %s/%s: %w", owner, repoName, err)
+	if err := p.Clone(owner+"/"+repoName, target, out); err != nil {
+		return "", err
 	}
 	return target, nil
 }
 
-// repoRootForIssue resolves the local git repo root to use, along with the
-// bare issue number and the argument to pass to `gh issue view`.
+// repoRootForIssue resolves the local git repo root, bare issue number, the
+// issue argument to pass to the VCS CLI, and the detected provider.
 //
-// When arg is a bare issue number the repo is inferred from the current
-// working directory (existing behaviour). When arg is a full GitHub issue URL
-// (https://github.com/<owner>/<repo>/issues/<number>) the target repository is
-// located or cloned automatically, so the caller does not need to cd first.
-func repoRootForIssue(arg string, out io.Writer) (repoRoot, issueNum, ghIssueArg string, err error) {
-	owner, repoName, issueNum, isURL := parseIssueURL(arg)
+// When arg is a bare issue number the repo is inferred from the current working
+// directory. When arg is a full issue URL (GitHub or GitLab) the target
+// repository is located or cloned automatically.
+func repoRootForIssue(arg string, out io.Writer) (repoRoot, issueNum, issueArg string, p vcs.Provider, err error) {
+	owner, repoName, issueNum, providerName, isURL := vcs.ParseIssueURL(arg)
 	if !isURL {
-		root, err := git.RepoRoot()
-		if err != nil {
-			return "", "", "", fmt.Errorf("cannot determine repo root: %w", err)
+		root, rootErr := git.RepoRoot()
+		if rootErr != nil {
+			return "", "", "", nil, fmt.Errorf("cannot determine repo root: %w", rootErr)
 		}
-		// Resolve bare number to a full GitHub URL so IssueArg is always
+		provider, detectErr := vcs.Detect(root)
+		if detectErr != nil {
+			return "", "", "", nil, detectErr
+		}
+		// Resolve bare number to a full issue URL so IssueArg is always
 		// unambiguous regardless of how the issue was supplied.
-		if fullURL := githubIssueURL(root, arg); fullURL != "" {
-			return root, arg, fullURL, nil
+		if fullURL := provider.IssueURL(root, arg); fullURL != "" {
+			return root, arg, fullURL, provider, nil
 		}
-		return root, arg, arg, nil
+		return root, arg, arg, provider, nil
 	}
-	root, err := locateOrCloneRepo(owner, repoName, out)
-	if err != nil {
-		return "", "", "", err
+	urlProvider, provErr := vcs.ProviderForName(providerName)
+	if provErr != nil {
+		return "", "", "", nil, provErr
 	}
-	// Pass the original URL to gh so it resolves without requiring a
-	// matching git remote in the working directory.
-	return root, issueNum, arg, nil
+	root, cloneErr := locateOrCloneRepo(owner, repoName, urlProvider, out)
+	if cloneErr != nil {
+		return "", "", "", nil, cloneErr
+	}
+	// Re-detect after clone so any config-file override in the cloned repo is honoured.
+	provider, detectErr := vcs.Detect(root)
+	if detectErr != nil {
+		provider = urlProvider
+	}
+	// Pass the original URL as issueArg so the VCS CLI can resolve it without
+	// requiring a matching git remote.
+	return root, issueNum, arg, provider, nil
 }
 
 // worktreeExistsError returns a descriptive, actionable error for the case
@@ -2565,60 +2468,6 @@ func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
 	return nil
 }
 
-// ensureGHToken ensures GITHUB_TOKEN is set in the environment before agents
-// are launched. It checks env vars first; only when both are absent does it
-// shell out to `gh auth token` as a convenience fallback. Resolution order:
-//  1. GITHUB_TOKEN already set — use it.
-//  2. GH_TOKEN set — copy to GITHUB_TOKEN.
-//  3. `gh auth token` succeeds — set GITHUB_TOKEN from its output.
-//  4. All fail — return an actionable error that includes any `gh` diagnostic.
-func ensureGHToken() error {
-	if os.Getenv("GITHUB_TOKEN") != "" {
-		return nil
-	}
-	if tok := os.Getenv("GH_TOKEN"); tok != "" {
-		os.Setenv("GITHUB_TOKEN", tok)
-		return nil
-	}
-	// Try gh auth token as a convenience fallback for users with a configured gh CLI.
-	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("gh", "auth", "token")
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err == nil {
-		if tok := strings.TrimSpace(stdout.String()); tok != "" {
-			os.Setenv("GITHUB_TOKEN", tok)
-			return nil
-		}
-	}
-	msg := "GITHUB_TOKEN is not set\n\nSet it in your current shell (or shell profile) and re-run:\n  export GITHUB_TOKEN=<your-token>\n\nBoth GITHUB_TOKEN and GH_TOKEN are accepted. To obtain a token, run:\n  gh auth token"
-	if ghErr := strings.TrimSpace(stderr.String()); ghErr != "" {
-		msg += "\n\n`gh auth token` reported: " + ghErr
-	}
-	return fmt.Errorf("%s", msg)
-}
-
-// slugFromIssue fetches the GitHub issue title and converts it to a slug.
-// issueArg may be a bare issue number or a full GitHub issue URL; both are
-// accepted by `gh issue view`.
-func slugFromIssue(issueArg string) (string, error) {
-	cmd := exec.Command("gh", "issue", "view", issueArg, "--json", "title", "-q", ".title")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &bytes.Buffer{}
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("could not fetch title for issue %s; pass a slug explicitly", issueArg)
-	}
-	title := strings.TrimSpace(out.String())
-	if title == "" {
-		return "", fmt.Errorf("could not fetch title for issue %s; pass a slug explicitly", issueArg)
-	}
-	slug := titleToSlug(title)
-	if slug == "" {
-		slug = "work"
-	}
-	return slug, nil
-}
 
 // slugFromTask derives a task branch name from the first six words of the
 // task description using the same slugging rules as GitHub issue titles.
@@ -3914,24 +3763,28 @@ func agentEnv(wtPath string) ([]string, error) {
 			}
 		}
 
-		// Expose only ~/.config/gh (the gh CLI credential store) rather than
-		// the entire ~/.config tree, to limit the host config surface accessible
-		// from the agent's isolated HOME.
-		ghConfigSrc := filepath.Join(realHome, ".config", "gh")
-		if _, srcErr := os.Lstat(ghConfigSrc); srcErr == nil {
-			agentConfigDir := filepath.Join(agentHome, ".config")
+		// Expose ~/.config/gh and ~/.config/glab-cli (the CLI credential stores)
+		// rather than the entire ~/.config tree, to limit the host config surface
+		// accessible from the agent's isolated HOME.
+		agentConfigDir := filepath.Join(agentHome, ".config")
+		for _, cfgDir := range []string{"gh", "glab-cli"} {
+			cfgSrc := filepath.Join(realHome, ".config", cfgDir)
+			if _, srcErr := os.Lstat(cfgSrc); srcErr != nil {
+				if !os.IsNotExist(srcErr) {
+					fmt.Fprintf(os.Stderr, "agentctl: warning: stat %s: %v\n", cfgSrc, srcErr)
+				}
+				continue
+			}
 			if mkdirErr := os.MkdirAll(agentConfigDir, 0o755); mkdirErr != nil {
 				fmt.Fprintf(os.Stderr, "agentctl: warning: mkdir %s: %v\n", agentConfigDir, mkdirErr)
-			} else {
-				ghConfigDst := filepath.Join(agentConfigDir, "gh")
-				if _, statErr := os.Lstat(ghConfigDst); os.IsNotExist(statErr) {
-					if symlinkErr := os.Symlink(ghConfigSrc, ghConfigDst); symlinkErr != nil {
-						fmt.Fprintf(os.Stderr, "agentctl: warning: symlink .config/gh: %v (gh credentials may not work)\n", symlinkErr)
-					}
+				continue
+			}
+			cfgDst := filepath.Join(agentConfigDir, cfgDir)
+			if _, statErr := os.Lstat(cfgDst); os.IsNotExist(statErr) {
+				if symlinkErr := os.Symlink(cfgSrc, cfgDst); symlinkErr != nil {
+					fmt.Fprintf(os.Stderr, "agentctl: warning: symlink .config/%s: %v (%s credentials may not work)\n", cfgDir, symlinkErr, cfgDir)
 				}
 			}
-		} else if !os.IsNotExist(srcErr) {
-			fmt.Fprintf(os.Stderr, "agentctl: warning: stat %s: %v\n", ghConfigSrc, srcErr)
 		}
 	}
 
@@ -4014,9 +3867,11 @@ func writeClaudeSettings(wtPath string) error {
 // blocks until the agent exits. When headless is true it detaches immediately
 // and writes output to agent.log.
 func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless, quiet, sendNotify bool) error {
-	// Verify GITHUB_TOKEN is set before any gh calls. Never touches the keychain.
-	if err := ensureGHToken(); err != nil {
-		return err
+	// Verify VCS credentials are available before any provider calls.
+	if p, err := resolveProvider(wtPath); err == nil {
+		if authErr := p.AuthCheck(); authErr != nil {
+			return authErr
+		}
 	}
 
 	ad, err := adapters.Get(adapterName)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -314,7 +314,7 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 
 	var kickoff string
 	if sddName == "" {
-		kickoff = buildKickoff(issueNum, portStr, p.CLI()+" platform", p.PRTerm())
+		kickoff = buildKickoff(issueNum, portStr, p.Platform(), p.PRTerm())
 	} else {
 		m, sddErr := sdd.Get(sddName)
 		if sddErr != nil {
@@ -1499,11 +1499,10 @@ func runStatus(verbose bool) error {
 
 		prState := "none"
 		if branch != "?" && branch != "HEAD" {
-			statusProvider, _ := resolveProvider(repoRoot)
-			if statusProvider == nil {
-				statusProvider, _ = vcs.ProviderForName("github")
-			}
-			if af.PRNumber != "" {
+			statusProvider, provErr := resolveProvider(repoRoot)
+			if provErr != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: could not detect VCS provider for %s: %v\n", repoRoot, provErr)
+			} else if af.PRNumber != "" {
 				// Cache hit — use stored number, call VCS CLI live for current state.
 				if ps, _, prURL, err := statusProvider.PRForBranch(repoRoot, af.PRNumber); err == nil && ps != "" {
 					prState = fmt.Sprintf("#%s %s", af.PRNumber, ps)
@@ -2219,7 +2218,7 @@ type prInfo struct {
 func linkPRToIssue(dir, branch, issueNum string) (*prInfo, error) {
 	p, err := resolveProvider(dir)
 	if err != nil {
-		p, _ = vcs.ProviderForName("github")
+		return nil, fmt.Errorf("could not detect VCS provider: %w", err)
 	}
 
 	prState, number, url, err := p.PRForBranch(dir, branch)
@@ -2242,32 +2241,22 @@ func linkPRToIssue(dir, branch, issueNum string) (*prInfo, error) {
 		return pr, nil
 	}
 
-	// For GitHub, append a "Closes #N" line so the issue is linked.
-	// GitLab handles issue linking differently (via the MR description or
-	// project settings), so we skip the body edit for non-GitHub providers.
-	if p.CLI() == "gh" {
-		// Re-fetch to get body (GitHub provider only).
-		cmd := exec.Command("gh", "pr", "view", branch, "--json", "number,body,url")
-		cmd.Dir = dir
-		var out, errBuf bytes.Buffer
-		cmd.Stdout = &out
-		cmd.Stderr = &errBuf
-		if cmdErr := cmd.Run(); cmdErr == nil {
-			var full prInfo
-			if jsonErr := json.Unmarshal(out.Bytes(), &full); jsonErr == nil {
-				lower := strings.ToLower(full.Body)
-				if !strings.Contains(lower, "closes #"+issueNum) && !strings.Contains(lower, "fixes #"+issueNum) {
-					newBody := strings.TrimRight(full.Body, "\n") + "\n\nCloses #" + issueNum
-					if editErr := p.EditPRBody(dir, full.Number, newBody); editErr != nil {
-						return &full, fmt.Errorf("gh pr edit: %w", editErr)
-					}
-				}
-				return &full, nil
-			}
+	// Re-fetch the PR/MR details to get the body so we can append a closing
+	// keyword when it is missing.  Errors here are surfaced rather than
+	// swallowed so regressions in issue-linking are immediately visible.
+	fullNumber, body, fullURL, detailErr := p.FetchPRDetails(dir, branch)
+	if detailErr != nil {
+		return pr, fmt.Errorf("%s pr view: %w", p.CLI(), detailErr)
+	}
+	full := &prInfo{Number: fullNumber, Body: body, URL: fullURL}
+	lower := strings.ToLower(body)
+	if !strings.Contains(lower, "closes #"+issueNum) && !strings.Contains(lower, "fixes #"+issueNum) {
+		newBody := strings.TrimRight(body, "\n") + "\n\nCloses #" + issueNum
+		if editErr := p.EditPRBody(dir, fullNumber, newBody); editErr != nil {
+			return full, fmt.Errorf("%s pr edit: %w", p.CLI(), editErr)
 		}
 	}
-
-	return pr, nil
+	return full, nil
 }
 
 // reportPRStatus links the PR to the issue and prints the PR URL to w.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -2348,11 +2348,6 @@ func repoRootForIssue(arg string, out io.Writer) (repoRoot, issueNum, issueArg s
 		if detectErr != nil {
 			return "", "", "", nil, detectErr
 		}
-		// Resolve bare number to a full issue URL so IssueArg is always
-		// unambiguous regardless of how the issue was supplied.
-		if fullURL := provider.IssueURL(root, arg); fullURL != "" {
-			return root, arg, fullURL, provider, nil
-		}
 		return root, arg, arg, provider, nil
 	}
 	urlProvider, provErr := vcs.ProviderForName(providerName)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -353,9 +353,6 @@ func startTask(task, branch, agentName, sddName string, headless, quiet, sendNot
 	if err != nil {
 		return err
 	}
-	if err := p.AuthCheck(); err != nil {
-		return err
-	}
 
 	parentDir := filepath.Dir(repoRoot)
 	repoName := filepath.Base(repoRoot)

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/arun-gupta/agentctl/internal/process"
 	"github.com/arun-gupta/agentctl/internal/sdd"
 	"github.com/arun-gupta/agentctl/internal/state"
+	"github.com/arun-gupta/agentctl/internal/vcs"
 )
 
 // TestMain handles the hidden __stream-log subprocess that launchAgent/agentResume
@@ -297,7 +298,7 @@ Initializing agent...
 }
 
 func TestBuildKickoff_substitution(t *testing.T) {
-	kickoff := buildKickoff("42", "3010")
+	kickoff := buildKickoff("42", "3010", "GitHub", "PR")
 	if strings.Contains(kickoff, "{issue}") {
 		t.Error("buildKickoff did not substitute {issue}")
 	}
@@ -313,7 +314,7 @@ func TestBuildKickoff_substitution(t *testing.T) {
 }
 
 func TestBuildKickoff_noPort_omitsDevServerLine(t *testing.T) {
-	kickoff := buildKickoff("42", "")
+	kickoff := buildKickoff("42", "", "GitHub", "PR")
 	if strings.Contains(kickoff, "port") || strings.Contains(kickoff, "{port}") {
 		t.Errorf("buildKickoff with empty port must not mention port, got:\n%s", kickoff)
 	}
@@ -323,7 +324,7 @@ func TestBuildKickoff_noPort_omitsDevServerLine(t *testing.T) {
 }
 
 func TestBuildKickoff_isAgentNeutral(t *testing.T) {
-	kickoff := buildKickoff("42", "3010")
+	kickoff := buildKickoff("42", "3010", "GitHub", "PR")
 	if strings.Contains(kickoff, "CLAUDE.md") {
 		t.Errorf("buildKickoff must not reference CLAUDE.md; got:\n%s", kickoff)
 	}
@@ -338,8 +339,18 @@ func TestBuildKickoff_isAgentNeutral(t *testing.T) {
 	}
 }
 
+func TestBuildKickoff_gitlab(t *testing.T) {
+	kickoff := buildKickoff("42", "3010", "GitLab", "MR")
+	if !strings.Contains(kickoff, "GitLab") {
+		t.Error("buildKickoff with GitLab platform should contain 'GitLab'")
+	}
+	if !strings.Contains(kickoff, "open a MR") {
+		t.Error("buildKickoff with MR prTerm should say 'open a MR'")
+	}
+}
+
 func TestBuildKickoffFromTask_noPortUsesTaskDescription(t *testing.T) {
-	kickoff := buildKickoffFromTask("Refactor the auth middleware to use JWT", "")
+	kickoff := buildKickoffFromTask("Refactor the auth middleware to use JWT", "", "PR")
 	if !strings.Contains(kickoff, "Refactor the auth middleware to use JWT") {
 		t.Fatalf("task kickoff must include the task description, got:\n%s", kickoff)
 	}
@@ -570,7 +581,7 @@ func TestParseIssueURL_invalidPaths(t *testing.T) {
 	}
 }
 
-// ─── matchesGitHubOrigin ─────────────────────────────────────────────────────
+// ─── vcs.MatchesOrigin ───────────────────────────────────────────────────────
 
 // initGitRepoWithOrigin creates a bare git repo and sets a given origin URL.
 // Returns the repo directory path.
@@ -590,85 +601,104 @@ func initGitRepoWithOrigin(t *testing.T, originURL string) string {
 	return dir
 }
 
-func TestMatchesGitHubOrigin_https(t *testing.T) {
+func TestMatchesOrigin_https(t *testing.T) {
 	dir := initGitRepoWithOrigin(t, "https://github.com/myorg/myrepo.git")
-	if !matchesGitHubOrigin(dir, "myorg", "myrepo") {
-		t.Error("expected matchesGitHubOrigin to return true for https URL")
+	p, _ := vcs.ProviderForName("github")
+	if !vcs.MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin to return true for https URL")
 	}
 }
 
-func TestMatchesGitHubOrigin_ssh(t *testing.T) {
+func TestMatchesOrigin_ssh(t *testing.T) {
 	dir := initGitRepoWithOrigin(t, "git@github.com:myorg/myrepo.git")
-	if !matchesGitHubOrigin(dir, "myorg", "myrepo") {
-		t.Error("expected matchesGitHubOrigin to return true for SSH URL")
+	p, _ := vcs.ProviderForName("github")
+	if !vcs.MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin to return true for SSH URL")
 	}
 }
 
-func TestMatchesGitHubOrigin_noGitSuffix(t *testing.T) {
+func TestMatchesOrigin_noGitSuffix(t *testing.T) {
 	dir := initGitRepoWithOrigin(t, "https://github.com/myorg/myrepo")
-	if !matchesGitHubOrigin(dir, "myorg", "myrepo") {
-		t.Error("expected matchesGitHubOrigin to return true when .git suffix absent")
+	p, _ := vcs.ProviderForName("github")
+	if !vcs.MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin to return true when .git suffix absent")
 	}
 }
 
-func TestMatchesGitHubOrigin_wrongOwner(t *testing.T) {
+func TestMatchesOrigin_wrongOwner(t *testing.T) {
 	dir := initGitRepoWithOrigin(t, "https://github.com/otherorg/myrepo.git")
-	if matchesGitHubOrigin(dir, "myorg", "myrepo") {
-		t.Error("expected matchesGitHubOrigin to return false for wrong owner")
+	p, _ := vcs.ProviderForName("github")
+	if vcs.MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin to return false for wrong owner")
 	}
 }
 
-func TestMatchesGitHubOrigin_noOrigin(t *testing.T) {
+func TestMatchesOrigin_noOrigin(t *testing.T) {
 	dir := t.TempDir()
 	cmd := exec.Command("git", "init")
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v\n%s", err, out)
 	}
-	if matchesGitHubOrigin(dir, "myorg", "myrepo") {
-		t.Error("expected matchesGitHubOrigin to return false when no origin remote")
+	p, _ := vcs.ProviderForName("github")
+	if vcs.MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin to return false when no origin remote")
 	}
 }
 
-// ─── githubIssueURL ──────────────────────────────────────────────────────────
+// ─── Provider.IssueURL ───────────────────────────────────────────────────────
 
-func TestGithubIssueURL_https(t *testing.T) {
+func TestProviderIssueURL_github_https(t *testing.T) {
 	dir := initGitRepoWithOrigin(t, "https://github.com/myorg/myrepo.git")
-	got := githubIssueURL(dir, "42")
+	p, _ := vcs.ProviderForName("github")
+	got := p.IssueURL(dir, "42")
 	want := "https://github.com/myorg/myrepo/issues/42"
 	if got != want {
-		t.Errorf("githubIssueURL (HTTPS) = %q, want %q", got, want)
+		t.Errorf("IssueURL (HTTPS) = %q, want %q", got, want)
 	}
 }
 
-func TestGithubIssueURL_ssh(t *testing.T) {
+func TestProviderIssueURL_github_ssh(t *testing.T) {
 	dir := initGitRepoWithOrigin(t, "git@github.com:myorg/myrepo.git")
-	got := githubIssueURL(dir, "7")
+	p, _ := vcs.ProviderForName("github")
+	got := p.IssueURL(dir, "7")
 	want := "https://github.com/myorg/myrepo/issues/7"
 	if got != want {
-		t.Errorf("githubIssueURL (SSH) = %q, want %q", got, want)
+		t.Errorf("IssueURL (SSH) = %q, want %q", got, want)
 	}
 }
 
-func TestGithubIssueURL_sshURL(t *testing.T) {
+func TestProviderIssueURL_github_sshURL(t *testing.T) {
 	dir := initGitRepoWithOrigin(t, "ssh://git@github.com/myorg/myrepo.git")
-	got := githubIssueURL(dir, "5")
+	p, _ := vcs.ProviderForName("github")
+	got := p.IssueURL(dir, "5")
 	want := "https://github.com/myorg/myrepo/issues/5"
 	if got != want {
-		t.Errorf("githubIssueURL (ssh://) = %q, want %q", got, want)
+		t.Errorf("IssueURL (ssh://) = %q, want %q", got, want)
 	}
 }
 
-func TestGithubIssueURL_noOrigin(t *testing.T) {
+func TestProviderIssueURL_github_noOrigin(t *testing.T) {
 	dir := t.TempDir()
 	cmd := exec.Command("git", "init")
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v\n%s", err, out)
 	}
-	got := githubIssueURL(dir, "1")
+	p, _ := vcs.ProviderForName("github")
+	got := p.IssueURL(dir, "1")
 	if got != "" {
-		t.Errorf("githubIssueURL without origin = %q, want empty string", got)
+		t.Errorf("IssueURL without origin = %q, want empty string", got)
+	}
+}
+
+func TestProviderIssueURL_gitlab_https(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://gitlab.com/myorg/myrepo.git")
+	p, _ := vcs.ProviderForName("gitlab")
+	got := p.IssueURL(dir, "42")
+	want := "https://gitlab.com/myorg/myrepo/-/issues/42"
+	if got != want {
+		t.Errorf("GitLab IssueURL (HTTPS) = %q, want %q", got, want)
 	}
 }
 
@@ -677,8 +707,9 @@ func TestGithubIssueURL_noOrigin(t *testing.T) {
 func TestLocateOrCloneRepo_cwdMatch(t *testing.T) {
 	dir := initGitRepoWithOrigin(t, "https://github.com/myorg/myrepo.git")
 	chdirTemp(t, dir)
+	p, _ := vcs.ProviderForName("github")
 
-	got, err := locateOrCloneRepo("myorg", "myrepo", io.Discard)
+	got, err := locateOrCloneRepo("myorg", "myrepo", p, io.Discard)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -720,7 +751,8 @@ func TestLocateOrCloneRepo_siblingMatch(t *testing.T) {
 		}
 	}
 
-	got, err := locateOrCloneRepo("myorg", "myrepo", io.Discard)
+	p, _ := vcs.ProviderForName("github")
+	got, err := locateOrCloneRepo("myorg", "myrepo", p, io.Discard)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -752,7 +784,8 @@ func TestLocateOrCloneRepo_siblingWrongOrigin(t *testing.T) {
 		}
 	}
 
-	_, err := locateOrCloneRepo("myorg", "myrepo", io.Discard)
+	p, _ := vcs.ProviderForName("github")
+	_, err := locateOrCloneRepo("myorg", "myrepo", p, io.Discard)
 	if err == nil {
 		t.Fatal("expected error when sibling has wrong origin")
 	}
@@ -767,7 +800,7 @@ func TestRepoRootForIssue_bareNumber(t *testing.T) {
 	dir := initGitRepoWithOrigin(t, "https://github.com/myorg/myrepo.git")
 	chdirTemp(t, dir)
 
-	root, issueNum, ghArg, err := repoRootForIssue("42", io.Discard)
+	root, issueNum, issueArg, p, err := repoRootForIssue("42", io.Discard)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -780,8 +813,11 @@ func TestRepoRootForIssue_bareNumber(t *testing.T) {
 	if issueNum != "42" {
 		t.Errorf("issueNum = %q, want %q", issueNum, "42")
 	}
-	if ghArg != "https://github.com/myorg/myrepo/issues/42" {
-		t.Errorf("ghArg = %q, want full GitHub URL", ghArg)
+	if issueArg != "https://github.com/myorg/myrepo/issues/42" {
+		t.Errorf("issueArg = %q, want full GitHub URL", issueArg)
+	}
+	if p == nil || p.CLI() != "gh" {
+		t.Errorf("expected GitHub provider, got %v", p)
 	}
 }
 
@@ -790,7 +826,7 @@ func TestRepoRootForIssue_urlCwdMatch(t *testing.T) {
 	chdirTemp(t, dir)
 
 	const rawURL = "https://github.com/myorg/myrepo/issues/99"
-	root, issueNum, ghArg, err := repoRootForIssue(rawURL, io.Discard)
+	root, issueNum, issueArg, p, err := repoRootForIssue(rawURL, io.Discard)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -803,8 +839,11 @@ func TestRepoRootForIssue_urlCwdMatch(t *testing.T) {
 	if issueNum != "99" {
 		t.Errorf("issueNum = %q, want %q", issueNum, "99")
 	}
-	if ghArg != rawURL {
-		t.Errorf("ghArg = %q, want %q", ghArg, rawURL)
+	if issueArg != rawURL {
+		t.Errorf("issueArg = %q, want %q", issueArg, rawURL)
+	}
+	if p == nil || p.CLI() != "gh" {
+		t.Errorf("expected GitHub provider, got %v", p)
 	}
 }
 
@@ -851,7 +890,7 @@ func TestRunCleanupAllMerged_prunesRemoteOnlyMergedBranch(t *testing.T) {
 	gitRun(t, repo, "branch", "-D", nonAgentBranch)
 
 	stubDir := t.TempDir()
-	makeGHCleanupStateStub(t, stubDir, "MERGED 251")
+	makeGHCleanupStateStub(t, stubDir, `{"state":"MERGED","number":251,"url":""}`)
 	prependPath(t, stubDir)
 
 	chdirTemp(t, repo)
@@ -884,7 +923,7 @@ func TestRunCleanupAllMerged_skipsRemoteOnlyOpenBranch(t *testing.T) {
 	gitRun(t, repo, "branch", "-D", openBranch)
 
 	stubDir := t.TempDir()
-	makeGHCleanupStateStub(t, stubDir, "OPEN 252")
+	makeGHCleanupStateStub(t, stubDir, `{"state":"OPEN","number":252,"url":""}`)
 	prependPath(t, stubDir)
 
 	chdirTemp(t, repo)
@@ -2677,6 +2716,27 @@ func TestAgentEnv_preservesExistingToken(t *testing.T) {
 	t.Error("GITHUB_TOKEN not found in env at all")
 }
 
+// ensureGHToken is a test-local helper that exercises the GitHub provider's
+// AuthCheck logic (the former ensureGHToken function, now part of vcs package).
+func ensureGHToken() error {
+	p, _ := vcs.ProviderForName("github")
+	return p.AuthCheck()
+}
+
+// ghHasPR is a test-local helper that exercises the GitHub provider's HasPR
+// logic (the former ghHasPR function, now part of the vcs package).
+func ghHasPR(repoRoot, branch string) (bool, error) {
+	p, _ := vcs.ProviderForName("github")
+	return p.HasPR(repoRoot, branch)
+}
+
+// ghPRInfoWithURL is a test-local helper that exercises the GitHub provider's
+// PRForBranch logic (the former ghPRInfoWithURL function, now vcs package).
+func ghPRInfoWithURL(repoRoot, ref string) (prState string, number int, url string, err error) {
+	p, _ := vcs.ProviderForName("github")
+	return p.PRForBranch(repoRoot, ref)
+}
+
 // TestEnsureGHToken_failsWhenAbsent verifies that ensureGHToken returns an
 // error when neither GITHUB_TOKEN nor GH_TOKEN is set and gh auth token fails.
 // It also checks that gh's stderr diagnostic is included in the error message.
@@ -4236,12 +4296,15 @@ exit 0`,
 	return callsFile
 }
 
-func makeGHCleanupStateStub(t *testing.T, stubDir, prViewOutput string) {
+func makeGHCleanupStateStub(t *testing.T, stubDir, prViewJSON string) {
 	t.Helper()
-
+	responseFile := filepath.Join(stubDir, "gh-response.json")
+	if err := os.WriteFile(responseFile, []byte(prViewJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	script := fmt.Sprintf(`#!/bin/sh
 if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
-  printf '%%s\n' %q
+  cat %s
   exit 0
 fi
 if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
@@ -4249,7 +4312,7 @@ if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
   exit 0
 fi
 exit 0
-`, prViewOutput)
+`, responseFile)
 
 	if err := os.WriteFile(filepath.Join(stubDir, "gh"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
@@ -4316,7 +4379,7 @@ func TestLinkPRToIssue_alreadyLinked(t *testing.T) {
 
 func TestLinkPRToIssue_addsLink(t *testing.T) {
 	stubDir := t.TempDir()
-	viewJSON := `{"number":7,"body":"some PR work","url":"https://github.com/owner/repo/pull/7"}`
+	viewJSON := `{"state":"OPEN","number":7,"body":"some PR work","url":"https://github.com/owner/repo/pull/7"}`
 	callsFile := makeGHStub(t, stubDir, viewJSON, "", false)
 	prependPath(t, stubDir)
 
@@ -4340,7 +4403,7 @@ func TestLinkPRToIssue_addsLink(t *testing.T) {
 
 func TestLinkPRToIssue_addsLink_emptyBody(t *testing.T) {
 	stubDir := t.TempDir()
-	viewJSON := `{"number":3,"body":"","url":"https://github.com/owner/repo/pull/3"}`
+	viewJSON := `{"state":"OPEN","number":3,"body":"","url":"https://github.com/owner/repo/pull/3"}`
 	callsFile := makeGHStub(t, stubDir, viewJSON, "", false)
 	prependPath(t, stubDir)
 
@@ -4357,7 +4420,7 @@ func TestLinkPRToIssue_addsLink_emptyBody(t *testing.T) {
 
 func TestLinkPRToIssue_editError(t *testing.T) {
 	stubDir := t.TempDir()
-	viewJSON := `{"number":7,"body":"some work","url":"https://github.com/owner/repo/pull/7"}`
+	viewJSON := `{"state":"OPEN","number":7,"body":"some work","url":"https://github.com/owner/repo/pull/7"}`
 	makeGHStub(t, stubDir, viewJSON, "", true) // editFail=true
 	prependPath(t, stubDir)
 
@@ -4372,7 +4435,7 @@ func TestLinkPRToIssue_editError(t *testing.T) {
 
 func TestReportPRStatus_printsPRLink(t *testing.T) {
 	stubDir := t.TempDir()
-	viewJSON := `{"number":9,"body":"work","url":"https://github.com/owner/repo/pull/9"}`
+	viewJSON := `{"state":"OPEN","number":9,"body":"work","url":"https://github.com/owner/repo/pull/9"}`
 	makeGHStub(t, stubDir, viewJSON, "", false)
 	prependPath(t, stubDir)
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -870,6 +870,8 @@ func TestRemoveBranchRefs_alreadyRemovedIsQuiet(t *testing.T) {
 
 func TestRunCleanupAllMerged_prunesRemoteOnlyMergedBranch(t *testing.T) {
 	repo := initGitRepoWithBareOrigin(t)
+	// Test repos use local file paths as origins; configure the provider explicitly.
+	writeVCSProvider(t, repo, "github")
 
 	createCommittedFile(t, repo, "tracked.txt", "initial\n")
 	gitRun(t, repo, "checkout", "-b", "main")
@@ -909,6 +911,8 @@ func TestRunCleanupAllMerged_prunesRemoteOnlyMergedBranch(t *testing.T) {
 
 func TestRunCleanupAllMerged_skipsRemoteOnlyOpenBranch(t *testing.T) {
 	repo := initGitRepoWithBareOrigin(t)
+	// Test repos use local file paths as origins; configure the provider explicitly.
+	writeVCSProvider(t, repo, "github")
 
 	createCommittedFile(t, repo, "tracked.txt", "initial\n")
 	gitRun(t, repo, "checkout", "-b", "main")
@@ -1149,6 +1153,16 @@ func writeLocalAdapter(t *testing.T, dir, name, content string) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(adapterDir, name+".yml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeVCSProvider writes a .agentctl.yml with a vcs.provider override so
+// that Detect works in test repos whose origin is a local file path.
+func writeVCSProvider(t *testing.T, dir, provider string) {
+	t.Helper()
+	yaml := "vcs:\n  provider: " + provider + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -4954,6 +4968,8 @@ func TestRunDiscardStale_confirmationYES_removesWorktreeAndBranch(t *testing.T) 
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git remote add: %v\n%s", err, out)
 	}
+	// Test repos use local file paths as origins; configure the provider explicitly.
+	writeVCSProvider(t, repo, "github")
 
 	wtPath := filepath.Join(t.TempDir(), "42-my-feature")
 	addWorktree(t, repo, wtPath, "42-my-feature")

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -813,8 +813,8 @@ func TestRepoRootForIssue_bareNumber(t *testing.T) {
 	if issueNum != "42" {
 		t.Errorf("issueNum = %q, want %q", issueNum, "42")
 	}
-	if issueArg != "https://github.com/myorg/myrepo/issues/42" {
-		t.Errorf("issueArg = %q, want full GitHub URL", issueArg)
+	if issueArg != "42" {
+		t.Errorf("issueArg = %q, want bare issue number", issueArg)
 	}
 	if p == nil || p.CLI() != "gh" {
 		t.Errorf("expected GitHub provider, got %v", p)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,15 @@ import (
 
 const Filename = ".agentctl.yml"
 
+// VCSConfig holds optional VCS provider overrides. Useful for self-hosted
+// GitLab instances where the origin URL does not contain "gitlab.com".
+type VCSConfig struct {
+	// Provider overrides automatic detection. Valid values: "github", "gitlab".
+	Provider string `yaml:"provider,omitempty"`
+	// Server is the base URL of a self-hosted instance (e.g. https://gitlab.mycompany.com).
+	Server string `yaml:"server,omitempty"`
+}
+
 // AgentctlConfig is the schema for .agentctl.yml.
 type AgentctlConfig struct {
 	// DevServer is the command to start the project's dev server.
@@ -28,6 +37,9 @@ type AgentctlConfig struct {
 	// Valid values: "squash" (default when empty), "merge", "rebase".
 	// Override per-invocation with the --strategy flag.
 	MergeStrategy string `yaml:"merge_strategy,omitempty"`
+
+	// VCS holds optional VCS provider overrides for self-hosted instances.
+	VCS VCSConfig `yaml:"vcs,omitempty"`
 }
 
 // Read loads .agentctl.yml from dir. If the file does not exist, an empty

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -140,3 +140,75 @@ func TestWrite_preservesMergeStrategy(t *testing.T) {
 		t.Errorf("MergeStrategy = %q, want %q", got.MergeStrategy, "squash")
 	}
 }
+
+func TestRead_parsesVCSProvider(t *testing.T) {
+dir := t.TempDir()
+if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("vcs:\n  provider: gitlab\n"), 0o644); err != nil {
+t.Fatal(err)
+}
+cfg, err := config.Read(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if cfg.VCS.Provider != "gitlab" {
+t.Errorf("VCS.Provider = %q, want %q", cfg.VCS.Provider, "gitlab")
+}
+}
+
+func TestRead_parsesVCSServer(t *testing.T) {
+dir := t.TempDir()
+yaml := "vcs:\n  provider: gitlab\n  server: https://gitlab.company.com\n"
+if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte(yaml), 0o644); err != nil {
+t.Fatal(err)
+}
+cfg, err := config.Read(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if cfg.VCS.Provider != "gitlab" {
+t.Errorf("VCS.Provider = %q, want %q", cfg.VCS.Provider, "gitlab")
+}
+if cfg.VCS.Server != "https://gitlab.company.com" {
+t.Errorf("VCS.Server = %q, want %q", cfg.VCS.Server, "https://gitlab.company.com")
+}
+}
+
+func TestRead_vcsDefaultsEmpty(t *testing.T) {
+dir := t.TempDir()
+if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"npm start\"\n"), 0o644); err != nil {
+t.Fatal(err)
+}
+cfg, err := config.Read(dir)
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if cfg.VCS.Provider != "" {
+t.Errorf("VCS.Provider = %q, want empty string (default)", cfg.VCS.Provider)
+}
+if cfg.VCS.Server != "" {
+t.Errorf("VCS.Server = %q, want empty string (default)", cfg.VCS.Server)
+}
+}
+
+func TestWrite_preservesVCS(t *testing.T) {
+dir := t.TempDir()
+cfg := &config.AgentctlConfig{
+VCS: config.VCSConfig{
+Provider: "gitlab",
+Server:   "https://gitlab.company.com",
+},
+}
+if err := config.Write(dir, cfg); err != nil {
+t.Fatalf("Write error: %v", err)
+}
+got, err := config.Read(dir)
+if err != nil {
+t.Fatal(err)
+}
+if got.VCS.Provider != "gitlab" {
+t.Errorf("VCS.Provider = %q, want %q", got.VCS.Provider, "gitlab")
+}
+if got.VCS.Server != "https://gitlab.company.com" {
+t.Errorf("VCS.Server = %q, want %q", got.VCS.Server, "https://gitlab.company.com")
+}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -142,73 +142,73 @@ func TestWrite_preservesMergeStrategy(t *testing.T) {
 }
 
 func TestRead_parsesVCSProvider(t *testing.T) {
-dir := t.TempDir()
-if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("vcs:\n  provider: gitlab\n"), 0o644); err != nil {
-t.Fatal(err)
-}
-cfg, err := config.Read(dir)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-if cfg.VCS.Provider != "gitlab" {
-t.Errorf("VCS.Provider = %q, want %q", cfg.VCS.Provider, "gitlab")
-}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("vcs:\n  provider: gitlab\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.VCS.Provider != "gitlab" {
+		t.Errorf("VCS.Provider = %q, want %q", cfg.VCS.Provider, "gitlab")
+	}
 }
 
 func TestRead_parsesVCSServer(t *testing.T) {
-dir := t.TempDir()
-yaml := "vcs:\n  provider: gitlab\n  server: https://gitlab.company.com\n"
-if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte(yaml), 0o644); err != nil {
-t.Fatal(err)
-}
-cfg, err := config.Read(dir)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-if cfg.VCS.Provider != "gitlab" {
-t.Errorf("VCS.Provider = %q, want %q", cfg.VCS.Provider, "gitlab")
-}
-if cfg.VCS.Server != "https://gitlab.company.com" {
-t.Errorf("VCS.Server = %q, want %q", cfg.VCS.Server, "https://gitlab.company.com")
-}
+	dir := t.TempDir()
+	yaml := "vcs:\n  provider: gitlab\n  server: https://gitlab.company.com\n"
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.VCS.Provider != "gitlab" {
+		t.Errorf("VCS.Provider = %q, want %q", cfg.VCS.Provider, "gitlab")
+	}
+	if cfg.VCS.Server != "https://gitlab.company.com" {
+		t.Errorf("VCS.Server = %q, want %q", cfg.VCS.Server, "https://gitlab.company.com")
+	}
 }
 
 func TestRead_vcsDefaultsEmpty(t *testing.T) {
-dir := t.TempDir()
-if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"npm start\"\n"), 0o644); err != nil {
-t.Fatal(err)
-}
-cfg, err := config.Read(dir)
-if err != nil {
-t.Fatalf("unexpected error: %v", err)
-}
-if cfg.VCS.Provider != "" {
-t.Errorf("VCS.Provider = %q, want empty string (default)", cfg.VCS.Provider)
-}
-if cfg.VCS.Server != "" {
-t.Errorf("VCS.Server = %q, want empty string (default)", cfg.VCS.Server)
-}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"npm start\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.VCS.Provider != "" {
+		t.Errorf("VCS.Provider = %q, want empty string (default)", cfg.VCS.Provider)
+	}
+	if cfg.VCS.Server != "" {
+		t.Errorf("VCS.Server = %q, want empty string (default)", cfg.VCS.Server)
+	}
 }
 
 func TestWrite_preservesVCS(t *testing.T) {
-dir := t.TempDir()
-cfg := &config.AgentctlConfig{
-VCS: config.VCSConfig{
-Provider: "gitlab",
-Server:   "https://gitlab.company.com",
-},
-}
-if err := config.Write(dir, cfg); err != nil {
-t.Fatalf("Write error: %v", err)
-}
-got, err := config.Read(dir)
-if err != nil {
-t.Fatal(err)
-}
-if got.VCS.Provider != "gitlab" {
-t.Errorf("VCS.Provider = %q, want %q", got.VCS.Provider, "gitlab")
-}
-if got.VCS.Server != "https://gitlab.company.com" {
-t.Errorf("VCS.Server = %q, want %q", got.VCS.Server, "https://gitlab.company.com")
-}
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{
+		VCS: config.VCSConfig{
+			Provider: "gitlab",
+			Server:   "https://gitlab.company.com",
+		},
+	}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	got, err := config.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.VCS.Provider != "gitlab" {
+		t.Errorf("VCS.Provider = %q, want %q", got.VCS.Provider, "gitlab")
+	}
+	if got.VCS.Server != "https://gitlab.company.com" {
+		t.Errorf("VCS.Server = %q, want %q", got.VCS.Server, "https://gitlab.company.com")
+	}
 }

--- a/internal/vcs/detect.go
+++ b/internal/vcs/detect.go
@@ -16,7 +16,7 @@ import (
 //  2. git origin URL — github.com variants → GitHub, gitlab.com variants → GitLab
 //
 // Returns an error when the origin matches neither provider and no config
-// override is present.  When there is no origin at all, GitHub is returned
+// override is present. When there is no origin at all, GitHub is returned
 // for backward compatibility with local-only repos.
 func Detect(repoRoot string) (Provider, error) {
 	// Config file override takes priority.
@@ -106,7 +106,7 @@ func ParseIssueURL(arg string) (owner, repo, issueNum, providerName string, ok b
 		if len(parts) < 5 {
 			return "", "", arg, "", false
 		}
-		// Locate the "/-/issues/<num>" segment.  We start at index 2 so there
+		// Locate the "/-/issues/<num>" segment. We start at index 2 so there
 		// are always at least two path components (owner + repo) before the dash.
 		dashIdx := -1
 		for i := 2; i < len(parts)-2; i++ {

--- a/internal/vcs/detect.go
+++ b/internal/vcs/detect.go
@@ -1,0 +1,114 @@
+package vcs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/arun-gupta/agentctl/internal/config"
+	"github.com/arun-gupta/agentctl/internal/git"
+)
+
+// Detect returns the Provider for the repository at repoRoot.
+//
+// Detection order:
+//  1. vcs.provider in .agentctl.yml (explicit override, useful for self-hosted instances)
+//  2. git origin URL — github.com variants → GitHub, gitlab.com variants → GitLab
+//
+// Returns an error when the origin matches neither provider and no config
+// override is present.
+func Detect(repoRoot string) (Provider, error) {
+	// Config file override takes priority.
+	if cfg, err := config.Read(repoRoot); err == nil && cfg.VCS.Provider != "" {
+		switch strings.ToLower(cfg.VCS.Provider) {
+		case "github":
+			return githubProvider{}, nil
+		case "gitlab":
+			return gitlabProvider{}, nil
+		default:
+			return nil, fmt.Errorf("unknown vcs provider %q in .agentctl.yml; valid values: github, gitlab", cfg.VCS.Provider)
+		}
+	}
+
+	u, err := git.OriginURL(repoRoot)
+	if err != nil {
+		// No origin remote; fall back to GitHub for backward compatibility.
+		return githubProvider{}, nil
+	}
+	u = strings.TrimSuffix(strings.TrimSpace(u), ".git")
+
+	switch {
+	case strings.HasPrefix(u, "https://github.com/"),
+		strings.HasPrefix(u, "git@github.com:"),
+		strings.HasPrefix(u, "ssh://git@github.com/"):
+		return githubProvider{}, nil
+	case strings.HasPrefix(u, "https://gitlab.com/"),
+		strings.HasPrefix(u, "git@gitlab.com:"),
+		strings.HasPrefix(u, "ssh://git@gitlab.com/"):
+		return gitlabProvider{}, nil
+	default:
+		// Unknown origin — fall back to GitHub for backward compatibility.
+		return githubProvider{}, nil
+	}
+}
+
+// MatchesOrigin reports whether the "origin" remote of repoRoot points to
+// owner/repoName on any recognised remote for provider p. Both HTTPS and
+// SSH URL formats are handled; a trailing ".git" suffix is ignored.
+func MatchesOrigin(repoRoot, owner, repoName string, p Provider) bool {
+	u, err := git.OriginURL(repoRoot)
+	if err != nil {
+		return false
+	}
+	u = strings.TrimSuffix(u, ".git")
+	suffix := owner + "/" + repoName
+	return strings.HasSuffix(u, "/"+suffix) || strings.HasSuffix(u, ":"+suffix)
+}
+
+// ParseIssueURL parses a full GitHub or GitLab issue URL and returns the
+// owner, repo, issue number, and provider name ("github" or "gitlab").
+//
+// Supported formats:
+//   - https://github.com/<owner>/<repo>/issues/<num>
+//   - https://gitlab.com/<owner>/<repo>/-/issues/<num>
+func ParseIssueURL(arg string) (owner, repo, issueNum, providerName string, ok bool) {
+	switch {
+	case strings.HasPrefix(arg, "https://github.com/"):
+		tail := strings.TrimSuffix(strings.TrimPrefix(arg, "https://github.com/"), "/")
+		parts := strings.Split(tail, "/")
+		if len(parts) != 4 || parts[2] != "issues" {
+			return "", "", arg, "", false
+		}
+		if _, err := strconv.Atoi(parts[3]); err != nil {
+			return "", "", arg, "", false
+		}
+		return parts[0], parts[1], parts[3], "github", true
+
+	case strings.HasPrefix(arg, "https://gitlab.com/"):
+		tail := strings.TrimSuffix(strings.TrimPrefix(arg, "https://gitlab.com/"), "/")
+		parts := strings.Split(tail, "/")
+		// Expected: owner / repo / - / issues / num  (5 parts)
+		if len(parts) != 5 || parts[2] != "-" || parts[3] != "issues" {
+			return "", "", arg, "", false
+		}
+		if _, err := strconv.Atoi(parts[4]); err != nil {
+			return "", "", arg, "", false
+		}
+		return parts[0], parts[1], parts[4], "gitlab", true
+	}
+	return "", "", arg, "", false
+}
+
+// ProviderForName returns the provider implementation for a provider name
+// ("github" or "gitlab"). Used when the provider is known from a URL parse
+// result before a repoRoot is available.
+func ProviderForName(name string) (Provider, error) {
+	switch strings.ToLower(name) {
+	case "github":
+		return githubProvider{}, nil
+	case "gitlab":
+		return gitlabProvider{}, nil
+	default:
+		return nil, fmt.Errorf("unknown vcs provider %q; valid values: github, gitlab", name)
+	}
+}

--- a/internal/vcs/detect.go
+++ b/internal/vcs/detect.go
@@ -16,15 +16,16 @@ import (
 //  2. git origin URL — github.com variants → GitHub, gitlab.com variants → GitLab
 //
 // Returns an error when the origin matches neither provider and no config
-// override is present.
+// override is present.  When there is no origin at all, GitHub is returned
+// for backward compatibility with local-only repos.
 func Detect(repoRoot string) (Provider, error) {
 	// Config file override takes priority.
 	if cfg, err := config.Read(repoRoot); err == nil && cfg.VCS.Provider != "" {
 		switch strings.ToLower(cfg.VCS.Provider) {
 		case "github":
-			return githubProvider{}, nil
+			return githubProvider{server: cfg.VCS.Server}, nil
 		case "gitlab":
-			return gitlabProvider{}, nil
+			return gitlabProvider{server: cfg.VCS.Server}, nil
 		default:
 			return nil, fmt.Errorf("unknown vcs provider %q in .agentctl.yml; valid values: github, gitlab", cfg.VCS.Provider)
 		}
@@ -32,7 +33,8 @@ func Detect(repoRoot string) (Provider, error) {
 
 	u, err := git.OriginURL(repoRoot)
 	if err != nil {
-		// No origin remote; fall back to GitHub for backward compatibility.
+		// No origin remote; fall back to GitHub for backward compatibility
+		// with repos that have no remote (e.g. local-only development).
 		return githubProvider{}, nil
 	}
 	u = strings.TrimSuffix(strings.TrimSpace(u), ".git")
@@ -47,22 +49,29 @@ func Detect(repoRoot string) (Provider, error) {
 		strings.HasPrefix(u, "ssh://git@gitlab.com/"):
 		return gitlabProvider{}, nil
 	default:
-		// Unknown origin — fall back to GitHub for backward compatibility.
-		return githubProvider{}, nil
+		// Unknown origin with no config override: surface an error instead of
+		// silently using gh, which would produce confusing auth/lookup failures.
+		return nil, fmt.Errorf("could not detect VCS provider from origin %q; set vcs.provider in .agentctl.yml (valid values: github, gitlab)", u)
 	}
 }
 
 // MatchesOrigin reports whether the "origin" remote of repoRoot points to
 // owner/repoName on any recognised remote for provider p. Both HTTPS and
 // SSH URL formats are handled; a trailing ".git" suffix is ignored.
+// The provider's host is also checked to prevent cross-provider false positives
+// (e.g. a GitLab issue URL matching an adjacent GitHub clone with the same path).
 func MatchesOrigin(repoRoot, owner, repoName string, p Provider) bool {
 	u, err := git.OriginURL(repoRoot)
 	if err != nil {
 		return false
 	}
-	u = strings.TrimSuffix(u, ".git")
+	u = strings.TrimSuffix(strings.TrimSpace(u), ".git")
 	suffix := owner + "/" + repoName
-	return strings.HasSuffix(u, "/"+suffix) || strings.HasSuffix(u, ":"+suffix)
+	if !(strings.HasSuffix(u, "/"+suffix) || strings.HasSuffix(u, ":"+suffix)) {
+		return false
+	}
+	// Also verify the origin URL belongs to this provider's hosting domain.
+	return p.MatchesHost(u)
 }
 
 // ParseIssueURL parses a full GitHub or GitLab issue URL and returns the
@@ -70,7 +79,10 @@ func MatchesOrigin(repoRoot, owner, repoName string, p Provider) bool {
 //
 // Supported formats:
 //   - https://github.com/<owner>/<repo>/issues/<num>
-//   - https://gitlab.com/<owner>/<repo>/-/issues/<num>
+//   - https://gitlab.com/<groups...>/<repo>/-/issues/<num>
+//
+// GitLab supports nested groups: owner may be "group/subgroup" for a project
+// hosted under a GitLab group hierarchy.
 func ParseIssueURL(arg string) (owner, repo, issueNum, providerName string, ok bool) {
 	switch {
 	case strings.HasPrefix(arg, "https://github.com/"):
@@ -87,14 +99,33 @@ func ParseIssueURL(arg string) (owner, repo, issueNum, providerName string, ok b
 	case strings.HasPrefix(arg, "https://gitlab.com/"):
 		tail := strings.TrimSuffix(strings.TrimPrefix(arg, "https://gitlab.com/"), "/")
 		parts := strings.Split(tail, "/")
-		// Expected: owner / repo / - / issues / num  (5 parts)
-		if len(parts) != 5 || parts[2] != "-" || parts[3] != "issues" {
+		// GitLab issue URLs follow the pattern:
+		//   <groups...>/<repo>/-/issues/<num>
+		// where there must be at least one group and one repo before "/-/",
+		// giving a minimum of 5 parts: owner/repo/-/issues/num.
+		if len(parts) < 5 {
 			return "", "", arg, "", false
 		}
-		if _, err := strconv.Atoi(parts[4]); err != nil {
+		// Locate the "/-/issues/<num>" segment.  We start at index 2 so there
+		// are always at least two path components (owner + repo) before the dash.
+		dashIdx := -1
+		for i := 2; i < len(parts)-2; i++ {
+			if parts[i] == "-" && parts[i+1] == "issues" {
+				dashIdx = i
+				break
+			}
+		}
+		if dashIdx == -1 {
 			return "", "", arg, "", false
 		}
-		return parts[0], parts[1], parts[4], "gitlab", true
+		numStr := parts[dashIdx+2]
+		if _, err := strconv.Atoi(numStr); err != nil {
+			return "", "", arg, "", false
+		}
+		// repo = segment immediately before "/-/"; owner = everything before it.
+		repoSeg := parts[dashIdx-1]
+		ownerSeg := strings.Join(parts[:dashIdx-1], "/")
+		return ownerSeg, repoSeg, numStr, "gitlab", true
 	}
 	return "", "", arg, "", false
 }

--- a/internal/vcs/github.go
+++ b/internal/vcs/github.go
@@ -14,13 +14,40 @@ import (
 )
 
 // githubProvider implements Provider using the gh CLI.
-type githubProvider struct{}
+type githubProvider struct {
+	// server is the base URL for a self-hosted GitHub Enterprise instance.
+	// When empty, github.com is used.
+	server string
+}
 
 // compile-time interface check
 var _ Provider = githubProvider{}
 
-func (g githubProvider) CLI() string  { return "gh" }
-func (g githubProvider) PRTerm() string { return "PR" }
+func (g githubProvider) CLI() string      { return "gh" }
+func (g githubProvider) PRTerm() string   { return "PR" }
+func (g githubProvider) Platform() string { return "GitHub" }
+
+// baseURL returns the HTTPS base URL for this provider instance.
+func (g githubProvider) baseURL() string {
+	if g.server != "" {
+		return strings.TrimRight(g.server, "/")
+	}
+	return "https://github.com"
+}
+
+// MatchesHost reports whether originURL belongs to the GitHub hosting domain
+// (or the configured self-hosted GitHub Enterprise server).
+// When a custom server is configured only that server's URL is accepted; the
+// canonical github.com host is not matched to prevent cross-instance confusion.
+func (g githubProvider) MatchesHost(u string) bool {
+	if g.server != "" {
+		base := strings.TrimRight(g.server, "/")
+		return strings.HasPrefix(u, base+"/")
+	}
+	return strings.HasPrefix(u, "https://github.com/") ||
+		strings.HasPrefix(u, "git@github.com:") ||
+		strings.HasPrefix(u, "ssh://git@github.com/")
+}
 
 func (g githubProvider) AuthCheck() error {
 	if os.Getenv("GITHUB_TOKEN") != "" {
@@ -68,16 +95,20 @@ func (g githubProvider) IssueURL(repoRoot, issueNum string) string {
 		return ""
 	}
 	u = strings.TrimSuffix(strings.TrimSpace(u), ".git")
-	if strings.HasPrefix(u, "https://github.com/") {
+	base := g.baseURL()
+	if strings.HasPrefix(u, base+"/") {
 		return u + "/issues/" + issueNum
 	}
-	const sshPrefix = "git@github.com:"
-	if strings.HasPrefix(u, sshPrefix) {
-		return "https://github.com/" + strings.TrimPrefix(u, sshPrefix) + "/issues/" + issueNum
-	}
-	const sshURLPrefix = "ssh://git@github.com/"
-	if strings.HasPrefix(u, sshURLPrefix) {
-		return "https://github.com/" + strings.TrimPrefix(u, sshURLPrefix) + "/issues/" + issueNum
+	if g.server == "" {
+		// Canonical github.com SSH forms.
+		const sshPrefix = "git@github.com:"
+		if strings.HasPrefix(u, sshPrefix) {
+			return "https://github.com/" + strings.TrimPrefix(u, sshPrefix) + "/issues/" + issueNum
+		}
+		const sshURLPrefix = "ssh://git@github.com/"
+		if strings.HasPrefix(u, sshURLPrefix) {
+			return "https://github.com/" + strings.TrimPrefix(u, sshURLPrefix) + "/issues/" + issueNum
+		}
 	}
 	return ""
 }
@@ -152,6 +183,26 @@ func (g githubProvider) EditPRBody(repoRoot string, number int, body string) err
 		return fmt.Errorf("gh pr edit: %w: %s", err, strings.TrimSpace(errBuf.String()))
 	}
 	return nil
+}
+
+func (g githubProvider) FetchPRDetails(repoRoot, ref string) (number int, body, url string, err error) {
+	cmd := exec.Command("gh", "pr", "view", ref, "--json", "number,body,url")
+	cmd.Dir = repoRoot
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err = cmd.Run(); err != nil {
+		return 0, "", "", fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	var result struct {
+		Number int    `json:"number"`
+		Body   string `json:"body"`
+		URL    string `json:"url"`
+	}
+	if err = json.Unmarshal(out.Bytes(), &result); err != nil {
+		return 0, "", "", fmt.Errorf("gh pr view: unexpected output: %w", err)
+	}
+	return result.Number, result.Body, result.URL, nil
 }
 
 func (g githubProvider) MergePR(repoRoot, branch, strategy string) error {

--- a/internal/vcs/github.go
+++ b/internal/vcs/github.go
@@ -1,0 +1,186 @@
+package vcs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/arun-gupta/agentctl/internal/git"
+)
+
+// githubProvider implements Provider using the gh CLI.
+type githubProvider struct{}
+
+// compile-time interface check
+var _ Provider = githubProvider{}
+
+func (g githubProvider) CLI() string  { return "gh" }
+func (g githubProvider) PRTerm() string { return "PR" }
+
+func (g githubProvider) AuthCheck() error {
+	if os.Getenv("GITHUB_TOKEN") != "" {
+		return nil
+	}
+	if tok := os.Getenv("GH_TOKEN"); tok != "" {
+		os.Setenv("GITHUB_TOKEN", tok)
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("gh", "auth", "token")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		if tok := strings.TrimSpace(stdout.String()); tok != "" {
+			os.Setenv("GITHUB_TOKEN", tok)
+			return nil
+		}
+	}
+	msg := "GITHUB_TOKEN is not set\n\nSet it in your current shell (or shell profile) and re-run:\n  export GITHUB_TOKEN=<your-token>\n\nBoth GITHUB_TOKEN and GH_TOKEN are accepted. To obtain a token, run:\n  gh auth token"
+	if ghErr := strings.TrimSpace(stderr.String()); ghErr != "" {
+		msg += "\n\n`gh auth token` reported: " + ghErr
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+func (g githubProvider) FetchIssueTitle(issueArg string) (string, error) {
+	cmd := exec.Command("gh", "issue", "view", issueArg, "--json", "title", "-q", ".title")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("could not fetch title for issue %s; pass a slug explicitly", issueArg)
+	}
+	title := strings.TrimSpace(out.String())
+	if title == "" {
+		return "", fmt.Errorf("could not fetch title for issue %s; pass a slug explicitly", issueArg)
+	}
+	return title, nil
+}
+
+func (g githubProvider) IssueURL(repoRoot, issueNum string) string {
+	u, err := git.OriginURL(repoRoot)
+	if err != nil {
+		return ""
+	}
+	u = strings.TrimSuffix(strings.TrimSpace(u), ".git")
+	if strings.HasPrefix(u, "https://github.com/") {
+		return u + "/issues/" + issueNum
+	}
+	const sshPrefix = "git@github.com:"
+	if strings.HasPrefix(u, sshPrefix) {
+		return "https://github.com/" + strings.TrimPrefix(u, sshPrefix) + "/issues/" + issueNum
+	}
+	const sshURLPrefix = "ssh://git@github.com/"
+	if strings.HasPrefix(u, sshURLPrefix) {
+		return "https://github.com/" + strings.TrimPrefix(u, sshURLPrefix) + "/issues/" + issueNum
+	}
+	return ""
+}
+
+func (g githubProvider) PRForBranch(repoRoot, ref string) (prState string, number int, url string, err error) {
+	cmd := exec.Command("gh", "pr", "view", ref, "--json", "state,number,url")
+	cmd.Dir = repoRoot
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err = cmd.Run(); err != nil {
+		return "", 0, "", fmt.Errorf("%w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	var result struct {
+		State  string `json:"state"`
+		Number int    `json:"number"`
+		URL    string `json:"url"`
+	}
+	if err = json.Unmarshal(out.Bytes(), &result); err != nil {
+		snippet := strings.TrimSpace(out.String())
+		runes := []rune(snippet)
+		if len(runes) > 200 {
+			snippet = string(runes[:200]) + "..."
+		}
+		return "", 0, "", fmt.Errorf("unexpected gh output: %w (output: %q)", err, snippet)
+	}
+	return result.State, result.Number, result.URL, nil
+}
+
+func (g githubProvider) HasPR(repoRoot, branch string) (bool, error) {
+	cmd := exec.Command("gh", "pr", "list", "--head", branch, "--state", "all", "--json", "number")
+	cmd.Dir = repoRoot
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	return strings.TrimSpace(out.String()) != "[]", nil
+}
+
+func (g githubProvider) PRMergeInfo(repoRoot, branch string) (prState, mergeable, reviewDecision string, err error) {
+	cmd := exec.Command("gh", "pr", "view", branch,
+		"--json", "state,mergeable,reviewDecision",
+		"-q", ".state+\" \"+.mergeable+\" \"+.reviewDecision")
+	cmd.Dir = repoRoot
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", "", "", fmt.Errorf("%s", strings.TrimSpace(errBuf.String()))
+	}
+	parts := strings.Fields(strings.TrimSpace(out.String()))
+	if len(parts) >= 3 {
+		return parts[0], parts[1], parts[2], nil
+	}
+	if len(parts) >= 2 {
+		return parts[0], parts[1], "", nil
+	}
+	if len(parts) == 1 {
+		return parts[0], "", "", nil
+	}
+	return "", "", "", nil
+}
+
+func (g githubProvider) EditPRBody(repoRoot string, number int, body string) error {
+	cmd := exec.Command("gh", "pr", "edit", strconv.Itoa(number), "--body", body)
+	cmd.Dir = repoRoot
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh pr edit: %w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	return nil
+}
+
+func (g githubProvider) MergePR(repoRoot, branch, strategy string) error {
+	args := []string{"pr", "merge", branch, "--yes"}
+	switch strategy {
+	case "squash":
+		args = append(args, "--squash")
+	case "merge":
+		args = append(args, "--merge")
+	case "rebase":
+		args = append(args, "--rebase")
+	}
+	cmd := exec.Command("gh", args...)
+	cmd.Dir = repoRoot
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func (g githubProvider) Clone(ownerRepo, targetDir string, out io.Writer) error {
+	cmd := exec.Command("gh", "repo", "clone", ownerRepo, targetDir)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh repo clone %s: %w", ownerRepo, err)
+	}
+	return nil
+}

--- a/internal/vcs/github.go
+++ b/internal/vcs/github.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -50,28 +49,7 @@ func (g githubProvider) MatchesHost(u string) bool {
 }
 
 func (g githubProvider) AuthCheck() error {
-	if os.Getenv("GITHUB_TOKEN") != "" {
-		return nil
-	}
-	if tok := os.Getenv("GH_TOKEN"); tok != "" {
-		os.Setenv("GITHUB_TOKEN", tok)
-		return nil
-	}
-	var stdout, stderr bytes.Buffer
-	cmd := exec.Command("gh", "auth", "token")
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err == nil {
-		if tok := strings.TrimSpace(stdout.String()); tok != "" {
-			os.Setenv("GITHUB_TOKEN", tok)
-			return nil
-		}
-	}
-	msg := "GITHUB_TOKEN is not set\n\nSet it in your current shell (or shell profile) and re-run:\n  export GITHUB_TOKEN=<your-token>\n\nBoth GITHUB_TOKEN and GH_TOKEN are accepted. To obtain a token, run:\n  gh auth token"
-	if ghErr := strings.TrimSpace(stderr.String()); ghErr != "" {
-		msg += "\n\n`gh auth token` reported: " + ghErr
-	}
-	return fmt.Errorf("%s", msg)
+	return authCheckFromCLI("GITHUB_TOKEN", "GH_TOKEN", "gh")
 }
 
 func (g githubProvider) FetchIssueTitle(issueArg string) (string, error) {

--- a/internal/vcs/gitlab.go
+++ b/internal/vcs/gitlab.go
@@ -174,7 +174,7 @@ func (g gitlabProvider) prView(repoRoot, ref string) (*glabMRJSON, error) {
 
 // prByBranch looks up the MR for a source branch name across all states.
 func (g gitlabProvider) prByBranch(repoRoot, branch string) (*glabMRJSON, error) {
-	cmd := exec.Command("glab", "mr", "list", "--source-branch", branch, "--state", "all", "--output", "json")
+	cmd := exec.Command("glab", "mr", "list", "--source-branch", branch, "--all", "--output", "json")
 	cmd.Dir = repoRoot
 	var out, errBuf bytes.Buffer
 	cmd.Stdout = &out

--- a/internal/vcs/gitlab.go
+++ b/internal/vcs/gitlab.go
@@ -1,0 +1,214 @@
+package vcs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/arun-gupta/agentctl/internal/git"
+)
+
+// gitlabProvider implements Provider using the glab CLI.
+type gitlabProvider struct{}
+
+// compile-time interface check
+var _ Provider = gitlabProvider{}
+
+func (g gitlabProvider) CLI() string   { return "glab" }
+func (g gitlabProvider) PRTerm() string { return "MR" }
+
+func (g gitlabProvider) AuthCheck() error {
+	if os.Getenv("GITLAB_TOKEN") != "" {
+		return nil
+	}
+	if tok := os.Getenv("GL_TOKEN"); tok != "" {
+		os.Setenv("GITLAB_TOKEN", tok)
+		return nil
+	}
+	var stderr bytes.Buffer
+	cmd := exec.Command("glab", "auth", "status")
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		return nil
+	}
+	msg := "GITLAB_TOKEN is not set and glab is not authenticated\n\nSet it in your current shell (or shell profile) and re-run:\n  export GITLAB_TOKEN=<your-token>\n\nBoth GITLAB_TOKEN and GL_TOKEN are accepted. To authenticate via glab, run:\n  glab auth login"
+	if glErr := strings.TrimSpace(stderr.String()); glErr != "" {
+		msg += "\n\n`glab auth status` reported: " + glErr
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+func (g gitlabProvider) FetchIssueTitle(issueArg string) (string, error) {
+	// glab issue view accepts a bare number; for full URLs extract the number first.
+	num := issueArg
+	if _, _, n, _, ok := ParseIssueURL(issueArg); ok {
+		num = n
+	}
+	cmd := exec.Command("glab", "issue", "view", num, "--output", "json")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &bytes.Buffer{}
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("could not fetch title for issue %s; pass a slug explicitly", issueArg)
+	}
+	var result struct {
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil || result.Title == "" {
+		return "", fmt.Errorf("could not fetch title for issue %s; pass a slug explicitly", issueArg)
+	}
+	return result.Title, nil
+}
+
+func (g gitlabProvider) IssueURL(repoRoot, issueNum string) string {
+	u, err := git.OriginURL(repoRoot)
+	if err != nil {
+		return ""
+	}
+	u = strings.TrimSuffix(strings.TrimSpace(u), ".git")
+	if strings.HasPrefix(u, "https://gitlab.com/") {
+		return u + "/-/issues/" + issueNum
+	}
+	const sshPrefix = "git@gitlab.com:"
+	if strings.HasPrefix(u, sshPrefix) {
+		return "https://gitlab.com/" + strings.TrimPrefix(u, sshPrefix) + "/-/issues/" + issueNum
+	}
+	const sshURLPrefix = "ssh://git@gitlab.com/"
+	if strings.HasPrefix(u, sshURLPrefix) {
+		return "https://gitlab.com/" + strings.TrimPrefix(u, sshURLPrefix) + "/-/issues/" + issueNum
+	}
+	return ""
+}
+
+// glabMRJSON is the subset of fields returned by `glab mr view --output json`.
+type glabMRJSON struct {
+	State  string `json:"state"`  // "opened", "closed", "merged"
+	IID    int    `json:"iid"`    // MR number within project
+	WebURL string `json:"web_url"`
+	// merge_status: "can_be_merged", "cannot_be_merged", "unchecked", etc.
+	MergeStatus string `json:"merge_status"`
+}
+
+// glabStateToGH converts a GitLab MR state string to the GitHub-equivalent
+// uppercase state used throughout agentctl ("OPEN", "MERGED", "CLOSED").
+func glabStateToGH(state string) string {
+	switch strings.ToLower(state) {
+	case "opened":
+		return "OPEN"
+	case "merged":
+		return "MERGED"
+	case "closed":
+		return "CLOSED"
+	default:
+		return strings.ToUpper(state)
+	}
+}
+
+// glabMergeStatusToGH converts a GitLab merge_status to the GitHub-equivalent
+// mergeable string ("MERGEABLE", "CONFLICTING", "UNKNOWN").
+func glabMergeStatusToGH(status string) string {
+	switch strings.ToLower(status) {
+	case "can_be_merged":
+		return "MERGEABLE"
+	case "cannot_be_merged":
+		return "CONFLICTING"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func (g gitlabProvider) prView(repoRoot, ref string) (*glabMRJSON, error) {
+	cmd := exec.Command("glab", "mr", "view", ref, "--output", "json")
+	cmd.Dir = repoRoot
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	var mr glabMRJSON
+	if err := json.Unmarshal(out.Bytes(), &mr); err != nil {
+		snippet := strings.TrimSpace(out.String())
+		runes := []rune(snippet)
+		if len(runes) > 200 {
+			snippet = string(runes[:200]) + "..."
+		}
+		return nil, fmt.Errorf("unexpected glab output: %w (output: %q)", err, snippet)
+	}
+	return &mr, nil
+}
+
+func (g gitlabProvider) PRForBranch(repoRoot, ref string) (prState string, number int, url string, err error) {
+	mr, err := g.prView(repoRoot, ref)
+	if err != nil {
+		return "", 0, "", err
+	}
+	return glabStateToGH(mr.State), mr.IID, mr.WebURL, nil
+}
+
+func (g gitlabProvider) HasPR(repoRoot, branch string) (bool, error) {
+	// List MRs for the branch; --source-branch filters by source branch name.
+	cmd := exec.Command("glab", "mr", "list", "--source-branch", branch, "--output", "json")
+	cmd.Dir = repoRoot
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	return strings.TrimSpace(out.String()) != "[]", nil
+}
+
+func (g gitlabProvider) PRMergeInfo(repoRoot, branch string) (prState, mergeable, reviewDecision string, err error) {
+	mr, viewErr := g.prView(repoRoot, branch)
+	if viewErr != nil {
+		return "", "", "", viewErr
+	}
+	return glabStateToGH(mr.State), glabMergeStatusToGH(mr.MergeStatus), "", nil
+}
+
+func (g gitlabProvider) EditPRBody(repoRoot string, number int, body string) error {
+	cmd := exec.Command("glab", "mr", "update", strconv.Itoa(number), "--description", body)
+	cmd.Dir = repoRoot
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("glab mr update: %w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	return nil
+}
+
+func (g gitlabProvider) MergePR(repoRoot, branch, strategy string) error {
+	args := []string{"mr", "merge", branch, "--yes"}
+	switch strategy {
+	case "squash":
+		args = append(args, "--squash")
+	case "rebase":
+		args = append(args, "--rebase")
+	// GitLab's default merge is equivalent to GitHub's --merge; no extra flag needed.
+	}
+	cmd := exec.Command("glab", args...)
+	cmd.Dir = repoRoot
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(out.String()))
+	}
+	return nil
+}
+
+func (g gitlabProvider) Clone(ownerRepo, targetDir string, out io.Writer) error {
+	cmd := exec.Command("glab", "repo", "clone", ownerRepo, targetDir)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("glab repo clone %s: %w", ownerRepo, err)
+	}
+	return nil
+}

--- a/internal/vcs/gitlab.go
+++ b/internal/vcs/gitlab.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -56,24 +55,7 @@ func (g gitlabProvider) MatchesHost(u string) bool {
 }
 
 func (g gitlabProvider) AuthCheck() error {
-	if os.Getenv("GITLAB_TOKEN") != "" {
-		return nil
-	}
-	if tok := os.Getenv("GL_TOKEN"); tok != "" {
-		os.Setenv("GITLAB_TOKEN", tok)
-		return nil
-	}
-	var stderr bytes.Buffer
-	cmd := exec.Command("glab", "auth", "status")
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err == nil {
-		return nil
-	}
-	msg := "GITLAB_TOKEN is not set and glab is not authenticated\n\nSet it in your current shell (or shell profile) and re-run:\n  export GITLAB_TOKEN=<your-token>\n\nBoth GITLAB_TOKEN and GL_TOKEN are accepted. To authenticate via glab, run:\n  glab auth login"
-	if glErr := strings.TrimSpace(stderr.String()); glErr != "" {
-		msg += "\n\n`glab auth status` reported: " + glErr
-	}
-	return fmt.Errorf("%s", msg)
+	return authCheckFromCLI("GITLAB_TOKEN", "GL_TOKEN", "glab")
 }
 
 func (g gitlabProvider) FetchIssueTitle(issueArg string) (string, error) {

--- a/internal/vcs/gitlab.go
+++ b/internal/vcs/gitlab.go
@@ -147,6 +147,11 @@ func glabMergeStatusToGH(status string) string {
 }
 
 func (g gitlabProvider) prView(repoRoot, ref string) (*glabMRJSON, error) {
+	// glab mr view only accepts an MR number, not a branch name.
+	// When ref is not a number, resolve it to an MR via mr list --source-branch.
+	if _, err := strconv.Atoi(ref); err != nil {
+		return g.prByBranch(repoRoot, ref)
+	}
 	cmd := exec.Command("glab", "mr", "view", ref, "--output", "json")
 	cmd.Dir = repoRoot
 	var out, errBuf bytes.Buffer
@@ -165,6 +170,26 @@ func (g gitlabProvider) prView(repoRoot, ref string) (*glabMRJSON, error) {
 		return nil, fmt.Errorf("unexpected glab output: %w (output: %q)", err, snippet)
 	}
 	return &mr, nil
+}
+
+// prByBranch looks up the MR for a source branch name across all states.
+func (g gitlabProvider) prByBranch(repoRoot, branch string) (*glabMRJSON, error) {
+	cmd := exec.Command("glab", "mr", "list", "--source-branch", branch, "--state", "all", "--output", "json")
+	cmd.Dir = repoRoot
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("%w: %s", err, strings.TrimSpace(errBuf.String()))
+	}
+	var mrs []glabMRJSON
+	if err := json.Unmarshal(out.Bytes(), &mrs); err != nil {
+		return nil, fmt.Errorf("unexpected glab output: %w", err)
+	}
+	if len(mrs) == 0 {
+		return nil, fmt.Errorf("no MR found for branch %s", branch)
+	}
+	return &mrs[0], nil
 }
 
 func (g gitlabProvider) PRForBranch(repoRoot, ref string) (prState string, number int, url string, err error) {

--- a/internal/vcs/gitlab.go
+++ b/internal/vcs/gitlab.go
@@ -14,13 +14,46 @@ import (
 )
 
 // gitlabProvider implements Provider using the glab CLI.
-type gitlabProvider struct{}
+type gitlabProvider struct {
+	// server is the base URL for a self-hosted GitLab instance.
+	// When empty, gitlab.com is used.
+	server string
+}
 
 // compile-time interface check
 var _ Provider = gitlabProvider{}
 
-func (g gitlabProvider) CLI() string   { return "glab" }
-func (g gitlabProvider) PRTerm() string { return "MR" }
+func (g gitlabProvider) CLI() string      { return "glab" }
+func (g gitlabProvider) PRTerm() string   { return "MR" }
+func (g gitlabProvider) Platform() string { return "GitLab" }
+
+// baseURL returns the HTTPS base URL for this provider instance.
+func (g gitlabProvider) baseURL() string {
+	if g.server != "" {
+		return strings.TrimRight(g.server, "/")
+	}
+	return "https://gitlab.com"
+}
+
+// MatchesHost reports whether originURL belongs to the GitLab hosting domain
+// (or the configured self-hosted GitLab server).
+// When a custom server is configured only that server's URL is accepted; the
+// canonical gitlab.com host is not matched to prevent cross-instance confusion.
+func (g gitlabProvider) MatchesHost(u string) bool {
+	if g.server != "" {
+		base := strings.TrimRight(g.server, "/")
+		if strings.HasPrefix(u, base+"/") {
+			return true
+		}
+		// Also accept SSH form of the server host.
+		host := strings.TrimPrefix(strings.TrimPrefix(base, "https://"), "http://")
+		host = strings.SplitN(host, "/", 2)[0]
+		return strings.HasPrefix(u, "git@"+host+":") || strings.HasPrefix(u, "ssh://git@"+host+"/")
+	}
+	return strings.HasPrefix(u, "https://gitlab.com/") ||
+		strings.HasPrefix(u, "git@gitlab.com:") ||
+		strings.HasPrefix(u, "ssh://git@gitlab.com/")
+}
 
 func (g gitlabProvider) AuthCheck() error {
 	if os.Getenv("GITLAB_TOKEN") != "" {
@@ -44,12 +77,16 @@ func (g gitlabProvider) AuthCheck() error {
 }
 
 func (g gitlabProvider) FetchIssueTitle(issueArg string) (string, error) {
-	// glab issue view accepts a bare number; for full URLs extract the number first.
+	// glab issue view accepts a bare number with an optional --repo flag.
+	// For full URLs, extract the owner/repo and number so the command runs
+	// against the correct project regardless of the caller's working directory.
 	num := issueArg
-	if _, _, n, _, ok := ParseIssueURL(issueArg); ok {
+	args := []string{"issue", "view", num, "--output", "json"}
+	if owner, repo, n, _, ok := ParseIssueURL(issueArg); ok {
 		num = n
+		args = []string{"issue", "view", num, "--repo", owner + "/" + repo, "--output", "json"}
 	}
-	cmd := exec.Command("glab", "issue", "view", num, "--output", "json")
+	cmd := exec.Command("glab", args...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &bytes.Buffer{}
@@ -71,16 +108,20 @@ func (g gitlabProvider) IssueURL(repoRoot, issueNum string) string {
 		return ""
 	}
 	u = strings.TrimSuffix(strings.TrimSpace(u), ".git")
-	if strings.HasPrefix(u, "https://gitlab.com/") {
+	base := g.baseURL()
+	if strings.HasPrefix(u, base+"/") {
 		return u + "/-/issues/" + issueNum
 	}
-	const sshPrefix = "git@gitlab.com:"
-	if strings.HasPrefix(u, sshPrefix) {
-		return "https://gitlab.com/" + strings.TrimPrefix(u, sshPrefix) + "/-/issues/" + issueNum
-	}
-	const sshURLPrefix = "ssh://git@gitlab.com/"
-	if strings.HasPrefix(u, sshURLPrefix) {
-		return "https://gitlab.com/" + strings.TrimPrefix(u, sshURLPrefix) + "/-/issues/" + issueNum
+	if g.server == "" {
+		// Canonical gitlab.com SSH forms.
+		const sshPrefix = "git@gitlab.com:"
+		if strings.HasPrefix(u, sshPrefix) {
+			return "https://gitlab.com/" + strings.TrimPrefix(u, sshPrefix) + "/-/issues/" + issueNum
+		}
+		const sshURLPrefix = "ssh://git@gitlab.com/"
+		if strings.HasPrefix(u, sshURLPrefix) {
+			return "https://gitlab.com/" + strings.TrimPrefix(u, sshURLPrefix) + "/-/issues/" + issueNum
+		}
 	}
 	return ""
 }
@@ -92,6 +133,7 @@ type glabMRJSON struct {
 	WebURL string `json:"web_url"`
 	// merge_status: "can_be_merged", "cannot_be_merged", "unchecked", etc.
 	MergeStatus string `json:"merge_status"`
+	Description string `json:"description"` // MR description / body
 }
 
 // glabStateToGH converts a GitLab MR state string to the GitHub-equivalent
@@ -181,6 +223,14 @@ func (g gitlabProvider) EditPRBody(repoRoot string, number int, body string) err
 		return fmt.Errorf("glab mr update: %w: %s", err, strings.TrimSpace(errBuf.String()))
 	}
 	return nil
+}
+
+func (g gitlabProvider) FetchPRDetails(repoRoot, ref string) (number int, body, url string, err error) {
+	mr, err := g.prView(repoRoot, ref)
+	if err != nil {
+		return 0, "", "", fmt.Errorf("glab mr view: %w", err)
+	}
+	return mr.IID, mr.Description, mr.WebURL, nil
 }
 
 func (g gitlabProvider) MergePR(repoRoot, branch, strategy string) error {

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -2,7 +2,44 @@
 // lifecycle works identically on GitHub and GitLab repositories.
 package vcs
 
-import "io"
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// authCheckFromCLI is the shared AuthCheck implementation for all providers.
+// It checks primaryEnv, then aliasEnv, then extracts a token via `cli auth token`.
+func authCheckFromCLI(primaryEnv, aliasEnv, cli string) error {
+	if os.Getenv(primaryEnv) != "" {
+		return nil
+	}
+	if tok := os.Getenv(aliasEnv); tok != "" {
+		os.Setenv(primaryEnv, tok)
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(cli, "auth", "token")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err == nil {
+		if tok := strings.TrimSpace(stdout.String()); tok != "" {
+			os.Setenv(primaryEnv, tok)
+			return nil
+		}
+	}
+	msg := fmt.Sprintf(
+		"%s is not set and %s is not authenticated\n\nSet it in your current shell (or shell profile) and re-run:\n  export %s=<your-token>\n\nBoth %s and %s are accepted. To authenticate via %s, run:\n  %s auth login",
+		primaryEnv, cli, primaryEnv, primaryEnv, aliasEnv, cli, cli,
+	)
+	if cliErr := strings.TrimSpace(stderr.String()); cliErr != "" {
+		msg += fmt.Sprintf("\n\n`%s auth token` reported: %s", cli, cliErr)
+	}
+	return fmt.Errorf("%s", msg)
+}
 
 // Provider wraps all provider-specific CLI calls used by agentctl commands.
 // Two concrete implementations exist: githubProvider (wraps gh) and

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -1,0 +1,53 @@
+// Package vcs abstracts VCS-provider-specific CLI calls so the full agentctl
+// lifecycle works identically on GitHub and GitLab repositories.
+package vcs
+
+import "io"
+
+// Provider wraps all provider-specific CLI calls used by agentctl commands.
+// Two concrete implementations exist: githubProvider (wraps gh) and
+// gitlabProvider (wraps glab). The active provider is resolved once per
+// command invocation via Detect.
+type Provider interface {
+	// FetchIssueTitle returns the title of the given issue. issueArg may be
+	// a bare number ("42") or a full issue URL; both are accepted by the
+	// underlying CLI.
+	FetchIssueTitle(issueArg string) (title string, err error)
+
+	// IssueURL builds the canonical issue URL from the git origin of repoRoot.
+	// Returns "" when the origin is not a recognised remote for this provider.
+	IssueURL(repoRoot, issueNum string) string
+
+	// PRForBranch returns the state, number, and URL of the PR/MR for ref.
+	// ref may be a branch name or a PR/MR number string.
+	// All values are zero on error.
+	PRForBranch(repoRoot, ref string) (prState string, number int, url string, err error)
+
+	// HasPR reports whether any PR/MR (open, closed, or merged) exists for branch.
+	// Returns (false, err) on auth/network failures so callers can be conservative.
+	HasPR(repoRoot, branch string) (bool, error)
+
+	// PRMergeInfo returns the PR/MR state, mergeability, and review decision.
+	PRMergeInfo(repoRoot, branch string) (prState, mergeable, reviewDecision string, err error)
+
+	// EditPRBody updates the body of the PR/MR identified by number in repoRoot.
+	EditPRBody(repoRoot string, number int, body string) error
+
+	// MergePR merges the PR/MR for branch using strategy (squash/merge/rebase).
+	MergePR(repoRoot, branch, strategy string) error
+
+	// AuthCheck verifies that a valid VCS credential is available in the
+	// current environment. It may set token environment variables as a
+	// side-effect (e.g. GITHUB_TOKEN, GITLAB_TOKEN).
+	AuthCheck() error
+
+	// Clone clones ownerRepo (e.g. "myorg/myrepo") into targetDir.
+	Clone(ownerRepo, targetDir string, out io.Writer) error
+
+	// CLI returns the CLI tool name ("gh" or "glab") for use in error messages.
+	CLI() string
+
+	// PRTerm returns the provider-appropriate term for a pull/merge request
+	// ("PR" for GitHub, "MR" for GitLab).
+	PRTerm() string
+}

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -23,6 +23,11 @@ type Provider interface {
 	// All values are zero on error.
 	PRForBranch(repoRoot, ref string) (prState string, number int, url string, err error)
 
+	// FetchPRDetails fetches the PR/MR number, description body, and URL for
+	// the branch or PR number identified by ref.  Used to add issue-closing
+	// keywords to the PR/MR body after the agent opens it.
+	FetchPRDetails(repoRoot, ref string) (number int, body, url string, err error)
+
 	// HasPR reports whether any PR/MR (open, closed, or merged) exists for branch.
 	// Returns (false, err) on auth/network failures so callers can be conservative.
 	HasPR(repoRoot, branch string) (bool, error)
@@ -47,7 +52,15 @@ type Provider interface {
 	// CLI returns the CLI tool name ("gh" or "glab") for use in error messages.
 	CLI() string
 
+	// Platform returns the human-readable VCS platform name ("GitHub" or "GitLab").
+	Platform() string
+
 	// PRTerm returns the provider-appropriate term for a pull/merge request
 	// ("PR" for GitHub, "MR" for GitLab).
 	PRTerm() string
+
+	// MatchesHost reports whether originURL belongs to this provider's hosting
+	// domain (or the configured self-hosted server).  Used by MatchesOrigin to
+	// prevent cross-provider false positives.
+	MatchesHost(originURL string) bool
 }

--- a/internal/vcs/vcs_test.go
+++ b/internal/vcs/vcs_test.go
@@ -1,0 +1,239 @@
+package vcs
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// initGitRepoWithOrigin creates a temp git repo with the given origin URL.
+func initGitRepoWithOrigin(t *testing.T, originURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"remote", "add", "origin", originURL},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+// ─── ParseIssueURL ───────────────────────────────────────────────────────────
+
+func TestParseIssueURL_bareNumber(t *testing.T) {
+	owner, repo, issueNum, prov, ok := ParseIssueURL("42")
+	if ok {
+		t.Error("ParseIssueURL(\"42\") should return ok=false")
+	}
+	if owner != "" || repo != "" || prov != "" {
+		t.Errorf("expected empty owner/repo/provider for bare number, got %q %q %q", owner, repo, prov)
+	}
+	if issueNum != "42" {
+		t.Errorf("issueNum = %q, want %q", issueNum, "42")
+	}
+}
+
+func TestParseIssueURL_github(t *testing.T) {
+	owner, repo, issueNum, prov, ok := ParseIssueURL("https://github.com/myorg/myrepo/issues/99")
+	if !ok {
+		t.Fatal("ParseIssueURL should return ok=true for a valid GitHub URL")
+	}
+	if owner != "myorg" {
+		t.Errorf("owner = %q, want %q", owner, "myorg")
+	}
+	if repo != "myrepo" {
+		t.Errorf("repo = %q, want %q", repo, "myrepo")
+	}
+	if issueNum != "99" {
+		t.Errorf("issueNum = %q, want %q", issueNum, "99")
+	}
+	if prov != "github" {
+		t.Errorf("provider = %q, want %q", prov, "github")
+	}
+}
+
+func TestParseIssueURL_githubTrailingSlash(t *testing.T) {
+	_, _, issueNum, prov, ok := ParseIssueURL("https://github.com/myorg/myrepo/issues/7/")
+	if !ok {
+		t.Fatal("trailing slash should be accepted")
+	}
+	if issueNum != "7" {
+		t.Errorf("issueNum = %q, want %q", issueNum, "7")
+	}
+	if prov != "github" {
+		t.Errorf("provider = %q, want %q", prov, "github")
+	}
+}
+
+func TestParseIssueURL_gitlab(t *testing.T) {
+	owner, repo, issueNum, prov, ok := ParseIssueURL("https://gitlab.com/myorg/myrepo/-/issues/42")
+	if !ok {
+		t.Fatal("ParseIssueURL should return ok=true for a valid GitLab URL")
+	}
+	if owner != "myorg" {
+		t.Errorf("owner = %q, want %q", owner, "myorg")
+	}
+	if repo != "myrepo" {
+		t.Errorf("repo = %q, want %q", repo, "myrepo")
+	}
+	if issueNum != "42" {
+		t.Errorf("issueNum = %q, want %q", issueNum, "42")
+	}
+	if prov != "gitlab" {
+		t.Errorf("provider = %q, want %q", prov, "gitlab")
+	}
+}
+
+func TestParseIssueURL_gitlabTrailingSlash(t *testing.T) {
+	_, _, issueNum, prov, ok := ParseIssueURL("https://gitlab.com/myorg/myrepo/-/issues/7/")
+	if !ok {
+		t.Fatal("trailing slash should be accepted for GitLab URL")
+	}
+	if issueNum != "7" {
+		t.Errorf("issueNum = %q, want %q", issueNum, "7")
+	}
+	if prov != "gitlab" {
+		t.Errorf("provider = %q, want %q", prov, "gitlab")
+	}
+}
+
+func TestParseIssueURL_invalidPaths(t *testing.T) {
+	cases := []string{
+		"https://github.com/myorg/myrepo/pull/42",      // pull request URL
+		"https://github.com/myorg/myrepo/issues/",      // missing number
+		"https://github.com/myorg/myrepo/issues/abc",   // non-numeric
+		"https://github.com/myorg/myrepo",              // no issues path
+		"https://gitlab.com/myorg/myrepo/issues/42",    // GitLab without /-/ separator
+		"https://gitlab.com/myorg/myrepo/-/issues/abc", // non-numeric
+		"https://example.com/owner/repo/issues/1",      // unknown host
+	}
+	for _, c := range cases {
+		_, _, _, _, ok := ParseIssueURL(c)
+		if ok {
+			t.Errorf("ParseIssueURL(%q) should return ok=false", c)
+		}
+	}
+}
+
+// ─── Detect ──────────────────────────────────────────────────────────────────
+
+func TestDetect_github_https(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://github.com/myorg/myrepo.git")
+	p, err := Detect(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.CLI() != "gh" {
+		t.Errorf("expected gh CLI for GitHub HTTPS origin, got %q", p.CLI())
+	}
+}
+
+func TestDetect_github_ssh(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "git@github.com:myorg/myrepo.git")
+	p, err := Detect(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.CLI() != "gh" {
+		t.Errorf("expected gh CLI for GitHub SSH origin, got %q", p.CLI())
+	}
+}
+
+func TestDetect_gitlab_https(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://gitlab.com/myorg/myrepo.git")
+	p, err := Detect(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.CLI() != "glab" {
+		t.Errorf("expected glab CLI for GitLab HTTPS origin, got %q", p.CLI())
+	}
+	if p.PRTerm() != "MR" {
+		t.Errorf("expected PRTerm=MR for GitLab, got %q", p.PRTerm())
+	}
+}
+
+func TestDetect_gitlab_ssh(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "git@gitlab.com:myorg/myrepo.git")
+	p, err := Detect(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.CLI() != "glab" {
+		t.Errorf("expected glab CLI for GitLab SSH origin, got %q", p.CLI())
+	}
+}
+
+func TestDetect_noOrigin_fallbackGitHub(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	p, err := Detect(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.CLI() != "gh" {
+		t.Errorf("expected gh CLI fallback when no origin, got %q", p.CLI())
+	}
+}
+
+func TestDetect_unknownOrigin_fallbackGitHub(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://bitbucket.org/myorg/myrepo.git")
+	p, err := Detect(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.CLI() != "gh" {
+		t.Errorf("expected gh CLI fallback for unknown origin, got %q", p.CLI())
+	}
+}
+
+// ─── MatchesOrigin ────────────────────────────────────────────────────────────
+
+func TestMatchesOrigin_github_https(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://github.com/myorg/myrepo.git")
+	p := githubProvider{}
+	if !MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin true for https GitHub URL")
+	}
+}
+
+func TestMatchesOrigin_github_ssh(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "git@github.com:myorg/myrepo.git")
+	p := githubProvider{}
+	if !MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin true for SSH GitHub URL")
+	}
+}
+
+func TestMatchesOrigin_wrongOwner(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://github.com/otherorg/myrepo.git")
+	p := githubProvider{}
+	if MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin false for wrong owner")
+	}
+}
+
+// ─── glabStateToGH ───────────────────────────────────────────────────────────
+
+func TestGlabStateToGH(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"opened", "OPEN"},
+		{"merged", "MERGED"},
+		{"closed", "CLOSED"},
+		{"OPENED", "OPEN"},
+	}
+	for _, c := range cases {
+		got := glabStateToGH(c.in)
+		if got != c.want {
+			t.Errorf("glabStateToGH(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/vcs/vcs_test.go
+++ b/internal/vcs/vcs_test.go
@@ -1,8 +1,12 @@
 package vcs
 
 import (
+	"os"
+	"path/filepath"
 	"os/exec"
 	"testing"
+
+	"github.com/arun-gupta/agentctl/internal/config"
 )
 
 // initGitRepoWithOrigin creates a temp git repo with the given origin URL.
@@ -184,14 +188,47 @@ func TestDetect_noOrigin_fallbackGitHub(t *testing.T) {
 	}
 }
 
-func TestDetect_unknownOrigin_fallbackGitHub(t *testing.T) {
+func TestDetect_unknownOrigin_returnsError(t *testing.T) {
 	dir := initGitRepoWithOrigin(t, "https://bitbucket.org/myorg/myrepo.git")
+	_, err := Detect(dir)
+	if err == nil {
+		t.Error("Detect should return an error for an unrecognised origin (no vcs.provider config)")
+	}
+}
+
+func TestDetect_configOverride_passesServerToProvider(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://bitbucket.org/myorg/myrepo.git")
+	// Write .agentctl.yml with provider + server override.
+	cfg := &config.AgentctlConfig{
+		VCS: config.VCSConfig{
+			Provider: "gitlab",
+			Server:   "https://gitlab.company.com",
+		},
+	}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("config.Write: %v", err)
+	}
 	p, err := Detect(dir)
 	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.CLI() != "glab" {
+		t.Errorf("CLI() = %q, want %q", p.CLI(), "glab")
+	}
+	// Verify the server URL is honoured in MatchesHost.
+	if !p.MatchesHost("https://gitlab.company.com/org/repo") {
+		t.Error("MatchesHost should return true for self-hosted server URL")
+	}
+}
+
+func TestDetect_configOverride_unknownProvider_error(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("vcs:\n  provider: bitbucket\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if p.CLI() != "gh" {
-		t.Errorf("expected gh CLI fallback for unknown origin, got %q", p.CLI())
+	_, err := Detect(dir)
+	if err == nil {
+		t.Error("Detect should return an error for unknown provider in config")
 	}
 }
 
@@ -235,5 +272,109 @@ func TestGlabStateToGH(t *testing.T) {
 		if got != c.want {
 			t.Errorf("glabStateToGH(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// ─── Platform ────────────────────────────────────────────────────────────────
+
+func TestPlatform_github(t *testing.T) {
+	p := githubProvider{}
+	if p.Platform() != "GitHub" {
+		t.Errorf("Platform() = %q, want %q", p.Platform(), "GitHub")
+	}
+}
+
+func TestPlatform_gitlab(t *testing.T) {
+	p := gitlabProvider{}
+	if p.Platform() != "GitLab" {
+		t.Errorf("Platform() = %q, want %q", p.Platform(), "GitLab")
+	}
+}
+
+// ─── ParseIssueURL nested groups ─────────────────────────────────────────────
+
+func TestParseIssueURL_gitlabNestedGroups(t *testing.T) {
+	owner, repo, issueNum, prov, ok := ParseIssueURL("https://gitlab.com/group/subgroup/myrepo/-/issues/7")
+	if !ok {
+		t.Fatal("ParseIssueURL should return ok=true for GitLab nested-group URL")
+	}
+	if owner != "group/subgroup" {
+		t.Errorf("owner = %q, want %q", owner, "group/subgroup")
+	}
+	if repo != "myrepo" {
+		t.Errorf("repo = %q, want %q", repo, "myrepo")
+	}
+	if issueNum != "7" {
+		t.Errorf("issueNum = %q, want %q", issueNum, "7")
+	}
+	if prov != "gitlab" {
+		t.Errorf("provider = %q, want %q", prov, "gitlab")
+	}
+}
+
+func TestParseIssueURL_gitlabDeeplyNestedGroups(t *testing.T) {
+	owner, repo, issueNum, prov, ok := ParseIssueURL("https://gitlab.com/a/b/c/myrepo/-/issues/99")
+	if !ok {
+		t.Fatal("ParseIssueURL should return ok=true for deeply-nested GitLab URL")
+	}
+	if owner != "a/b/c" {
+		t.Errorf("owner = %q, want %q", owner, "a/b/c")
+	}
+	if repo != "myrepo" {
+		t.Errorf("repo = %q, want %q", repo, "myrepo")
+	}
+	if issueNum != "99" {
+		t.Errorf("issueNum = %q, want %q", issueNum, "99")
+	}
+	if prov != "gitlab" {
+		t.Errorf("provider = %q, want %q", prov, "gitlab")
+	}
+}
+
+// ─── MatchesOrigin cross-provider ────────────────────────────────────────────
+
+func TestMatchesOrigin_githubURLRejectedForGitLab(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://github.com/myorg/myrepo.git")
+	p := gitlabProvider{}
+	if MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin false: GitHub origin should not match GitLab provider")
+	}
+}
+
+func TestMatchesOrigin_gitlabURLRejectedForGitHub(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://gitlab.com/myorg/myrepo.git")
+	p := githubProvider{}
+	if MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin false: GitLab origin should not match GitHub provider")
+	}
+}
+
+func TestMatchesOrigin_gitlab_https(t *testing.T) {
+	dir := initGitRepoWithOrigin(t, "https://gitlab.com/myorg/myrepo.git")
+	p := gitlabProvider{}
+	if !MatchesOrigin(dir, "myorg", "myrepo", p) {
+		t.Error("expected MatchesOrigin true for https GitLab URL")
+	}
+}
+
+// ─── MatchesHost self-hosted ──────────────────────────────────────────────────
+
+func TestMatchesHost_selfHostedGitLab(t *testing.T) {
+	p := gitlabProvider{server: "https://gitlab.company.com"}
+	if !p.MatchesHost("https://gitlab.company.com/myorg/myrepo") {
+		t.Error("expected MatchesHost true for self-hosted GitLab HTTPS URL")
+	}
+	if p.MatchesHost("https://gitlab.com/myorg/myrepo") {
+		t.Error("expected MatchesHost false for canonical GitLab when server is set to different host")
+	}
+}
+
+func TestMatchesHost_selfHostedGitHub(t *testing.T) {
+	p := githubProvider{server: "https://github.company.com"}
+	if !p.MatchesHost("https://github.company.com/myorg/myrepo") {
+		t.Error("expected MatchesHost true for self-hosted GitHub Enterprise URL")
+	}
+	if p.MatchesHost("https://github.com/myorg/myrepo") {
+		t.Error("expected MatchesHost false for canonical GitHub when server is set to different host")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #240

- Introduces a `vcs.Provider` interface (`internal/vcs/vcs.go`) with 11 methods covering the full agentctl lifecycle: `FetchIssueTitle`, `IssueURL`, `PRForBranch`, `HasPR`, `PRMergeInfo`, `EditPRBody`, `MergePR`, `AuthCheck`, `Clone`, `CLI`, `PRTerm`
- Implements `githubProvider` (wraps `gh`) and `gitlabProvider` (wraps `glab`) in `internal/vcs/github.go` and `internal/vcs/gitlab.go`
- Auto-detects provider from git `origin` URL (`github.com` → GitHub, `gitlab.com` → GitLab) in `internal/vcs/detect.go`; self-hosted instances can override via `vcs.provider` in `.agentctl.yml`
- Replaces all hard-coded `gh` calls in `internal/cmd/commands.go` with provider method calls; removed 10+ GitHub-specific functions (`ensureGHToken`, `slugFromIssue`, `ghPRInfo`, `ghPRState`, `ghHasPR`, etc.)
- Adds `VCSConfig` struct to `internal/config/config.go` for `.agentctl.yml` override support
- Full test coverage: `internal/vcs/vcs_test.go` covers `ParseIssueURL`, `Detect`, `MatchesOrigin`, and `glabStateToGH`; `commands_test.go` updated for all refactored call sites

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — no issues
- [ ] Manual: `agentctl start` on a GitLab repo (requires `glab` installed and authenticated)
- [ ] Manual: `agentctl merge` on a GitLab MR
- [ ] Manual: `agentctl status` on a GitLab repo shows MR link

🤖 Generated with [Claude Code](https://claude.com/claude-code)