### PR TITLE
feat: per-project default agent via .agentctl.yml

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -80,7 +80,7 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 			if !cmd.Flags().Changed("agent") {
 				root, err := startConfigRepoRoot(args, os.Stdout)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to determine repository for configuration: %w", err)
 				}
 				if root != "" {
 					cfg, cfgErr := config.Read(root)
@@ -192,7 +192,7 @@ func startConfigRepoRoot(args []string, out io.Writer) (string, error) {
 		}
 	}
 	if len(issues) == 1 {
-		if _, _, _, _, isURL := vcs.ParseIssueURL(issues[0]); isURL {
+		if isSupportedIssueURL(issues[0]) {
 			root, _, _, _, err := repoRootForIssue(issues[0], out)
 			if err != nil {
 				return "", err
@@ -205,6 +205,11 @@ func startConfigRepoRoot(args []string, out io.Writer) (string, error) {
 		return "", nil
 	}
 	return root, nil
+}
+
+func isSupportedIssueURL(arg string) bool {
+	_, _, _, ok := parseIssueURL(arg)
+	return ok
 }
 
 // resumeHintFmt is printed after a foreground agent exits so users know how

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -69,6 +69,15 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 (e.g. plain, speckit, or a custom methodology).`,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Apply per-project default_agent when --agent was not explicitly set.
+			if !cmd.Flags().Changed("agent") {
+				if root, err := git.RepoRoot(); err == nil {
+					if cfg, err := config.Read(root); err == nil && cfg.DefaultAgent != "" {
+						agentName = cfg.DefaultAgent
+					}
+				}
+			}
+
 			if task != "" && len(args) > 0 {
 				return fmt.Errorf("--task and a positional issue argument are mutually exclusive")
 			}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -70,21 +70,29 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 (e.g. plain, speckit, or a custom methodology).`,
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Apply per-project default_agent when --agent was not explicitly set.
-			if !cmd.Flags().Changed("agent") {
-				if root, err := git.RepoRoot(); err == nil {
-					if cfg, err := config.Read(root); err == nil && cfg.DefaultAgent != "" {
-						agentName = cfg.DefaultAgent
-					}
-				}
-			}
-
 			if task != "" && len(args) > 0 {
 				return fmt.Errorf("--task and a positional issue argument are mutually exclusive")
 			}
 			if branch != "" && task == "" {
 				return fmt.Errorf("--branch requires --task")
 			}
+			// Apply per-project default_agent when --agent was not explicitly set.
+			if !cmd.Flags().Changed("agent") {
+				root, err := startConfigRepoRoot(args, os.Stdout)
+				if err != nil {
+					return err
+				}
+				if root != "" {
+					cfg, cfgErr := config.Read(root)
+					if cfgErr != nil {
+						return fmt.Errorf("read %s: %w", filepath.Join(root, config.Filename), cfgErr)
+					}
+					if cfg.DefaultAgent != "" {
+						agentName = cfg.DefaultAgent
+					}
+				}
+			}
+
 			if task != "" {
 				return startTask(task, branch, agentName, sddName, headless, quiet, sendNotify, os.Stdout)
 			}
@@ -163,6 +171,40 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 	c.Flags().StringVar(&task, "task", "", "Free-form task description (alternative to a GitHub issue)")
 	c.Flags().BoolVar(&sendNotify, "notify", false, "Send a desktop notification when the headless agent finishes")
 	return c
+}
+
+// startConfigRepoRoot returns the repo root used for loading start-time config.
+// For single issue URLs, this resolves/locates the target repository so
+// default_agent is honoured even when invoked outside that repo.
+func startConfigRepoRoot(args []string, out io.Writer) (string, error) {
+	if len(args) == 0 {
+		root, err := git.RepoRoot()
+		if err != nil {
+			return "", nil
+		}
+		return root, nil
+	}
+	rawIssues := strings.Split(args[0], ",")
+	issues := make([]string, 0, len(rawIssues))
+	for _, iss := range rawIssues {
+		if s := strings.TrimSpace(iss); s != "" {
+			issues = append(issues, s)
+		}
+	}
+	if len(issues) == 1 {
+		if _, _, _, _, isURL := vcs.ParseIssueURL(issues[0]); isURL {
+			root, _, _, _, err := repoRootForIssue(issues[0], out)
+			if err != nil {
+				return "", err
+			}
+			return root, nil
+		}
+	}
+	root, err := git.RepoRoot()
+	if err != nil {
+		return "", nil
+	}
+	return root, nil
 }
 
 // resumeHintFmt is printed after a foreground agent exits so users know how

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5832,3 +5832,75 @@ func TestStartCmd_defaultAgent_flagOverridesConfig(t *testing.T) {
 		t.Errorf("config agent leaked into error when flag was set: %v", err)
 	}
 }
+
+// TestStartCmd_defaultAgent_fromIssueURLRepo verifies default_agent is resolved
+// from the target repo even when cwd is outside that repo and issue is a URL.
+func TestStartCmd_defaultAgent_fromIssueURLRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "myrepo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init"},
+		{"remote", "add", "origin", "https://github.com/myorg/myrepo.git"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".agentctl.yml"),
+		[]byte("default_agent: zqxuniqurlconfigagent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(parent, "workspace")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, cwd)
+
+	c := NewStartCmd()
+	c.SilenceUsage = true
+	c.SilenceErrors = true
+	c.SetArgs([]string{"https://github.com/myorg/myrepo/issues/99"})
+	err := c.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown adapter: zqxuniqurlconfigagent") {
+		t.Errorf("error %q does not contain URL-repo default agent", err.Error())
+	}
+}
+
+// TestStartCmd_defaultAgent_invalidConfigReturnsError verifies parse/read errors
+// in .agentctl.yml are surfaced instead of silently falling back to defaults.
+func TestStartCmd_defaultAgent_invalidConfigReturnsError(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+
+	dir := initGitRepoForStale(t)
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),
+		[]byte("default_agent: [\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, dir)
+
+	c := NewStartCmd()
+	c.SilenceUsage = true
+	c.SilenceErrors = true
+	c.SetArgs([]string{"--task", "do something"})
+	err := c.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), ".agentctl.yml") {
+		t.Errorf("error %q does not mention .agentctl.yml", err.Error())
+	}
+}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5845,18 +5845,18 @@ func TestStartCmd_defaultAgent_fromIssueURLRepo(t *testing.T) {
 	if err := os.MkdirAll(repo, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	for _, args := range [][]string{
+	for _, gitArgs := range [][]string{
 		{"init"},
 		{"remote", "add", "origin", "https://github.com/myorg/myrepo.git"},
 	} {
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", gitArgs...)
 		cmd.Dir = repo
 		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
+			t.Fatalf("git %v: %v\n%s", gitArgs, err, out)
 		}
 	}
 	if err := os.WriteFile(filepath.Join(repo, ".agentctl.yml"),
-		[]byte("default_agent: zqxuniqurlconfigagent\n"), 0o644); err != nil {
+		[]byte("default_agent: unique_url_test_agent\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	cwd := filepath.Join(parent, "workspace")
@@ -5868,12 +5868,13 @@ func TestStartCmd_defaultAgent_fromIssueURLRepo(t *testing.T) {
 	c := NewStartCmd()
 	c.SilenceUsage = true
 	c.SilenceErrors = true
-	c.SetArgs([]string{"https://github.com/myorg/myrepo/issues/99"})
+	const issueURL = "https://github.com/myorg/myrepo/issues/99"
+	c.SetArgs([]string{issueURL})
 	err := c.Execute()
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "unknown adapter: zqxuniqurlconfigagent") {
+	if !strings.Contains(err.Error(), "unknown adapter: unique_url_test_agent") {
 		t.Errorf("error %q does not contain URL-repo default agent", err.Error())
 	}
 }
@@ -5902,5 +5903,8 @@ func TestStartCmd_defaultAgent_invalidConfigReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), ".agentctl.yml") {
 		t.Errorf("error %q does not mention .agentctl.yml", err.Error())
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "yaml") {
+		t.Errorf("error %q does not describe YAML parsing failure", err.Error())
 	}
 }

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5682,3 +5682,74 @@ func TestStartCmd_agentFlag_filtersEmptyAndRejectsDuplicates(t *testing.T) {
 		}
 	})
 }
+
+// ─── default_agent resolution ─────────────────────────────────────────────────
+
+// TestStartCmd_defaultAgentFlagDefault verifies the --agent flag default value
+// is "claude", covering the "no config → built-in default" case from issue #265.
+func TestStartCmd_defaultAgentFlagDefault(t *testing.T) {
+	f := NewStartCmd().Flags().Lookup("agent")
+	if f == nil {
+		t.Fatal("--agent flag not registered")
+	}
+	if f.DefValue != "claude" {
+		t.Errorf("--agent default = %q, want %q", f.DefValue, "claude")
+	}
+}
+
+// TestStartCmd_defaultAgent_fromConfig verifies that when .agentctl.yml sets
+// default_agent and --agent is not passed, the configured agent is used.
+// We use --task so startTask calls validateAdapter before any network call,
+// letting us detect the resolved agent name from the adapter error message.
+func TestStartCmd_defaultAgent_fromConfig(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	dir := initGitRepoForStale(t)
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),
+		[]byte("default_agent: zqxuniqconfigagent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, dir)
+
+	c := NewStartCmd()
+	c.SilenceUsage = true
+	c.SilenceErrors = true
+	c.SetArgs([]string{"--task", "do something"})
+	err := c.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown adapter: zqxuniqconfigagent") {
+		t.Errorf("error %q does not contain expected agent name", err.Error())
+	}
+}
+
+// TestStartCmd_defaultAgent_flagOverridesConfig verifies that an explicit
+// --agent flag takes priority over default_agent in .agentctl.yml.
+func TestStartCmd_defaultAgent_flagOverridesConfig(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	dir := initGitRepoForStale(t)
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"),
+		[]byte("default_agent: zqxuniqconfigagent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chdirTemp(t, dir)
+
+	c := NewStartCmd()
+	c.SilenceUsage = true
+	c.SilenceErrors = true
+	c.SetArgs([]string{"--task", "do something", "--agent", "zqxuniqflagagent"})
+	err := c.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown adapter: zqxuniqflagagent") {
+		t.Errorf("error %q does not contain flag agent name", err.Error())
+	}
+	if strings.Contains(err.Error(), "zqxuniqconfigagent") {
+		t.Errorf("config agent leaked into error when flag was set: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,11 @@ type AgentctlConfig struct {
 	// Valid values: "squash" (default when empty), "merge", "rebase".
 	// Override per-invocation with the --strategy flag.
 	MergeStrategy string `yaml:"merge_strategy,omitempty"`
+
+	// DefaultAgent overrides the built-in "claude" default for agentctl start.
+	// Any installed adapter name is valid (e.g. "codex", "copilot").
+	// Overridden per-invocation by the --agent flag.
+	DefaultAgent string `yaml:"default_agent,omitempty"`
 }
 
 // Read loads .agentctl.yml from dir. If the file does not exist, an empty


### PR DESCRIPTION
## Summary

- Adds `DefaultAgent string` field to `AgentctlConfig` in `internal/config/config.go` (`yaml:"default_agent,omitempty"`)
- In `NewStartCmd()` RunE, reads `default_agent` from `.agentctl.yml` at the repo root when `--agent` was not explicitly passed (`cmd.Flags().Changed("agent")` is false)
- Priority order: `--agent` flag > `default_agent` in `.agentctl.yml` > built-in default (`claude`)

Resolves #265.

## Test plan

- [ ] `go build ./...` — compiles clean
- [ ] `go vet ./...` — no issues
- [ ] `go test ./...` — all packages pass
- [ ] `TestStartCmd_defaultAgentFlagDefault` — `--agent` default is `"claude"` (no-config case)
- [ ] `TestStartCmd_defaultAgent_fromConfig` — config `default_agent` is used when `--agent` not set
- [ ] `TestStartCmd_defaultAgent_flagOverridesConfig` — explicit `--agent` takes priority over config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #265