### PR TITLE
feat: agentctl open — open worktree in editor or IDE

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -12,6 +12,7 @@
 //	agentctl logs       [--lines N] [--no-follow] <issue>
 //	agentctl attach     <issue>
 //	agentctl diff       [--stat] [--base branch] [--no-pager] <issue>
+//	agentctl open       [--editor name] [--path] [--agent name] <issue>
 //	agentctl dev start  [--quiet] [issue]
 package main
 
@@ -53,6 +54,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewLogsCmd(),
 		cmd.NewAttachCmd(),
 		cmd.NewDiffCmd(),
+		cmd.NewOpenCmd(),
 		cmd.NewDevCmd(),
 		cmd.NewStreamLogCmd(),
 		cmd.NewStreamLogOpenHandsCmd(),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,6 +19,7 @@ Run `agentctl --help` or `agentctl <command> --help` for generated help from the
   - [agentctl logs](#agentctl-logs)
   - [agentctl attach](#agentctl-attach)
   - [agentctl diff](#agentctl-diff)
+  - [agentctl open](#agentctl-open)
   - [agentctl resume](#agentctl-resume)
   - [agentctl status](#agentctl-status)
   - [agentctl cleanup](#agentctl-cleanup)
@@ -318,6 +319,48 @@ Error cases:
 |-----------|---------------|
 | Issue not found | `no worktree found for issue N — has it been started?` |
 
+### `agentctl open`
+
+```bash
+agentctl open <issue-number-or-url>
+agentctl open <issue-number-or-url> --editor code
+agentctl open <issue-number-or-url> --editor cursor
+cd $(agentctl open <issue-number-or-url> --path)
+```
+
+Opens the worktree for an issue in the configured editor.
+
+Editor resolution order:
+
+1. `--editor` flag (per-invocation override)
+2. `editor` key in `.agentctl.yml`
+3. `AGENTCTL_EDITOR` env var
+4. `VISUAL` env var
+5. `EDITOR` env var
+6. Falls back to printing the worktree path if none are set
+
+Flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--editor <name>` | — | Editor to open the worktree in; overrides config and env vars |
+| `--path` | `false` | Print the worktree path to stdout without opening an editor |
+| `--agent <name>` | — | Disambiguate when multiple worktrees exist for the same issue |
+
+Behavior:
+
+- Resolves the linked worktree path for the given issue.
+- Launches the editor with the worktree path as a non-blocking background process (`.Start()`, not `.Run()`), so the command returns immediately.
+- When no editor is resolved, prints the worktree path to stdout and exits with no error — same as `--path`.
+- `--path` is useful for scripting: `cd $(agentctl open 42 --path)`.
+
+Error cases:
+
+| Condition | Error message |
+|-----------|---------------|
+| Issue not found | `no worktree found for issue N — has it been started?` |
+| Editor binary not found | `cannot open editor "<name>": ...` |
+
 ### `agentctl resume`
 
 ```bash
@@ -478,6 +521,10 @@ port: 3010
 # Send a native desktop notification when a headless agent finishes.
 # Can also be enabled per-invocation with --notify.
 notify: true
+
+# Editor opened by agentctl open. Overridden per-invocation with --editor.
+# Examples: "cursor", "code", "idea"
+editor: cursor
 ```
 
 ---

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -42,16 +43,22 @@ Use --path to print the worktree path to stdout without opening an editor.`,
 			if _, _, num, ok := parseIssueURL(arg); ok {
 				arg = num
 			}
-			wtPath, err := findWorktreePath(arg, agentSuffix)
+			repoRoot, err := git.RepoRoot()
+			if err != nil {
+				return fmt.Errorf("cannot determine repo root: %w", err)
+			}
+			wt, err := resolveWorktree(repoRoot, arg, agentSuffix)
 			if err != nil {
 				return err
 			}
+			wtPath := wt.Path
 
 			var editor string
 			if !printPath {
-				repoRoot, _ := git.RepoRoot()
-				cfg, _ := config.Read(repoRoot)
-				editor = resolveEditor(flagEditor, cfg)
+				editor, err = resolveEditorForRepo(flagEditor, repoRoot)
+				if err != nil {
+					return err
+				}
 			}
 
 			return openWorktree(wtPath, editor, printPath, cmd.OutOrStdout())
@@ -81,6 +88,17 @@ func resolveEditor(flagEditor string, cfg *config.AgentctlConfig) string {
 	return os.Getenv("EDITOR")
 }
 
+func resolveEditorForRepo(flagEditor, repoRoot string) (string, error) {
+	if flagEditor != "" {
+		return flagEditor, nil
+	}
+	cfg, err := config.Read(repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("cannot read config: %w", err)
+	}
+	return resolveEditor("", cfg), nil
+}
+
 // openWorktree launches editor for wtPath, or prints wtPath if printPath is true
 // or no editor is resolved.
 func openWorktree(wtPath, editor string, printPath bool, out io.Writer) error {
@@ -88,7 +106,13 @@ func openWorktree(wtPath, editor string, printPath bool, out io.Writer) error {
 		fmt.Fprintln(out, wtPath)
 		return nil
 	}
-	editorCmd := exec.Command(editor, wtPath) //nolint:gosec
+	editorArgs := strings.Fields(editor)
+	if len(editorArgs) == 0 {
+		fmt.Fprintln(out, wtPath)
+		return nil
+	}
+
+	editorCmd := exec.Command(editorArgs[0], append(editorArgs[1:], wtPath)...) //nolint:gosec
 	if err := editorCmd.Start(); err != nil {
 		return fmt.Errorf("cannot open editor %q: %w", editor, err)
 	}

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arun-gupta/agentctl/internal/config"
+	"github.com/arun-gupta/agentctl/internal/git"
+)
+
+// NewOpenCmd creates the `open` subcommand.
+func NewOpenCmd() *cobra.Command {
+	var agentSuffix string
+	var flagEditor string
+	var printPath bool
+
+	c := &cobra.Command{
+		Use:   "open <issue>",
+		Short: "Open the worktree for an issue in the configured editor",
+		Long: `Open the worktree for an issue in the configured editor.
+
+Editor resolution order:
+  1. --editor flag
+  2. editor key in .agentctl.yml
+  3. AGENTCTL_EDITOR env var
+  4. VISUAL env var
+  5. EDITOR env var
+  6. Falls back to printing the worktree path if none are set
+
+Use --path to print the worktree path to stdout without opening an editor.`,
+		Example: `  agentctl open 42
+  agentctl open 42 --editor code
+  agentctl open 42 --editor cursor
+  cd $(agentctl open 42 --path)`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			arg := args[0]
+			if _, _, num, ok := parseIssueURL(arg); ok {
+				arg = num
+			}
+			wtPath, err := findWorktreePath(arg, agentSuffix)
+			if err != nil {
+				return err
+			}
+
+			var editor string
+			if !printPath {
+				repoRoot, _ := git.RepoRoot()
+				cfg, _ := config.Read(repoRoot)
+				editor = resolveEditor(flagEditor, cfg)
+			}
+
+			return openWorktree(wtPath, editor, printPath, cmd.OutOrStdout())
+		},
+	}
+	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to disambiguate when multiple worktrees exist for the same issue")
+	c.Flags().StringVar(&flagEditor, "editor", "", "Editor to open the worktree in (overrides config and env vars)")
+	c.Flags().BoolVar(&printPath, "path", false, "Print the worktree path to stdout instead of opening an editor")
+	return c
+}
+
+// resolveEditor returns the editor to use based on the resolution order:
+// flagEditor > cfg.Editor > AGENTCTL_EDITOR > VISUAL > EDITOR > ""
+func resolveEditor(flagEditor string, cfg *config.AgentctlConfig) string {
+	if flagEditor != "" {
+		return flagEditor
+	}
+	if cfg != nil && cfg.Editor != "" {
+		return cfg.Editor
+	}
+	if v := os.Getenv("AGENTCTL_EDITOR"); v != "" {
+		return v
+	}
+	if v := os.Getenv("VISUAL"); v != "" {
+		return v
+	}
+	return os.Getenv("EDITOR")
+}
+
+// openWorktree launches editor for wtPath, or prints wtPath if printPath is true
+// or no editor is resolved.
+func openWorktree(wtPath, editor string, printPath bool, out io.Writer) error {
+	if printPath || editor == "" {
+		fmt.Fprintln(out, wtPath)
+		return nil
+	}
+	editorCmd := exec.Command(editor, wtPath) //nolint:gosec
+	if err := editorCmd.Start(); err != nil {
+		return fmt.Errorf("cannot open editor %q: %w", editor, err)
+	}
+	return nil
+}

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -112,5 +114,42 @@ func TestOpenWorktree_badEditor(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cannot open editor") {
 		t.Errorf("error = %q, want it to mention 'cannot open editor'", err.Error())
+	}
+}
+
+func TestOpenWorktree_editorWithArgs(t *testing.T) {
+	var buf bytes.Buffer
+	if err := openWorktree("/tmp/worktree-42", "echo -n", false, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveEditorForRepo_badConfig(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoRoot, ".agentctl.yml"), []byte("editor: ["), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := resolveEditorForRepo("", repoRoot)
+	if err == nil {
+		t.Fatal("expected error for malformed config, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot read config") {
+		t.Fatalf("error = %q, want it to mention cannot read config", err)
+	}
+}
+
+func TestResolveEditorForRepo_flagSkipsMalformedConfig(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoRoot, ".agentctl.yml"), []byte("editor: ["), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	got, err := resolveEditorForRepo("code", repoRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "code" {
+		t.Fatalf("resolveEditorForRepo() = %q, want %q", got, "code")
 	}
 }

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/arun-gupta/agentctl/internal/config"
+)
+
+func TestResolveEditor(t *testing.T) {
+	tests := []struct {
+		name       string
+		flagEditor string
+		cfg        *config.AgentctlConfig
+		env        map[string]string
+		want       string
+	}{
+		{
+			name:       "flag takes precedence over all",
+			flagEditor: "code",
+			cfg:        &config.AgentctlConfig{Editor: "cursor"},
+			env:        map[string]string{"AGENTCTL_EDITOR": "vim", "VISUAL": "nano", "EDITOR": "ed"},
+			want:       "code",
+		},
+		{
+			name:       "config overrides env vars",
+			flagEditor: "",
+			cfg:        &config.AgentctlConfig{Editor: "cursor"},
+			env:        map[string]string{"AGENTCTL_EDITOR": "vim", "VISUAL": "nano", "EDITOR": "ed"},
+			want:       "cursor",
+		},
+		{
+			name:       "AGENTCTL_EDITOR overrides VISUAL and EDITOR",
+			flagEditor: "",
+			cfg:        &config.AgentctlConfig{},
+			env:        map[string]string{"AGENTCTL_EDITOR": "vim", "VISUAL": "nano", "EDITOR": "ed"},
+			want:       "vim",
+		},
+		{
+			name:       "VISUAL overrides EDITOR",
+			flagEditor: "",
+			cfg:        &config.AgentctlConfig{},
+			env:        map[string]string{"VISUAL": "nano", "EDITOR": "ed"},
+			want:       "nano",
+		},
+		{
+			name:       "EDITOR is last fallback",
+			flagEditor: "",
+			cfg:        &config.AgentctlConfig{},
+			env:        map[string]string{"EDITOR": "ed"},
+			want:       "ed",
+		},
+		{
+			name:       "empty when no editor set",
+			flagEditor: "",
+			cfg:        &config.AgentctlConfig{},
+			env:        map[string]string{},
+			want:       "",
+		},
+		{
+			name:       "nil config is safe",
+			flagEditor: "",
+			cfg:        nil,
+			env:        map[string]string{"EDITOR": "vi"},
+			want:       "vi",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, k := range []string{"AGENTCTL_EDITOR", "VISUAL", "EDITOR"} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			got := resolveEditor(tt.flagEditor, tt.cfg)
+			if got != tt.want {
+				t.Errorf("resolveEditor() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenWorktree_pathFlag(t *testing.T) {
+	var buf bytes.Buffer
+	if err := openWorktree("/tmp/worktree-42", "", true, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != "/tmp/worktree-42" {
+		t.Errorf("openWorktree --path = %q, want %q", got, "/tmp/worktree-42")
+	}
+}
+
+func TestOpenWorktree_noEditorFallback(t *testing.T) {
+	var buf bytes.Buffer
+	if err := openWorktree("/tmp/worktree-42", "", false, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := strings.TrimSpace(buf.String())
+	if got != "/tmp/worktree-42" {
+		t.Errorf("openWorktree no-editor fallback = %q, want %q", got, "/tmp/worktree-42")
+	}
+}
+
+func TestOpenWorktree_badEditor(t *testing.T) {
+	var buf bytes.Buffer
+	err := openWorktree("/tmp/worktree-42", "no-such-editor-xyz-abc-999", false, &buf)
+	if err == nil {
+		t.Fatal("expected error for nonexistent editor, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot open editor") {
+		t.Errorf("error = %q, want it to mention 'cannot open editor'", err.Error())
+	}
+}

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -6,9 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/arun-gupta/agentctl/internal/config"
 )
+
+const malformedConfigYAML = "editor: ["
 
 func TestResolveEditor(t *testing.T) {
 	tests := []struct {
@@ -118,15 +121,41 @@ func TestOpenWorktree_badEditor(t *testing.T) {
 }
 
 func TestOpenWorktree_editorWithArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	argsPath := filepath.Join(tmpDir, "args.txt")
+	scriptPath := filepath.Join(tmpDir, "capture-args.sh")
+	wtPath := filepath.Join(tmpDir, "worktree-42")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argsPath + "\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
 	var buf bytes.Buffer
-	if err := openWorktree("/tmp/worktree-42", "echo -n", false, &buf); err != nil {
+	if err := openWorktree(wtPath, "sh "+scriptPath, false, &buf); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got []byte
+	var err error
+	for i := 0; i < 20; i++ {
+		got, err = os.ReadFile(argsPath)
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("read args output: %v", err)
+	}
+
+	if strings.TrimSpace(string(got)) != wtPath {
+		t.Fatalf("captured args = %q, want %q", strings.TrimSpace(string(got)), wtPath)
 	}
 }
 
 func TestResolveEditorForRepo_badConfig(t *testing.T) {
 	repoRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(repoRoot, ".agentctl.yml"), []byte("editor: ["), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(repoRoot, ".agentctl.yml"), []byte(malformedConfigYAML), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -141,7 +170,7 @@ func TestResolveEditorForRepo_badConfig(t *testing.T) {
 
 func TestResolveEditorForRepo_flagSkipsMalformedConfig(t *testing.T) {
 	repoRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(repoRoot, ".agentctl.yml"), []byte("editor: ["), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(repoRoot, ".agentctl.yml"), []byte(malformedConfigYAML), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 

--- a/internal/cmd/open_test.go
+++ b/internal/cmd/open_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,7 +124,8 @@ func TestOpenWorktree_badEditor(t *testing.T) {
 func TestOpenWorktree_editorWithArgs(t *testing.T) {
 	tmpDir := t.TempDir()
 	argsPath := filepath.Join(tmpDir, "args.txt")
-	scriptPath := filepath.Join(tmpDir, "capture-args.sh")
+	scriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("agentctl-open-capture-%d.sh", time.Now().UnixNano()))
+	t.Cleanup(func() { _ = os.Remove(scriptPath) })
 	wtPath := filepath.Join(tmpDir, "worktree-42")
 	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argsPath + "\n"
 	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
@@ -139,7 +141,7 @@ func TestOpenWorktree_editorWithArgs(t *testing.T) {
 	var err error
 	for i := 0; i < 20; i++ {
 		got, err = os.ReadFile(argsPath)
-		if err == nil {
+		if err == nil && strings.TrimSpace(string(got)) != "" {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,11 @@ type AgentctlConfig struct {
 	// Valid values: "squash" (default when empty), "merge", "rebase".
 	// Override per-invocation with the --strategy flag.
 	MergeStrategy string `yaml:"merge_strategy,omitempty"`
+
+	// Editor is the program used by agentctl open to open a worktree.
+	// Overridden per-invocation by the --editor flag.
+	// Example: "cursor", "code", "idea"
+	Editor string `yaml:"editor,omitempty"`
 }
 
 // Read loads .agentctl.yml from dir. If the file does not exist, an empty


### PR DESCRIPTION
Closes #194.

## Summary

- Adds `agentctl open <issue>` command that resolves the linked worktree path and opens it in the configured editor
- Editor resolution order: `--editor` flag → `editor` in `.agentctl.yml` → `AGENTCTL_EDITOR` env → `VISUAL` env → `EDITOR` env → prints path as fallback
- `--path` flag prints the worktree path to stdout for scripting (`cd $(agentctl open 42 --path)`)
- `--agent` flag disambiguates when multiple worktrees exist for the same issue (matches `attach`, `logs`, `diff`)
- Editor is launched non-blocking (`.Start()` not `.Run()`) so the command returns immediately
- Adds `Editor` field to `AgentctlConfig` (`editor:` key in `.agentctl.yml`)
- Documents the command in `docs/cli.md` including the config field

## Test plan

- [ ] `go build ./...` compiles cleanly
- [ ] `go test ./...` passes (all packages)
- [ ] `go vet ./...` reports no issues
- [ ] `TestResolveEditor` covers all resolution-order cases
- [ ] `TestOpenWorktree_pathFlag` verifies `--path` prints the worktree path
- [ ] `TestOpenWorktree_noEditorFallback` verifies no-editor falls back to printing path
- [ ] `TestOpenWorktree_badEditor` verifies nonexistent editor returns a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)