### PR TITLE
feat: agent runs tests and reports results in PR before opening

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -165,6 +165,14 @@ const kickoffTemplate = `Work on GitHub issue #{issue}. Read AGENTS.md or README
 Make the changes directly, push the branch, and open a PR. Do not merge.
 You are the coding agent — implement changes using your own file-editing and bash tools.
 Do not run agentctl, claude, codex, or any other agent-launcher CLI.
+Before opening the PR, run the project's test suite (use test_cmd from
+.agentctl.yml if present, otherwise infer from AGENTS.md or README.md).
+In the PR description include a '## Test plan' section with two subsections:
+- Automated: the command run and a pass/fail summary.
+- Manual: a bulleted list of scenarios that cannot be automated, each with
+  a one-line explanation of why manual verification is needed.
+If tests fail, fix the failures before opening the PR. If you cannot fix
+them, open the PR anyway but clearly mark the failing tests in the plan.
 Dev server is running on port {port}.`
 
 // buildKickoff returns the default agent kickoff prompt for a plain
@@ -190,7 +198,15 @@ func buildKickoffFromTask(task, port string) string {
 	s := "Work on the following task: " + task + "\n" +
 		"Make the changes directly, push the branch, and open a PR. Do not merge.\n" +
 		"You are the coding agent — implement changes using your own file-editing and bash tools.\n" +
-		"Do not run agentctl, claude, codex, or any other agent-launcher CLI."
+		"Do not run agentctl, claude, codex, or any other agent-launcher CLI.\n" +
+		"Before opening the PR, run the project's test suite (use test_cmd from\n" +
+		".agentctl.yml if present, otherwise infer from AGENTS.md or README.md).\n" +
+		"In the PR description include a '## Test plan' section with two subsections:\n" +
+		"- Automated: the command run and a pass/fail summary.\n" +
+		"- Manual: a bulleted list of scenarios that cannot be automated, each with\n" +
+		"  a one-line explanation of why manual verification is needed.\n" +
+		"If tests fail, fix the failures before opening the PR. If you cannot fix\n" +
+		"them, open the PR anyway but clearly mark the failing tests in the plan."
 	if port != "" {
 		s += "\nDev server is running on port " + port + "."
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -225,7 +225,7 @@ You are the coding agent — implement changes using your own file-editing and b
 Do not run agentctl, claude, codex, or any other agent-launcher CLI.
 Before opening the PR, run the project's test suite (use test_cmd from
 .agentctl.yml if present, otherwise infer from AGENTS.md or README.md).
-In the PR description include a '## Test plan' section with two subsections:
+In the PR description include a `## Test plan` section with two subsections:
 - Automated: the command run and a pass/fail summary.
 - Manual: a bulleted list of scenarios that cannot be automated, each with
   a one-line explanation of why manual verification is needed.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -225,7 +225,7 @@ You are the coding agent — implement changes using your own file-editing and b
 Do not run agentctl, claude, codex, or any other agent-launcher CLI.
 Before opening the PR, run the project's test suite (use test_cmd from
 .agentctl.yml if present, otherwise infer from AGENTS.md or README.md).
-In the PR description include a `## Test plan` section with two subsections:
+In the PR description include a ## Test plan section with two subsections:
 - Automated: the command run and a pass/fail summary.
 - Manual: a bulleted list of scenarios that cannot be automated, each with
   a one-line explanation of why manual verification is needed.

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5682,3 +5682,31 @@ func TestStartCmd_agentFlag_filtersEmptyAndRejectsDuplicates(t *testing.T) {
 		}
 	})
 }
+
+// ─── test plan instructions in kickoff prompts ────────────────────────────────
+
+func TestBuildKickoff_containsTestPlanInstruction(t *testing.T) {
+	kickoff := buildKickoff("42", "3010")
+	if !strings.Contains(kickoff, "## Test plan") {
+		t.Errorf("buildKickoff must instruct agent to include a '## Test plan' section; got:\n%s", kickoff)
+	}
+	if !strings.Contains(kickoff, "test suite") {
+		t.Errorf("buildKickoff must instruct agent to run the test suite; got:\n%s", kickoff)
+	}
+	if !strings.Contains(kickoff, "Automated") {
+		t.Errorf("buildKickoff must mention 'Automated' subsection in the test plan; got:\n%s", kickoff)
+	}
+	if !strings.Contains(kickoff, "Manual") {
+		t.Errorf("buildKickoff must mention 'Manual' subsection in the test plan; got:\n%s", kickoff)
+	}
+}
+
+func TestBuildKickoffFromTask_containsTestPlanInstruction(t *testing.T) {
+	kickoff := buildKickoffFromTask("Refactor the auth middleware", "")
+	if !strings.Contains(kickoff, "## Test plan") {
+		t.Errorf("buildKickoffFromTask must instruct agent to include a '## Test plan' section; got:\n%s", kickoff)
+	}
+	if !strings.Contains(kickoff, "test suite") {
+		t.Errorf("buildKickoffFromTask must instruct agent to run the test suite; got:\n%s", kickoff)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,11 @@ type AgentctlConfig struct {
 	// Valid values: "squash" (default when empty), "merge", "rebase".
 	// Override per-invocation with the --strategy flag.
 	MergeStrategy string `yaml:"merge_strategy,omitempty"`
+
+	// TestCmd is the command to run the project's automated test suite.
+	// When set, agents use this instead of inferring the command from AGENTS.md
+	// or README.md. Example: "go test ./...", "npm test", "pytest"
+	TestCmd string `yaml:"test_cmd,omitempty"`
 }
 
 // Read loads .agentctl.yml from dir. If the file does not exist, an empty

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -140,3 +140,46 @@ func TestWrite_preservesMergeStrategy(t *testing.T) {
 		t.Errorf("MergeStrategy = %q, want %q", got.MergeStrategy, "squash")
 	}
 }
+
+func TestRead_parsesTestCmd(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("test_cmd: \"go test ./...\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TestCmd != "go test ./..." {
+		t.Errorf("TestCmd = %q, want %q", cfg.TestCmd, "go test ./...")
+	}
+}
+
+func TestRead_testCmdDefaultsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agentctl.yml"), []byte("dev_server: \"npm start\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Read(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TestCmd != "" {
+		t.Errorf("TestCmd = %q, want empty string (default)", cfg.TestCmd)
+	}
+}
+
+func TestWrite_preservesTestCmd(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{TestCmd: "pytest"}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	got, err := config.Read(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TestCmd != "pytest" {
+		t.Errorf("TestCmd = %q, want %q", got.TestCmd, "pytest")
+	}
+}

--- a/internal/sdd/builtin/plain.yml
+++ b/internal/sdd/builtin/plain.yml
@@ -35,7 +35,7 @@ kickoff: |
   - STEP 2: After approval, implement the changes, run the project's test suite
     (use test_cmd from .agentctl.yml if present, otherwise infer from AGENTS.md
     or README.md), then push the branch and open a PR. Do not merge.
-    In the PR description include a '## Test plan' section with two subsections:
+    In the PR description include a `## Test plan` section with two subsections:
     - Automated: the command run and a pass/fail summary.
     - Manual: a bulleted list of scenarios that cannot be automated, each with
       a one-line explanation of why manual verification is needed.

--- a/internal/sdd/builtin/plain.yml
+++ b/internal/sdd/builtin/plain.yml
@@ -32,8 +32,16 @@ kickoff: |
       What will not be done in this PR. Write "None" if nothing is excluded.
 
     Stop and wait for human approval before proceeding.
-  - STEP 2: After approval, implement the changes, run tests, push the branch,
-    and open a PR. Do not merge. Run bash commands (tests, linters, builds)
-    directly without asking for human approval — you are authorised to execute
-    any command needed to complete the implementation.
+  - STEP 2: After approval, implement the changes, run the project's test suite
+    (use test_cmd from .agentctl.yml if present, otherwise infer from AGENTS.md
+    or README.md), then push the branch and open a PR. Do not merge.
+    In the PR description include a '## Test plan' section with two subsections:
+    - Automated: the command run and a pass/fail summary.
+    - Manual: a bulleted list of scenarios that cannot be automated, each with
+      a one-line explanation of why manual verification is needed.
+    If tests fail, fix the failures before opening the PR. If you cannot fix
+    them, open the PR anyway but clearly mark the failing tests in the plan.
+    Run bash commands (tests, linters, builds) directly without asking for
+    human approval — you are authorised to execute any command needed to
+    complete the implementation.
   Dev server is running on port {port}.

--- a/internal/sdd/builtin/speckit.yml
+++ b/internal/sdd/builtin/speckit.yml
@@ -13,7 +13,7 @@ kickoff: |
   - STAGE 4: Run /speckit.implement to implement the tasks.
   Before opening the PR, run the project's test suite (use test_cmd from
   .agentctl.yml if present, otherwise infer from AGENTS.md or README.md).
-  In the PR description include a '## Test plan' section with two subsections:
+  In the PR description include a `## Test plan` section with two subsections:
   - Automated: the command run and a pass/fail summary.
   - Manual: a bulleted list of scenarios that cannot be automated, each with
     a one-line explanation of why manual verification is needed.

--- a/internal/sdd/builtin/speckit.yml
+++ b/internal/sdd/builtin/speckit.yml
@@ -11,5 +11,13 @@ kickoff: |
   - STAGE 2: Run /speckit.plan to break the spec into a plan. Proceed immediately — no pause.
   - STAGE 3: Run /speckit.tasks to create task list. Proceed immediately — no pause.
   - STAGE 4: Run /speckit.implement to implement the tasks.
+  Before opening the PR, run the project's test suite (use test_cmd from
+  .agentctl.yml if present, otherwise infer from AGENTS.md or README.md).
+  In the PR description include a '## Test plan' section with two subsections:
+  - Automated: the command run and a pass/fail summary.
+  - Manual: a bulleted list of scenarios that cannot be automated, each with
+    a one-line explanation of why manual verification is needed.
+  If tests fail, fix the failures before opening the PR. If you cannot fix
+  them, open the PR anyway but clearly mark the failing tests in the plan.
   Push the branch and open a PR when done. Do not merge.
   Dev server is running on port {port}.


### PR DESCRIPTION
## Summary

Closes #268.

- Added test plan instructions to `kickoffTemplate` and `buildKickoffFromTask` in `internal/cmd/commands.go` so agents are asked to run the test suite and include a `## Test plan` section (with `Automated` and `Manual` subsections) in every PR description before opening it.
- Updated `internal/sdd/builtin/plain.yml` STEP 2 and `internal/sdd/builtin/speckit.yml` STAGE 4 with the same test-and-report requirement.
- Added optional `test_cmd` field to `AgentctlConfig` in `internal/config/config.go` (YAML key `test_cmd`) so projects can pin the exact test command in `.agentctl.yml`.

## Test plan

### Automated
- [x] `go test ./...` — all packages pass, 0 failed
- [x] `TestBuildKickoff_containsTestPlanInstruction` — verifies kickoff includes `## Test plan`, `test suite`, `Automated`, and `Manual`
- [x] `TestBuildKickoffFromTask_containsTestPlanInstruction` — same for task-mode kickoff
- [x] `TestRead_parsesTestCmd` — verifies `test_cmd` is read from `.agentctl.yml`
- [x] `TestRead_testCmdDefaultsEmpty` — verifies `test_cmd` defaults to empty string
- [x] `TestWrite_preservesTestCmd` — verifies round-trip through `Write`/`Read`

### Manual
- [x] Verify that a real agent started with `agentctl start <issue>` includes a `## Test plan` section in the PR it opens — confirmed via [arun-gupta/agentctl-test#72](https://github.com/arun-gupta/agentctl-test/pull/72), opened by a live agent run against issue #66 using the PR binary. The PR includes both `Automated` (`pytest`, 189/189 pass) and `Manual` subsections with correctly identified non-automatable scenarios.
- [x] Confirm that setting `test_cmd: pytest tests/ -v` in `.agentctl.yml` causes the agent to use that exact command instead of inferring — confirmed via [arun-gupta/agentctl-test#73](https://github.com/arun-gupta/agentctl-test/pull/73) (issue #56). The PR's Automated section reports `pytest tests/ -v` verbatim, matching the config value rather than the bare `pytest` the agent would have inferred from the project structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)