### PR TITLE
feat: agentctl build — compile a test binary from an issue worktree

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -58,6 +58,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewDevCmd(),
 		cmd.NewStreamLogCmd(),
 		cmd.NewStreamLogOpenHandsCmd(),
+		cmd.NewBuildCmd(),
 	)
 
 	// Pre-register --version without a short alias so that cobra's lazy

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arun-gupta/agentctl/internal/config"
+	"github.com/arun-gupta/agentctl/internal/git"
+)
+
+// NewBuildCmd creates the `build` subcommand.
+func NewBuildCmd() *cobra.Command {
+	var outputPath string
+	var agentSuffix string
+
+	c := &cobra.Command{
+		Use:   "build <issue>",
+		Short: "Compile a binary from an issue worktree or PR branch",
+		Long: `Compile a binary from the worktree associated with an issue.
+
+Source resolution order:
+  1. Linked worktree exists — build directly from the worktree.
+  2. No worktree, but a local branch exists — check out into a temporary
+     worktree, build, then remove the temporary worktree.
+  3. Neither — error with a clear message.
+
+Build command resolution:
+  1. build_cmd in .agentctl.yml (use {output} as the binary path placeholder).
+  2. go.mod present → go build -o {output} ./cmd/<first-subdir> (or ./ if none).
+  3. package.json with a build script → npm run build.
+  4. Makefile with a build target → make build.
+
+The built binary path is printed on success.`,
+		Example: `  agentctl build 42
+  agentctl build 42 --output ~/bin/agentctl-test`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			issue := args[0]
+			if _, _, num, ok := parseIssueURL(issue); ok {
+				issue = num
+			}
+			return runBuild(issue, outputPath, agentSuffix, cmd.OutOrStdout())
+		},
+	}
+	c.Flags().StringVarP(&outputPath, "output", "o", "", `Output path for the compiled binary (default: /tmp/<repo>-<issue>)`)
+	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to disambiguate when multiple worktrees exist for the same issue")
+	return c
+}
+
+// runBuild is the core logic for `agentctl build`.
+func runBuild(issue, outputPath, agentSuffix string, out io.Writer) error {
+	repoRoot, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("cannot determine repo root: %w", err)
+	}
+
+	// Resolve output path.
+	if outputPath == "" {
+		repoName := filepath.Base(repoRoot)
+		outputPath = filepath.Join(os.TempDir(), repoName+"-"+issue)
+	}
+
+	cfg, err := config.Read(repoRoot)
+	if err != nil {
+		return fmt.Errorf("cannot read config: %w", err)
+	}
+
+	// Try worktree first (fast path).
+	wtPath, wtErr := findWorktreePath(issue, agentSuffix)
+	if wtErr == nil {
+		return buildFrom(wtPath, outputPath, cfg.BuildCmd, out)
+	}
+
+	// Fall back: look for a local branch.
+	branch, branchErr := git.FindBranchByIssuePrefix(repoRoot, issue)
+	if branchErr != nil || branch == "" {
+		// Attempt to fetch from remote before giving up.
+		if fetchErr := git.FetchBranch(repoRoot, issue+"-*"); fetchErr == nil {
+			branch, branchErr = git.FindBranchByIssuePrefix(repoRoot, issue)
+		}
+	}
+	if branchErr != nil || branch == "" {
+		return fmt.Errorf("no worktree and no branch found for issue %s", issue)
+	}
+
+	// Check out into a temporary worktree, build, then clean up.
+	tmpPath := filepath.Join(os.TempDir(), "agentctl-build-"+issue)
+	if err := git.CheckoutWorktree(repoRoot, tmpPath, branch); err != nil {
+		return fmt.Errorf("cannot check out branch %s: %w", branch, err)
+	}
+	defer func() { _ = git.RemoveWorktree(repoRoot, tmpPath) }()
+	return buildFrom(tmpPath, outputPath, cfg.BuildCmd, out)
+}
+
+// buildFrom runs the build command inside srcPath and reports the output binary.
+func buildFrom(srcPath, outputPath, configBuildCmd string, out io.Writer) error {
+	buildCmd, err := resolveBuildCmd(srcPath, configBuildCmd, outputPath)
+	if err != nil {
+		return err
+	}
+
+	c := exec.Command("sh", "-c", buildCmd) //nolint:gosec
+	c.Dir = srcPath
+	c.Stdout = out
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("build failed: %w", err)
+	}
+	fmt.Fprintf(out, "Built: %s\n", outputPath)
+	return nil
+}
+
+// resolveBuildCmd returns the build command to execute.
+// configBuildCmd takes highest priority; auto-detection is the fallback.
+func resolveBuildCmd(srcPath, configBuildCmd, outputPath string) (string, error) {
+	if configBuildCmd != "" {
+		return strings.ReplaceAll(configBuildCmd, "{output}", outputPath), nil
+	}
+	return detectBuildCmd(srcPath, outputPath)
+}
+
+// detectBuildCmd infers the build command from project files present in srcPath.
+func detectBuildCmd(srcPath, outputPath string) (string, error) {
+	// 1. go.mod
+	if _, err := os.Stat(filepath.Join(srcPath, "go.mod")); err == nil {
+		target, err := goTarget(srcPath)
+		if err != nil {
+			return "", err
+		}
+		return "go build -o " + outputPath + " " + target, nil
+	}
+
+	// 2. package.json with a build script
+	pkgJSON := filepath.Join(srcPath, "package.json")
+	if _, err := os.Stat(pkgJSON); err == nil {
+		if hasNPMBuildScript(pkgJSON) {
+			return "npm run build", nil
+		}
+	}
+
+	// 3. Makefile with a build target
+	makeFile := filepath.Join(srcPath, "Makefile")
+	if _, err := os.Stat(makeFile); err == nil {
+		if hasMakeTarget(makeFile, "build") {
+			return "make build", nil
+		}
+	}
+
+	return "", fmt.Errorf(
+		"cannot detect build command: no go.mod, package.json with build script, or Makefile with build target found in %s",
+		srcPath,
+	)
+}
+
+// goTarget returns the Go build target for the given source directory.
+// It prefers the first subdirectory of cmd/, falling back to "./".
+func goTarget(srcPath string) (string, error) {
+	cmdDir := filepath.Join(srcPath, "cmd")
+	entries, err := os.ReadDir(cmdDir)
+	if err != nil {
+		// No cmd/ directory — build from module root.
+		return "./", nil
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			return "./cmd/" + e.Name(), nil
+		}
+	}
+	return "./", nil
+}
+
+// hasNPMBuildScript reports whether package.json contains a "build" entry
+// under "scripts".
+func hasNPMBuildScript(pkgJSON string) bool {
+	data, err := os.ReadFile(pkgJSON)
+	if err != nil {
+		return false
+	}
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+	_, ok := pkg.Scripts["build"]
+	return ok
+}
+
+// hasMakeTarget reports whether the Makefile contains a target named target.
+func hasMakeTarget(makeFile, target string) bool {
+	data, err := os.ReadFile(makeFile)
+	if err != nil {
+		return false
+	}
+	prefix := target + ":"
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cmd/build_test.go
+++ b/internal/cmd/build_test.go
@@ -1,0 +1,347 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arun-gupta/agentctl/internal/config"
+	"github.com/arun-gupta/agentctl/internal/git"
+)
+
+// initBuildRepo creates a temporary git repo with an initial commit.
+// Tests are skipped when git is not available.
+func initBuildRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	dir := t.TempDir()
+	gitRun := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	gitRun("init")
+	gitRun("config", "user.email", "test@example.com")
+	gitRun("config", "user.name", "Test")
+	gitRun("config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun("add", ".")
+	gitRun("commit", "-m", "init")
+	return dir
+}
+
+// ─── NewBuildCmd flags ────────────────────────────────────────────────────────
+
+func TestNewBuildCmd_flags(t *testing.T) {
+	c := NewBuildCmd()
+	if c.Use != "build <issue>" {
+		t.Errorf("Use = %q, want %q", c.Use, "build <issue>")
+	}
+
+	outputFlag := c.Flags().Lookup("output")
+	if outputFlag == nil {
+		t.Fatal("--output flag not registered")
+	}
+	if outputFlag.Shorthand != "o" {
+		t.Errorf("--output shorthand = %q, want %q", outputFlag.Shorthand, "o")
+	}
+
+	agentFlag := c.Flags().Lookup("agent")
+	if agentFlag == nil {
+		t.Fatal("--agent flag not registered")
+	}
+}
+
+// ─── detectBuildCmd ───────────────────────────────────────────────────────────
+
+func TestDetectBuildCmd_goMod_withCmdDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/foo\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmdDir := filepath.Join(dir, "cmd", "myapp")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cmdDir, "main.go"), []byte("package main\nfunc main(){}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := detectBuildCmd(dir, "/tmp/out")
+	if err != nil {
+		t.Fatalf("detectBuildCmd: %v", err)
+	}
+	if !strings.Contains(got, "go build") {
+		t.Errorf("expected go build in cmd, got %q", got)
+	}
+	if !strings.Contains(got, "/tmp/out") {
+		t.Errorf("expected output path in cmd, got %q", got)
+	}
+	if !strings.Contains(got, "cmd/myapp") {
+		t.Errorf("expected cmd/myapp in cmd, got %q", got)
+	}
+}
+
+func TestDetectBuildCmd_goMod_noCmdDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/foo\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := detectBuildCmd(dir, "/tmp/out")
+	if err != nil {
+		t.Fatalf("detectBuildCmd: %v", err)
+	}
+	if !strings.Contains(got, "go build") {
+		t.Errorf("expected go build in cmd, got %q", got)
+	}
+	if !strings.Contains(got, "/tmp/out") {
+		t.Errorf("expected output path in cmd, got %q", got)
+	}
+	if !strings.Contains(got, "./") {
+		t.Errorf("expected module root ./  in cmd, got %q", got)
+	}
+}
+
+func TestDetectBuildCmd_packageJSON_withBuildScript(t *testing.T) {
+	dir := t.TempDir()
+	pkgJSON := `{"name":"foo","scripts":{"build":"webpack"}}`
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkgJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := detectBuildCmd(dir, "/tmp/out")
+	if err != nil {
+		t.Fatalf("detectBuildCmd: %v", err)
+	}
+	if got != "npm run build" {
+		t.Errorf("detectBuildCmd = %q, want %q", got, "npm run build")
+	}
+}
+
+func TestDetectBuildCmd_packageJSON_noBuildScript(t *testing.T) {
+	dir := t.TempDir()
+	pkgJSON := `{"name":"foo","scripts":{"test":"jest"}}`
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkgJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := detectBuildCmd(dir, "/tmp/out")
+	if err == nil {
+		t.Error("expected error for package.json without build script, got nil")
+	}
+}
+
+func TestDetectBuildCmd_makefile_withBuildTarget(t *testing.T) {
+	dir := t.TempDir()
+	makefile := "build:\n\tgo build -o bin/app .\n"
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte(makefile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := detectBuildCmd(dir, "/tmp/out")
+	if err != nil {
+		t.Fatalf("detectBuildCmd: %v", err)
+	}
+	if got != "make build" {
+		t.Errorf("detectBuildCmd = %q, want %q", got, "make build")
+	}
+}
+
+func TestDetectBuildCmd_makefile_noBuildTarget(t *testing.T) {
+	dir := t.TempDir()
+	makefile := "test:\n\tgo test ./...\n"
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte(makefile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := detectBuildCmd(dir, "/tmp/out")
+	if err == nil {
+		t.Error("expected error for Makefile without build target, got nil")
+	}
+}
+
+func TestDetectBuildCmd_noMatchingFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := detectBuildCmd(dir, "/tmp/out")
+	if err == nil {
+		t.Error("expected error when no build files found, got nil")
+	}
+}
+
+// ─── resolveBuildCmd ──────────────────────────────────────────────────────────
+
+func TestResolveBuildCmd_usesConfigWhenSet(t *testing.T) {
+	dir := t.TempDir()
+	got, err := resolveBuildCmd(dir, "go build -o {output} ./cmd/myapp", "/tmp/mybin")
+	if err != nil {
+		t.Fatalf("resolveBuildCmd: %v", err)
+	}
+	want := "go build -o /tmp/mybin ./cmd/myapp"
+	if got != want {
+		t.Errorf("resolveBuildCmd = %q, want %q", got, want)
+	}
+}
+
+func TestResolveBuildCmd_fallsBackToDetect(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/foo\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveBuildCmd(dir, "", "/tmp/out")
+	if err != nil {
+		t.Fatalf("resolveBuildCmd: %v", err)
+	}
+	if !strings.Contains(got, "go build") {
+		t.Errorf("expected go build, got %q", got)
+	}
+}
+
+// ─── runBuild integration ─────────────────────────────────────────────────────
+
+func TestRunBuild_noWorktreeNoBranch(t *testing.T) {
+	repo := initBuildRepo(t)
+	outPath := filepath.Join(t.TempDir(), "out")
+
+	// runBuild needs git.RepoRoot() to work; run it from within the repo.
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(orig) }()
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	err = runBuild("999", outPath, "", &strings.Builder{})
+	if err == nil {
+		t.Fatal("expected error when no worktree and no branch exist, got nil")
+	}
+	if !strings.Contains(err.Error(), "no worktree") && !strings.Contains(err.Error(), "no branch") {
+		t.Errorf("error message %q should mention worktree or branch", err.Error())
+	}
+}
+
+func TestRunBuild_worktreeExists_usesConfigBuildCmd(t *testing.T) {
+	repo := initBuildRepo(t)
+
+	// Create a linked worktree for issue 42.
+	wtPath := filepath.Join(t.TempDir(), "wt-42-feature")
+	if err := git.AddWorktree(repo, wtPath, "42-feature"); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+
+	// Write a .agentctl.yml into the worktree with a build_cmd that touches a file.
+	outPath := filepath.Join(t.TempDir(), "mybin")
+	touchCmd := "touch " + outPath
+	cfg := &config.AgentctlConfig{BuildCmd: touchCmd}
+	if err := config.Write(repo, cfg); err != nil {
+		t.Fatalf("config.Write: %v", err)
+	}
+
+	// Change into repo so git.RepoRoot() resolves.
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(orig) }()
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if err := runBuild("42", outPath, "", &out); err != nil {
+		t.Fatalf("runBuild: %v", err)
+	}
+	if !strings.Contains(out.String(), "Built:") {
+		t.Errorf("output %q should contain 'Built:'", out.String())
+	}
+	if !strings.Contains(out.String(), outPath) {
+		t.Errorf("output %q should contain output path", out.String())
+	}
+}
+
+func TestRunBuild_branchExists_checksOutTempWorktree(t *testing.T) {
+	repo := initBuildRepo(t)
+
+	// Create a local branch for issue 55 (no linked worktree).
+	branchCmd := exec.Command("git", "-C", repo, "branch", "55-my-feature")
+	if out, err := branchCmd.CombinedOutput(); err != nil {
+		t.Fatalf("create branch: %v\n%s", err, out)
+	}
+
+	// Write a .agentctl.yml with a build_cmd that touches a file.
+	outPath := filepath.Join(t.TempDir(), "built-bin")
+	touchCmd := "touch " + outPath
+	cfg := &config.AgentctlConfig{BuildCmd: touchCmd}
+	if err := config.Write(repo, cfg); err != nil {
+		t.Fatalf("config.Write: %v", err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(orig) }()
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if err := runBuild("55", outPath, "", &out); err != nil {
+		t.Fatalf("runBuild: %v", err)
+	}
+	if !strings.Contains(out.String(), "Built:") {
+		t.Errorf("output %q should contain 'Built:'", out.String())
+	}
+}
+
+func TestRunBuild_defaultOutputPath(t *testing.T) {
+	repo := initBuildRepo(t)
+
+	// Create a linked worktree for issue 77.
+	wtPath := filepath.Join(t.TempDir(), "wt-77-thing")
+	if err := git.AddWorktree(repo, wtPath, "77-thing"); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+
+	// Use a build_cmd that echoes the output path back.
+	cfg := &config.AgentctlConfig{BuildCmd: "echo built {output}"}
+	if err := config.Write(repo, cfg); err != nil {
+		t.Fatalf("config.Write: %v", err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(orig) }()
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	// Pass empty output path to trigger default.
+	if err := runBuild("77", "", "", &out); err != nil {
+		t.Fatalf("runBuild: %v", err)
+	}
+	output := out.String()
+	if !strings.Contains(output, "Built:") {
+		t.Errorf("output %q should contain 'Built:'", output)
+	}
+	// Default path should contain the issue number.
+	if !strings.Contains(output, "77") {
+		t.Errorf("default output path in %q should contain issue number 77", output)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,11 @@ type AgentctlConfig struct {
 	// Overridden per-invocation by the --agent flag.
 	DefaultAgent string `yaml:"default_agent,omitempty"`
 
+	// BuildCmd is the command used by agentctl build to compile the project.
+	// Use {output} as a placeholder for the output binary path.
+	// Example: "go build -o {output} ./cmd/myapp"
+	BuildCmd string `yaml:"build_cmd,omitempty"`
+
 	// VCS holds optional VCS provider overrides for self-hosted instances.
 	VCS VCSConfig `yaml:"vcs,omitempty"`
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -221,9 +221,22 @@ func AddWorktree(repoRoot, path, branch string) error {
 	return err
 }
 
+// CheckoutWorktree creates a new linked worktree at path from an existing branch.
+// Unlike AddWorktree, it does not create a new branch (-b flag is omitted).
+func CheckoutWorktree(repoRoot, path, branch string) error {
+	_, err := run(repoRoot, "-C", repoRoot, "worktree", "add", path, branch)
+	return err
+}
+
 // RemoveWorktree removes a registered linked worktree (force).
 func RemoveWorktree(repoRoot, path string) error {
 	_, err := run(repoRoot, "-C", repoRoot, "worktree", "remove", "--force", path)
+	return err
+}
+
+// FetchBranch fetches a single branch from origin into a local tracking branch.
+func FetchBranch(repoRoot, branch string) error {
+	_, err := run(repoRoot, "-C", repoRoot, "fetch", "origin", branch+":"+branch)
 	return err
 }
 


### PR DESCRIPTION
## Summary

Implements `agentctl build <issue>` as described in #271.

- **Source resolution**: linked worktree (fast path) → local/fetched branch in a temporary worktree → error
- **Build command resolution**: `build_cmd` in `.agentctl.yml` → `go.mod` → `package.json` with build script → `Makefile` with build target → error
- **`--output` / `-o`**: override the binary path (default `/tmp/<repo>-<issue>`)
- **`--agent`**: disambiguate when multiple worktrees exist for the same issue

### Files changed

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `BuildCmd` field to `AgentctlConfig` |
| `internal/git/git.go` | Add `CheckoutWorktree` (existing branch) and `FetchBranch` helpers |
| `internal/cmd/build.go` | New command implementation |
| `internal/cmd/build_test.go` | Tests for all scenarios |
| `cmd/agentctl/main.go` | Register `NewBuildCmd()` |

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes (all 11 packages)
- [x] `go vet ./...` reports no issues
- [x] `agentctl build --help` prints usage with `--output` and `--agent` flags
- [x] `agentctl build 42` with an active worktree builds from that worktree
- [x] `agentctl build 55` with only a local branch checks out a temp worktree, builds, cleans up
- [x] `agentctl build 999` with neither worktree nor branch gives a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #271