### PR TITLE
feat: per-run diagnostics — structured metadata for each agent run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 # Go test cache
 *.test
 *.out
+
+# Per-run diagnostics (local only; use agentctl report to view)
+.agentctl/runs/

--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -8,12 +8,13 @@
 //	agentctl discard    [issue]
 //	agentctl cleanup    [issue | --all]
 //	agentctl merge      [--strategy squash|merge|rebase] [--no-delete] [--dry-run] [issue]
-//	agentctl status     [--verbose]
+//	agentctl status     [--verbose] [--json]
 //	agentctl logs       [--lines N] [--no-follow] <issue>
 //	agentctl attach     <issue>
 //	agentctl diff       [--stat] [--base branch] [--no-pager] <issue>
 //	agentctl open       [--editor name] [--path] [--agent name] <issue>
 //	agentctl dev start  [--quiet] [issue]
+//	agentctl report     [--json]
 package main
 
 import (
@@ -56,6 +57,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewDiffCmd(),
 		cmd.NewOpenCmd(),
 		cmd.NewDevCmd(),
+		cmd.NewReportCmd(),
 		cmd.NewStreamLogCmd(),
 		cmd.NewStreamLogOpenHandsCmd(),
 	)

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1204,7 +1204,6 @@ func runMerge(issue, strategy, agentSuffix string, noDelete, dryRun bool) error 
 	return cleanupMerged(repoRoot, issue, agentSuffix)
 }
 
-
 // ─── cleanup-merged ───────────────────────────────────────────────────────────
 
 // NewCleanupMergedCmd creates the `cleanup-merged` subcommand.
@@ -1551,8 +1550,8 @@ func NewStatusCmd() *cobra.Command {
 Compact (default):  ISSUE  BRANCH  AGENT  PORT  SPEC  PR
 Verbose:            ISSUE  BRANCH  AGENT  PATH  PORT  DEV-PID  AGENT-PID  SPEC  PR  SESSION
 
-Use --json to emit a JSON array of run records from .agentctl/runs/ merged
-with live worktree data. Each entry includes issue, branch, agent, status,
+Use --json to emit a JSON array of run records from .agentctl/runs/.
+Each entry includes issue, branch, agent, status,
 started_at, elapsed_seconds, pr_url, files_changed, and tokens_used.
 
 Spec states:  no-spec | paused | in-progress | done
@@ -1727,8 +1726,8 @@ func runStatusJSON() error {
 // NewLogsCmd creates the `logs` subcommand.
 func NewLogsCmd() *cobra.Command {
 	var (
-		lines      int
-		noFollow   bool
+		lines       int
+		noFollow    bool
 		agentSuffix string
 	)
 	c := &cobra.Command{
@@ -2391,7 +2390,6 @@ func findLinkedWorktree(repoRoot, ref string) (git.Worktree, bool, error) {
 	return git.FindWorktreeByBranch(repoRoot, ref)
 }
 
-
 type prInfo struct {
 	Number int    `json:"number"`
 	Body   string `json:"body"`
@@ -2635,7 +2633,6 @@ func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
 	}
 	return nil
 }
-
 
 // slugFromTask derives a task branch name from the first six words of the
 // task description using the same slugging rules as GitHub issue titles.
@@ -4383,6 +4380,9 @@ func runReport(asJSON bool, out io.Writer) error {
 	}
 
 	if asJSON {
+		if records == nil {
+			records = []*diagnostics.RunRecord{}
+		}
 		data, err := json.MarshalIndent(records, "", "  ")
 		if err != nil {
 			return err
@@ -4422,7 +4422,7 @@ func runReport(asJSON bool, out io.Writer) error {
 		}
 		avgTime := "-"
 		if total > 0 {
-			avg := time.Duration(totalSec/float64(total)) * time.Second
+			avg := time.Duration((totalSec / float64(total)) * float64(time.Second))
 			avgTime = formatDuration(avg)
 		}
 		totalTokStr := "-"
@@ -4527,12 +4527,30 @@ func repoRootFromWorktree(wtPath string) string {
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(string(out), "\n") {
+	var first, currWT, currGitDir string
+	lines := append(strings.Split(string(out), "\n"), "")
+	for _, line := range lines {
+		if line == "" {
+			if currWT != "" {
+				if first == "" {
+					first = currWT
+				}
+				if currGitDir == filepath.Join(currWT, ".git") {
+					return currWT
+				}
+			}
+			currWT, currGitDir = "", ""
+			continue
+		}
 		if strings.HasPrefix(line, "worktree ") {
-			return strings.TrimPrefix(line, "worktree ")
+			currWT = strings.TrimPrefix(line, "worktree ")
+			continue
+		}
+		if strings.HasPrefix(line, "gitdir ") {
+			currGitDir = strings.TrimPrefix(line, "gitdir ")
 		}
 	}
-	return ""
+	return first
 }
 
 // countFilesChanged counts unique files modified on the current branch relative
@@ -4547,13 +4565,25 @@ func countFilesChanged(wtPath string) int {
 			return countNonEmptyLines(string(out))
 		}
 	}
-	cmd := exec.Command("git", "diff", "--name-only", "HEAD")
-	cmd.Dir = wtPath
-	out, err := cmd.Output()
-	if err != nil {
-		return 0
+	seen := map[string]struct{}{}
+	for _, args := range [][]string{
+		{"diff", "--name-only"},
+		{"diff", "--cached", "--name-only", "HEAD"},
+		{"ls-files", "--others", "--exclude-standard"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		out, err := cmd.Output()
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			if line != "" {
+				seen[line] = struct{}{}
+			}
+		}
 	}
-	return countNonEmptyLines(string(out))
+	return len(seen)
 }
 
 // countNonEmptyLines returns the number of non-empty lines in s.
@@ -4587,12 +4617,7 @@ func finaliseDiagnostics(repoRoot, wtPath string, af state.AgentFile, exitReason
 		r.FilesChanged = filesChanged
 	})
 	// Append a snapshot to the global cross-repo history.
-	if recs, err := diagnostics.List(repoRoot); err == nil {
-		for _, rec := range recs {
-			if diagnostics.RecordFilename(rec.Issue, rec.StartedAt) == runFile {
-				_ = diagnostics.AppendGlobal(rec)
-				break
-			}
-		}
+	if rec, err := diagnostics.Read(repoRoot, runFile); err == nil {
+		_ = diagnostics.AppendGlobal(&rec)
 	}
 }

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -4535,7 +4535,7 @@ func repoRootFromWorktree(wtPath string) string {
 				if first == "" {
 					first = currWT
 				}
-				if currGitDir == filepath.Join(currWT, ".git") {
+				if sameGitDir(currWT, currGitDir, filepath.Join(currWT, ".git")) {
 					return currWT
 				}
 			}
@@ -4551,6 +4551,22 @@ func repoRootFromWorktree(wtPath string) string {
 		}
 	}
 	return first
+}
+
+func sameGitDir(worktree, a, b string) bool {
+	normalize := func(p string) string {
+		if p == "" {
+			return ""
+		}
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(worktree, p)
+		}
+		if abs, err := filepath.Abs(p); err == nil {
+			p = abs
+		}
+		return filepath.Clean(p)
+	}
+	return normalize(a) == normalize(b)
 }
 
 // countFilesChanged counts unique files modified on the current branch relative

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/arun-gupta/agentctl/internal/adapters"
 	"github.com/arun-gupta/agentctl/internal/config"
+	"github.com/arun-gupta/agentctl/internal/diagnostics"
 	"github.com/arun-gupta/agentctl/internal/git"
 	"github.com/arun-gupta/agentctl/internal/notify"
 	"github.com/arun-gupta/agentctl/internal/process"
@@ -286,6 +287,8 @@ func resolveProvider(repoRoot string) (vcs.Provider, error) {
 // agentSuffix is non-empty only in multi-agent mode (--agent claude,codex);
 // it is appended to the branch name and worktree path to avoid collisions.
 func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, quiet, sendNotify bool, out io.Writer) error {
+	startedAt := time.Now()
+
 	// Validate the adapter exists before doing any setup work.
 	if err := validateAdapter(agentName); err != nil {
 		return err
@@ -386,6 +389,21 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 		return err
 	}
 
+	// Write initial diagnostics record and store the filename in .agent so later
+	// commands can locate and update it.
+	if isDiagnosticsEnabled(repoRoot) {
+		dr := &diagnostics.RunRecord{
+			Issue:      issueNum,
+			Branch:     branch,
+			Agent:      agentName,
+			StartedAt:  startedAt,
+			ExitReason: "in_progress",
+		}
+		if runFile, diagErr := diagnostics.Write(repoRoot, dr); diagErr == nil {
+			_ = state.AppendKey(wtPath, "run-file", runFile)
+		}
+	}
+
 	var kickoff string
 	if sddName == "" {
 		kickoff = buildKickoff(issueNum, portStr, p.Platform(), p.PRTerm())
@@ -411,6 +429,8 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 
 // startTask provisions a worktree for a free-form task and launches the agent.
 func startTask(task, branch, agentName, sddName string, headless, quiet, sendNotify bool, out io.Writer) error {
+	startedAt := time.Now()
+
 	if strings.TrimSpace(task) == "" {
 		return fmt.Errorf("--task requires a non-empty task description")
 	}
@@ -490,6 +510,20 @@ func startTask(task, branch, agentName, sddName string, headless, quiet, sendNot
 	}
 	if err := state.Write(wtPath, af); err != nil {
 		return err
+	}
+
+	// Write initial diagnostics record for task-mode runs.
+	if isDiagnosticsEnabled(repoRoot) {
+		dr := &diagnostics.RunRecord{
+			Issue:      branch, // task mode: use branch name as the identifier
+			Branch:     branch,
+			Agent:      agentName,
+			StartedAt:  startedAt,
+			ExitReason: "in_progress",
+		}
+		if runFile, diagErr := diagnostics.Write(repoRoot, dr); diagErr == nil {
+			_ = state.AppendKey(wtPath, "run-file", runFile)
+		}
 	}
 
 	var kickoff string
@@ -998,6 +1032,8 @@ func runRemoveWorktree(issue, agentSuffix string) error {
 	// Kill running processes.
 	if wtPath != "" {
 		af, _ := state.Read(wtPath)
+		// Write diagnostics before removing the worktree (run-file may be inside it).
+		finaliseDiagnostics(repoRoot, wtPath, af, "discarded")
 		process.Kill(af.DevPID)
 		process.Kill(af.AgentPID)
 		if err := git.RemoveWorktree(repoRoot, wtPath); err != nil {
@@ -1505,6 +1541,7 @@ func runCleanupAllMerged() error {
 // NewStatusCmd creates the `status` subcommand.
 func NewStatusCmd() *cobra.Command {
 	var verbose bool
+	var asJSON bool
 	c := &cobra.Command{
 		Use:     "status",
 		Aliases: []string{"list"},
@@ -1514,14 +1551,22 @@ func NewStatusCmd() *cobra.Command {
 Compact (default):  ISSUE  BRANCH  AGENT  PORT  SPEC  PR
 Verbose:            ISSUE  BRANCH  AGENT  PATH  PORT  DEV-PID  AGENT-PID  SPEC  PR  SESSION
 
+Use --json to emit a JSON array of run records from .agentctl/runs/ merged
+with live worktree data. Each entry includes issue, branch, agent, status,
+started_at, elapsed_seconds, pr_url, files_changed, and tokens_used.
+
 Spec states:  no-spec | paused | in-progress | done
 PR states:    none | OPEN | MERGED | CLOSED`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if asJSON {
+				return runStatusJSON()
+			}
 			return runStatus(verbose)
 		},
 	}
 	c.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show full table including PATH, PIDs, and SESSION")
+	c.Flags().BoolVar(&asJSON, "json", false, "Emit JSON array of run records from .agentctl/runs/")
 	return c
 }
 
@@ -1624,6 +1669,57 @@ func runStatus(verbose bool) error {
 		}
 	}
 	return w.Flush()
+}
+
+// runStatusJSON emits a JSON array of run records from .agentctl/runs/,
+// sorted by started_at descending (newest first).
+func runStatusJSON() error {
+	repoRoot, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("cannot determine repo root: %w", err)
+	}
+	records, err := diagnostics.List(repoRoot)
+	if err != nil {
+		return fmt.Errorf("reading run records: %w", err)
+	}
+	// Reverse to show newest first.
+	for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
+		records[i], records[j] = records[j], records[i]
+	}
+	// statusJSON is a JSON-friendly projection of RunRecord with a "status" alias.
+	type statusJSON struct {
+		Issue          string     `json:"issue"`
+		Branch         string     `json:"branch"`
+		Agent          string     `json:"agent"`
+		Status         string     `json:"status"`
+		StartedAt      time.Time  `json:"started_at"`
+		StoppedAt      *time.Time `json:"stopped_at,omitempty"`
+		ElapsedSeconds float64    `json:"elapsed_seconds,omitempty"`
+		PRURL          string     `json:"pr_url,omitempty"`
+		FilesChanged   int        `json:"files_changed,omitempty"`
+		TokensUsed     int64      `json:"tokens_used,omitempty"`
+	}
+	out := make([]statusJSON, 0, len(records))
+	for _, r := range records {
+		out = append(out, statusJSON{
+			Issue:          r.Issue,
+			Branch:         r.Branch,
+			Agent:          r.Agent,
+			Status:         r.ExitReason,
+			StartedAt:      r.StartedAt,
+			StoppedAt:      r.StoppedAt,
+			ElapsedSeconds: r.ElapsedSeconds,
+			PRURL:          r.PRURL,
+			FilesChanged:   r.FilesChanged,
+			TokensUsed:     r.TokensUsed,
+		})
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
 }
 
 // ─── logs ─────────────────────────────────────────────────────────────────────
@@ -1732,19 +1828,36 @@ func streamLog(wtPath, issue string, lines int, noFollow bool, w io.Writer, logW
 				if id == "" {
 					id = issue
 				}
+				branch2, _ := git.CurrentBranch(wtPath)
 				specPath := findSpecPath(wtPath, issue)
 				switch {
 				case af2.SDD != "" && af2.SDDStage < 2 && specPath != "":
 					fmt.Fprintf(w, "Spec: %s\nSpec ready for review — agentctl resume %s\n", specPath, id)
 				case af2.SDD != "" && af2.SDDStage >= 2:
-					branch, _ := git.CurrentBranch(wtPath)
-					if reportPRStatus(w, wtPath, branch, issue, false) {
+					if reportPRStatus(w, wtPath, branch2, issue, false) {
 						fmt.Fprintf(w, "agentctl cleanup %s   # after PR is merged\n", id)
 					} else {
 						fmt.Fprintf(w, "agent process has exited\n")
 					}
 				default:
 					fmt.Fprintf(w, "agent process has exited\n")
+				}
+				// Update diagnostics: determine exit reason and PR URL.
+				if repoRoot2 := repoRootFromWorktree(wtPath); repoRoot2 != "" {
+					exitReason := "failed"
+					prURL := af2.PRURL
+					if prURL == "" && branch2 != "" {
+						if p2, pErr := resolveProvider(repoRoot2); pErr == nil {
+							if _, _, foundURL, pErr := p2.PRForBranch(repoRoot2, branch2); pErr == nil && foundURL != "" {
+								prURL = foundURL
+							}
+						}
+					}
+					if prURL != "" {
+						exitReason = "pr_opened"
+					}
+					af2.PRURL = prURL
+					finaliseDiagnostics(repoRoot2, wtPath, af2, exitReason)
 				}
 				return nil
 			}
@@ -4233,6 +4346,253 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", id2)
 			fmt.Fprintf(os.Stdout, "  agentctl discard %s  # permanently delete worktree and branches\n", id2)
 			return nil
+		}
+	}
+}
+
+// ─── report ───────────────────────────────────────────────────────────────────
+
+// NewReportCmd creates the `report` subcommand.
+func NewReportCmd() *cobra.Command {
+	var asJSON bool
+	c := &cobra.Command{
+		Use:   "report",
+		Short: "Aggregate view of all agent runs in the current repo",
+		Long: `Print a summary of all agent runs recorded in .agentctl/runs/.
+
+Default output shows period aggregates (last 7 and 30 days) and the
+slowest individual runs. Use --json for machine-readable output suitable
+for piping into dashboards or cost-accounting scripts.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReport(asJSON, os.Stdout)
+		},
+	}
+	c.Flags().BoolVar(&asJSON, "json", false, "Emit all run records as a JSON array")
+	return c
+}
+
+func runReport(asJSON bool, out io.Writer) error {
+	repoRoot, err := git.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("cannot determine repo root: %w", err)
+	}
+	records, err := diagnostics.List(repoRoot)
+	if err != nil {
+		return fmt.Errorf("reading run records: %w", err)
+	}
+
+	if asJSON {
+		data, err := json.MarshalIndent(records, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(out, string(data))
+		return nil
+	}
+
+	now := time.Now()
+	periods := []struct {
+		label string
+		since time.Duration
+	}{
+		{"Last 7 days", 7 * 24 * time.Hour},
+		{"Last 30 days", 30 * 24 * time.Hour},
+	}
+
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "PERIOD\tRUNS\tSUCCESS\tFAILED\tAVG TIME\tTOTAL TOKENS")
+	for _, p := range periods {
+		cutoff := now.Add(-p.since)
+		var total, success, failed int
+		var totalSec, totalTokens float64
+		for _, r := range records {
+			if r.StartedAt.Before(cutoff) {
+				continue
+			}
+			total++
+			switch r.ExitReason {
+			case "pr_opened":
+				success++
+			case "failed", "discarded":
+				failed++
+			}
+			totalSec += r.ElapsedSeconds
+			totalTokens += float64(r.TokensUsed)
+		}
+		avgTime := "-"
+		if total > 0 {
+			avg := time.Duration(totalSec/float64(total)) * time.Second
+			avgTime = formatDuration(avg)
+		}
+		totalTokStr := "-"
+		if totalTokens > 0 {
+			totalTokStr = formatTokens(totalTokens)
+		}
+		fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%s\t%s\n",
+			p.label, total, success, failed, avgTime, totalTokStr)
+	}
+	_ = tw.Flush()
+
+	// Slowest completed runs.
+	type slowRun struct {
+		issue   string
+		branch  string
+		elapsed float64
+		outcome string
+	}
+	var completed []slowRun
+	for _, r := range records {
+		if r.ExitReason == "in_progress" || r.ElapsedSeconds == 0 {
+			continue
+		}
+		completed = append(completed, slowRun{
+			issue:   r.Issue,
+			branch:  r.Branch,
+			elapsed: r.ElapsedSeconds,
+			outcome: r.ExitReason,
+		})
+	}
+	// Sort descending by elapsed.
+	for i := 0; i < len(completed)-1; i++ {
+		for j := i + 1; j < len(completed); j++ {
+			if completed[j].elapsed > completed[i].elapsed {
+				completed[i], completed[j] = completed[j], completed[i]
+			}
+		}
+	}
+	if len(completed) > 10 {
+		completed = completed[:10]
+	}
+	if len(completed) > 0 {
+		fmt.Fprintln(out, "\nSLOWEST RUNS")
+		tw2 := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw2, "ISSUE\tBRANCH\tELAPSED\tOUTCOME")
+		for _, r := range completed {
+			fmt.Fprintf(tw2, "%s\t%s\t%s\t%s\n",
+				r.issue, r.branch,
+				formatDuration(time.Duration(r.elapsed)*time.Second),
+				r.outcome)
+		}
+		_ = tw2.Flush()
+	}
+	return nil
+}
+
+// formatDuration renders a duration as "Xh Ym Zs" (or just "Ym Zs" / "Zs").
+func formatDuration(d time.Duration) string {
+	d = d.Truncate(time.Second)
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh %02dm %02ds", h, m, s)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm %02ds", m, s)
+	}
+	return fmt.Sprintf("%ds", s)
+}
+
+// formatTokens renders a token count as "1.2M", "87.4K", or the raw number.
+func formatTokens(t float64) string {
+	switch {
+	case t >= 1_000_000:
+		return fmt.Sprintf("%.1fM", t/1_000_000)
+	case t >= 1_000:
+		return fmt.Sprintf("%.1fK", t/1_000)
+	default:
+		return fmt.Sprintf("%.0f", t)
+	}
+}
+
+// ─── diagnostics helpers ──────────────────────────────────────────────────────
+
+// isDiagnosticsEnabled reports whether per-run diagnostics are enabled for repoRoot.
+// Diagnostics are on by default; set diagnostics.enabled: false in .agentctl.yml to opt out.
+func isDiagnosticsEnabled(repoRoot string) bool {
+	cfg, err := config.Read(repoRoot)
+	if err != nil || cfg.Diagnostics.Enabled == nil {
+		return true
+	}
+	return *cfg.Diagnostics.Enabled
+}
+
+// repoRootFromWorktree returns the primary (main) worktree path by running
+// `git worktree list --porcelain` from wtPath. Returns "" on failure.
+func repoRootFromWorktree(wtPath string) string {
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = wtPath
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "worktree ") {
+			return strings.TrimPrefix(line, "worktree ")
+		}
+	}
+	return ""
+}
+
+// countFilesChanged counts unique files modified on the current branch relative
+// to the first reachable base branch among main, master, origin/main, origin/master.
+// Falls back to counting uncommitted (staged+unstaged) changes.
+func countFilesChanged(wtPath string) int {
+	for _, base := range []string{"main", "master", "origin/main", "origin/master"} {
+		cmd := exec.Command("git", "diff", "--name-only", base+"...HEAD")
+		cmd.Dir = wtPath
+		out, err := cmd.Output()
+		if err == nil {
+			return countNonEmptyLines(string(out))
+		}
+	}
+	cmd := exec.Command("git", "diff", "--name-only", "HEAD")
+	cmd.Dir = wtPath
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	return countNonEmptyLines(string(out))
+}
+
+// countNonEmptyLines returns the number of non-empty lines in s.
+func countNonEmptyLines(s string) int {
+	n := 0
+	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
+		if line != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// finaliseDiagnostics updates the run record for wtPath with stop time,
+// exit reason, PR URL, and files changed, then appends to the global history.
+func finaliseDiagnostics(repoRoot, wtPath string, af state.AgentFile, exitReason string) {
+	runFile := af.Extra["run-file"]
+	if runFile == "" || !isDiagnosticsEnabled(repoRoot) {
+		return
+	}
+	stoppedAt := time.Now()
+	prURL := af.PRURL
+	filesChanged := countFilesChanged(wtPath)
+	_ = diagnostics.Update(repoRoot, runFile, func(r *diagnostics.RunRecord) {
+		r.StoppedAt = &stoppedAt
+		r.ElapsedSeconds = stoppedAt.Sub(r.StartedAt).Seconds()
+		r.ExitReason = exitReason
+		if prURL != "" {
+			r.PRURL = prURL
+		}
+		r.FilesChanged = filesChanged
+	})
+	// Append a snapshot to the global cross-repo history.
+	if recs, err := diagnostics.List(repoRoot); err == nil {
+		for _, rec := range recs {
+			if diagnostics.RecordFilename(rec.Issue, rec.StartedAt) == runFile {
+				_ = diagnostics.AppendGlobal(rec)
+				break
+			}
 		}
 	}
 }

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5989,7 +5989,7 @@ func TestRepoRootFromWorktreePicksPrimaryWorktree(t *testing.T) {
 		secondary,
 		filepath.Join(repoRoot, ".git", "worktrees", "feature"),
 		repoRoot,
-		filepath.Join(repoRoot, ".git"),
+		".git",
 	)
 	gitPath := filepath.Join(stubDir, "git")
 	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5959,3 +5959,72 @@ func TestStartCmd_defaultAgent_invalidConfigReturnsError(t *testing.T) {
 		t.Errorf("error %q does not describe YAML parsing failure", err.Error())
 	}
 }
+
+func TestRunReportJSONEmptyArray(t *testing.T) {
+	dir := initGitRepoForStale(t)
+	chdirTemp(t, dir)
+
+	var out bytes.Buffer
+	if err := runReport(true, &out); err != nil {
+		t.Fatalf("runReport(--json): %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "[]" {
+		t.Fatalf("runReport(--json) = %q, want []", got)
+	}
+}
+
+func TestRepoRootFromWorktreePicksPrimaryWorktree(t *testing.T) {
+	stubDir := t.TempDir()
+	repoRoot := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repoRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll repoRoot: %v", err)
+	}
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	if err := os.MkdirAll(wtPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll wtPath: %v", err)
+	}
+
+	secondary := filepath.Join(repoRoot, "feature-wt")
+	script := fmt.Sprintf("#!/bin/sh\ncat <<'EOF'\nworktree %s\nHEAD deadbeef\nbranch refs/heads/feature\ngitdir %s\n\nworktree %s\nHEAD cafebabe\nbranch refs/heads/main\ngitdir %s\nEOF\n",
+		secondary,
+		filepath.Join(repoRoot, ".git", "worktrees", "feature"),
+		repoRoot,
+		filepath.Join(repoRoot, ".git"),
+	)
+	gitPath := filepath.Join(stubDir, "git")
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile git stub: %v", err)
+	}
+	prependPath(t, stubDir)
+
+	if got := repoRootFromWorktree(wtPath); got != repoRoot {
+		t.Fatalf("repoRootFromWorktree() = %q, want %q", got, repoRoot)
+	}
+}
+
+func TestCountFilesChangedFallbackIncludesStagedAndUnstaged(t *testing.T) {
+	dir := initGitRepoForStale(t)
+	gitRun := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Force the helper into fallback mode by ensuring main/master refs do not exist.
+	gitRun("branch", "-m", "topic")
+
+	if err := os.WriteFile(filepath.Join(dir, "staged.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile staged.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "unstaged.txt"), []byte("b\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile unstaged.txt: %v", err)
+	}
+	gitRun("add", "staged.txt")
+
+	if got := countFilesChanged(dir); got != 2 {
+		t.Fatalf("countFilesChanged() = %d, want 2", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,17 @@ type AgentctlConfig struct {
 
 	// VCS holds optional VCS provider overrides for self-hosted instances.
 	VCS VCSConfig `yaml:"vcs,omitempty"`
+
+	// Diagnostics controls per-run structured metadata collection.
+	// Set enabled: false to disable writing run records to .agentctl/runs/.
+	Diagnostics DiagnosticsConfig `yaml:"diagnostics,omitempty"`
+}
+
+// DiagnosticsConfig controls per-run structured metadata collection.
+type DiagnosticsConfig struct {
+	// Enabled controls whether per-run diagnostics are written.
+	// Defaults to true when the field is absent.
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // Read loads .agentctl.yml from dir. If the file does not exist, an empty

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -60,7 +60,7 @@ func safeIdentifier(s string) string {
 			b.WriteByte('_')
 		}
 	}
-	out := strings.Trim(b.String(), "._-")
+	out := b.String()
 	if out == "" {
 		return "run"
 	}
@@ -161,6 +161,7 @@ func AppendGlobal(r *RunRecord) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
+	// Tighten permissions for existing directories created by older versions.
 	if err := os.Chmod(dir, 0o700); err != nil {
 		return err
 	}
@@ -170,6 +171,7 @@ func AppendGlobal(r *RunRecord) error {
 		return err
 	}
 	defer f.Close()
+	// Tighten permissions for existing history files created by older versions.
 	if err := os.Chmod(path, 0o600); err != nil {
 		return err
 	}

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -1,0 +1,142 @@
+// Package diagnostics writes and reads per-run structured metadata for agentctl.
+// Each agent run is persisted as a JSON file under .agentctl/runs/<issue>-<ts>.json
+// inside the repo, and a single-line JSON entry is appended to
+// ~/.config/agentctl/run-history.jsonl for cross-repo reporting.
+package diagnostics
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/arun-gupta/agentctl/internal/xdg"
+)
+
+const (
+	runsSubdir        = ".agentctl/runs"
+	globalHistoryFile = "run-history.jsonl"
+)
+
+// RunRecord captures structured metadata for a single agent run.
+type RunRecord struct {
+	Issue          string     `json:"issue"`
+	Branch         string     `json:"branch"`
+	Agent          string     `json:"agent"`
+	StartedAt      time.Time  `json:"started_at"`
+	StoppedAt      *time.Time `json:"stopped_at,omitempty"`
+	ElapsedSeconds float64    `json:"elapsed_seconds,omitempty"`
+	// ExitReason is one of: pr_opened, discarded, failed, in_progress.
+	ExitReason   string `json:"exit_reason,omitempty"`
+	PRURL        string `json:"pr_url,omitempty"`
+	FilesChanged int    `json:"files_changed,omitempty"`
+	TokensUsed   int64  `json:"tokens_used,omitempty"`
+	Template     string `json:"template,omitempty"`
+	Scheduled    bool   `json:"scheduled,omitempty"`
+}
+
+// RecordFilename returns the base filename for a run record: "<issue>-<ts>.json".
+func RecordFilename(issue string, startedAt time.Time) string {
+	ts := startedAt.UTC().Format("20060102T150405Z")
+	return issue + "-" + ts + ".json"
+}
+
+// Write creates (or overwrites) a run record in <repoRoot>/.agentctl/runs/.
+// It returns the base filename so callers can store it in the .agent state file.
+func Write(repoRoot string, r *RunRecord) (string, error) {
+	dir := filepath.Join(repoRoot, runsSubdir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	filename := RecordFilename(r.Issue, r.StartedAt)
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(dir, filename), data, 0o644); err != nil {
+		return "", err
+	}
+	return filename, nil
+}
+
+// Update reads the named file from <repoRoot>/.agentctl/runs/, applies fn to
+// the record, and writes it back. It is a no-op when the file does not exist.
+func Update(repoRoot, filename string, fn func(*RunRecord)) error {
+	path := filepath.Join(repoRoot, runsSubdir, filename)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var r RunRecord
+	if err := json.Unmarshal(data, &r); err != nil {
+		return err
+	}
+	fn(&r)
+	out, err := json.MarshalIndent(&r, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o644)
+}
+
+// List reads all run records from <repoRoot>/.agentctl/runs/, returning them
+// sorted by StartedAt ascending. An absent directory returns nil, nil.
+func List(repoRoot string) ([]*RunRecord, error) {
+	dir := filepath.Join(repoRoot, runsSubdir)
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var records []*RunRecord
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, readErr := os.ReadFile(filepath.Join(dir, e.Name()))
+		if readErr != nil {
+			continue
+		}
+		var r RunRecord
+		if jsonErr := json.Unmarshal(data, &r); jsonErr != nil {
+			continue
+		}
+		records = append(records, &r)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].StartedAt.Before(records[j].StartedAt)
+	})
+	return records, nil
+}
+
+// AppendGlobal appends r as a single newline-terminated JSON line to
+// ~/.config/agentctl/run-history.jsonl (created if absent).
+func AppendGlobal(r *RunRecord) error {
+	cfgDir := xdg.UserConfigDir()
+	if cfgDir == "" {
+		return nil // silently skip when config dir is unavailable
+	}
+	dir := filepath.Join(cfgDir, "agentctl")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, globalHistoryFile)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	data, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(append(data, '\n'))
+	return err
+}

--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -6,6 +6,7 @@ package diagnostics
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -40,7 +41,30 @@ type RunRecord struct {
 // RecordFilename returns the base filename for a run record: "<issue>-<ts>.json".
 func RecordFilename(issue string, startedAt time.Time) string {
 	ts := startedAt.UTC().Format("20060102T150405Z")
-	return issue + "-" + ts + ".json"
+	return safeIdentifier(issue) + "-" + ts + ".json"
+}
+
+func safeIdentifier(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "run"
+	}
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := strings.Trim(b.String(), "._-")
+	if out == "" {
+		return "run"
+	}
+	return out
 }
 
 // Write creates (or overwrites) a run record in <repoRoot>/.agentctl/runs/.
@@ -65,15 +89,11 @@ func Write(repoRoot string, r *RunRecord) (string, error) {
 // the record, and writes it back. It is a no-op when the file does not exist.
 func Update(repoRoot, filename string, fn func(*RunRecord)) error {
 	path := filepath.Join(repoRoot, runsSubdir, filename)
-	data, err := os.ReadFile(path)
+	r, err := Read(repoRoot, filename)
 	if os.IsNotExist(err) {
 		return nil
 	}
 	if err != nil {
-		return err
-	}
-	var r RunRecord
-	if err := json.Unmarshal(data, &r); err != nil {
 		return err
 	}
 	fn(&r)
@@ -82,6 +102,20 @@ func Update(repoRoot, filename string, fn func(*RunRecord)) error {
 		return err
 	}
 	return os.WriteFile(path, out, 0o644)
+}
+
+// Read reads and unmarshals a named run record from <repoRoot>/.agentctl/runs/.
+func Read(repoRoot, filename string) (RunRecord, error) {
+	path := filepath.Join(repoRoot, runsSubdir, filename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return RunRecord{}, err
+	}
+	var r RunRecord
+	if err := json.Unmarshal(data, &r); err != nil {
+		return RunRecord{}, err
+	}
+	return r, nil
 }
 
 // List reads all run records from <repoRoot>/.agentctl/runs/, returning them
@@ -102,11 +136,11 @@ func List(repoRoot string) ([]*RunRecord, error) {
 		}
 		data, readErr := os.ReadFile(filepath.Join(dir, e.Name()))
 		if readErr != nil {
-			continue
+			return nil, fmt.Errorf("read run record %q: %w", e.Name(), readErr)
 		}
 		var r RunRecord
 		if jsonErr := json.Unmarshal(data, &r); jsonErr != nil {
-			continue
+			return nil, fmt.Errorf("parse run record %q: %w", e.Name(), jsonErr)
 		}
 		records = append(records, &r)
 	}
@@ -124,15 +158,21 @@ func AppendGlobal(r *RunRecord) error {
 		return nil // silently skip when config dir is unavailable
 	}
 	dir := filepath.Join(cfgDir, "agentctl")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
 		return err
 	}
 	path := filepath.Join(dir, globalHistoryFile)
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
+	if err := os.Chmod(path, 0o600); err != nil {
+		return err
+	}
 	data, err := json.Marshal(r)
 	if err != nil {
 		return err

--- a/internal/diagnostics/diagnostics_test.go
+++ b/internal/diagnostics/diagnostics_test.go
@@ -1,0 +1,240 @@
+package diagnostics_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/arun-gupta/agentctl/internal/diagnostics"
+)
+
+func TestWriteAndList(t *testing.T) {
+	repoRoot := t.TempDir()
+	now := time.Date(2026, 5, 1, 10, 4, 11, 0, time.UTC)
+
+	r := &diagnostics.RunRecord{
+		Issue:     "42",
+		Branch:    "feat/42-dark-mode",
+		Agent:     "claude",
+		StartedAt: now,
+		ExitReason: "in_progress",
+	}
+
+	filename, err := diagnostics.Write(repoRoot, r)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if filename == "" {
+		t.Fatal("Write returned empty filename")
+	}
+
+	records, err := diagnostics.List(repoRoot)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("List: got %d records, want 1", len(records))
+	}
+	got := records[0]
+	if got.Issue != "42" {
+		t.Errorf("Issue: got %q, want %q", got.Issue, "42")
+	}
+	if got.Branch != "feat/42-dark-mode" {
+		t.Errorf("Branch: got %q, want %q", got.Branch, "feat/42-dark-mode")
+	}
+	if got.Agent != "claude" {
+		t.Errorf("Agent: got %q, want %q", got.Agent, "claude")
+	}
+	if !got.StartedAt.Equal(now) {
+		t.Errorf("StartedAt: got %v, want %v", got.StartedAt, now)
+	}
+	if got.ExitReason != "in_progress" {
+		t.Errorf("ExitReason: got %q, want %q", got.ExitReason, "in_progress")
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	repoRoot := t.TempDir()
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	stopped := now.Add(30 * time.Minute)
+
+	r := &diagnostics.RunRecord{
+		Issue:      "99",
+		Branch:     "feat/99-test",
+		Agent:      "claude",
+		StartedAt:  now,
+		ExitReason: "in_progress",
+	}
+
+	filename, err := diagnostics.Write(repoRoot, r)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	err = diagnostics.Update(repoRoot, filename, func(rec *diagnostics.RunRecord) {
+		rec.StoppedAt = &stopped
+		rec.ElapsedSeconds = stopped.Sub(rec.StartedAt).Seconds()
+		rec.ExitReason = "pr_opened"
+		rec.PRURL = "https://github.com/owner/repo/pull/5"
+		rec.FilesChanged = 7
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	records, err := diagnostics.List(repoRoot)
+	if err != nil {
+		t.Fatalf("List after Update: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	got := records[0]
+	if got.ExitReason != "pr_opened" {
+		t.Errorf("ExitReason: got %q, want %q", got.ExitReason, "pr_opened")
+	}
+	if got.StoppedAt == nil || !got.StoppedAt.Equal(stopped) {
+		t.Errorf("StoppedAt: got %v, want %v", got.StoppedAt, stopped)
+	}
+	if got.ElapsedSeconds != 1800 {
+		t.Errorf("ElapsedSeconds: got %v, want 1800", got.ElapsedSeconds)
+	}
+	if got.PRURL != "https://github.com/owner/repo/pull/5" {
+		t.Errorf("PRURL: got %q", got.PRURL)
+	}
+	if got.FilesChanged != 7 {
+		t.Errorf("FilesChanged: got %d, want 7", got.FilesChanged)
+	}
+}
+
+func TestListEmpty(t *testing.T) {
+	repoRoot := t.TempDir()
+	records, err := diagnostics.List(repoRoot)
+	if err != nil {
+		t.Fatalf("List on empty dir: %v", err)
+	}
+	if len(records) != 0 {
+		t.Errorf("expected 0 records, got %d", len(records))
+	}
+}
+
+func TestListSortedByStartedAt(t *testing.T) {
+	repoRoot := t.TempDir()
+	base := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+
+	// Write records out of order by sleeping a second between timestamps.
+	for _, offset := range []time.Duration{2 * time.Hour, 0, time.Hour} {
+		ts := base.Add(offset)
+		r := &diagnostics.RunRecord{
+			Issue:     "1",
+			Branch:    "feat/1",
+			Agent:     "claude",
+			StartedAt: ts,
+		}
+		if _, err := diagnostics.Write(repoRoot, r); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	records, err := diagnostics.List(repoRoot)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(records) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(records))
+	}
+	for i := 1; i < len(records); i++ {
+		if records[i].StartedAt.Before(records[i-1].StartedAt) {
+			t.Errorf("records not sorted ascending at index %d", i)
+		}
+	}
+}
+
+func TestRecordFilenameFormat(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 10, 4, 11, 0, time.UTC)
+	got := diagnostics.RecordFilename("42", ts)
+	want := "42-20260501T100411Z.json"
+	if got != want {
+		t.Errorf("RecordFilename: got %q, want %q", got, want)
+	}
+}
+
+func TestWriteCreatesDirectory(t *testing.T) {
+	repoRoot := t.TempDir()
+	r := &diagnostics.RunRecord{
+		Issue:     "5",
+		Branch:    "feat/5",
+		Agent:     "claude",
+		StartedAt: time.Now(),
+	}
+	if _, err := diagnostics.Write(repoRoot, r); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	dir := filepath.Join(repoRoot, ".agentctl", "runs")
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("runs directory not created: %v", err)
+	}
+}
+
+func TestWriteProducesValidJSON(t *testing.T) {
+	repoRoot := t.TempDir()
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	r := &diagnostics.RunRecord{
+		Issue:     "7",
+		Branch:    "feat/7",
+		Agent:     "claude",
+		StartedAt: now,
+	}
+	filename, err := diagnostics.Write(repoRoot, r)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot, ".agentctl", "runs", filename))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("JSON unmarshal: %v", err)
+	}
+	if parsed["issue"] != "7" {
+		t.Errorf("JSON issue: got %v, want %q", parsed["issue"], "7")
+	}
+}
+
+func TestAppendGlobal(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	r := &diagnostics.RunRecord{
+		Issue:     "42",
+		Branch:    "feat/42",
+		Agent:     "claude",
+		StartedAt: now,
+	}
+
+	if err := diagnostics.AppendGlobal(r); err != nil {
+		t.Fatalf("AppendGlobal: %v", err)
+	}
+	if err := diagnostics.AppendGlobal(r); err != nil {
+		t.Fatalf("AppendGlobal second call: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmp, "agentctl", "run-history.jsonl"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	lines := 0
+	for _, line := range filepath.SplitList(string(data)) {
+		if line != "" {
+			lines++
+		}
+	}
+	// Should have 2 newline-delimited JSON lines.
+	if lines < 2 {
+		t.Logf("raw content:\n%s", data)
+	}
+}

--- a/internal/diagnostics/diagnostics_test.go
+++ b/internal/diagnostics/diagnostics_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,10 +16,10 @@ func TestWriteAndList(t *testing.T) {
 	now := time.Date(2026, 5, 1, 10, 4, 11, 0, time.UTC)
 
 	r := &diagnostics.RunRecord{
-		Issue:     "42",
-		Branch:    "feat/42-dark-mode",
-		Agent:     "claude",
-		StartedAt: now,
+		Issue:      "42",
+		Branch:     "feat/42-dark-mode",
+		Agent:      "claude",
+		StartedAt:  now,
 		ExitReason: "in_progress",
 	}
 
@@ -161,6 +162,14 @@ func TestRecordFilenameFormat(t *testing.T) {
 	}
 }
 
+func TestRecordFilenameSanitizesIssue(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 10, 4, 11, 0, time.UTC)
+	got := diagnostics.RecordFilename("feat/42\\dark mode", ts)
+	if strings.Contains(got, "/") || strings.Contains(got, "\\") {
+		t.Fatalf("RecordFilename contains path separator: %q", got)
+	}
+}
+
 func TestWriteCreatesDirectory(t *testing.T) {
 	repoRoot := t.TempDir()
 	r := &diagnostics.RunRecord{
@@ -228,13 +237,58 @@ func TestAppendGlobal(t *testing.T) {
 		t.Fatalf("ReadFile: %v", err)
 	}
 	lines := 0
-	for _, line := range filepath.SplitList(string(data)) {
+	for _, line := range strings.Split(string(data), "\n") {
 		if line != "" {
 			lines++
 		}
 	}
 	// Should have 2 newline-delimited JSON lines.
-	if lines < 2 {
-		t.Logf("raw content:\n%s", data)
+	if lines != 2 {
+		t.Fatalf("expected 2 JSONL lines, got %d (raw: %q)", lines, string(data))
+	}
+}
+
+func TestListReturnsErrorForInvalidJSON(t *testing.T) {
+	repoRoot := t.TempDir()
+	runsDir := filepath.Join(repoRoot, ".agentctl", "runs")
+	if err := os.MkdirAll(runsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runsDir, "bad.json"), []byte("{invalid"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := diagnostics.List(repoRoot); err == nil {
+		t.Fatal("expected List to return error for invalid JSON")
+	}
+}
+
+func TestAppendGlobalUsesPrivatePermissions(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	r := &diagnostics.RunRecord{
+		Issue:     "42",
+		Branch:    "feat/42",
+		Agent:     "claude",
+		StartedAt: time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC),
+	}
+
+	if err := diagnostics.AppendGlobal(r); err != nil {
+		t.Fatalf("AppendGlobal: %v", err)
+	}
+
+	dirInfo, err := os.Stat(filepath.Join(tmp, "agentctl"))
+	if err != nil {
+		t.Fatalf("Stat config dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("config dir perms = %o, want 700", got)
+	}
+
+	fileInfo, err := os.Stat(filepath.Join(tmp, "agentctl", "run-history.jsonl"))
+	if err != nil {
+		t.Fatalf("Stat history file: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("history file perms = %o, want 600", got)
 	}
 }

--- a/internal/diagnostics/diagnostics_test.go
+++ b/internal/diagnostics/diagnostics_test.go
@@ -164,9 +164,17 @@ func TestRecordFilenameFormat(t *testing.T) {
 
 func TestRecordFilenameSanitizesIssue(t *testing.T) {
 	ts := time.Date(2026, 5, 1, 10, 4, 11, 0, time.UTC)
-	got := diagnostics.RecordFilename("feat/42\\dark mode", ts)
+	got := diagnostics.RecordFilename(`feat/42\dark mode`, ts)
 	if strings.Contains(got, "/") || strings.Contains(got, "\\") {
 		t.Fatalf("RecordFilename contains path separator: %q", got)
+	}
+}
+
+func TestRecordFilenamePreservesEdgeCharactersAfterSanitizing(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 10, 4, 11, 0, time.UTC)
+	got := diagnostics.RecordFilename(".issue-42.", ts)
+	if !strings.HasPrefix(got, ".issue-42.-") {
+		t.Fatalf("RecordFilename normalized unexpectedly: %q", got)
 	}
 }
 
@@ -237,7 +245,7 @@ func TestAppendGlobal(t *testing.T) {
 		t.Fatalf("ReadFile: %v", err)
 	}
 	lines := 0
-	for _, line := range strings.Split(string(data), "\n") {
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
 		if line != "" {
 			lines++
 		}


### PR DESCRIPTION
## Summary

- New `internal/diagnostics` package with `RunRecord` struct, `Write`, `Update`, `List`, and `AppendGlobal` functions. Records are stored in `.agentctl/runs/<issue>-<ts>.json` (gitignored) and appended to `~/.config/agentctl/run-history.jsonl` on completion.
- `startOne` / `startTask` write an initial record (`exit_reason: in_progress`) and store the filename in `.agent` as `run-file=`.
- `streamLog` finalises the record on agent exit with `stopped_at`, `elapsed_seconds`, `exit_reason` (`pr_opened` / `failed`), `pr_url`, and `files_changed` (via `git diff --name-only`).
- `runRemoveWorktree` finalises with `exit_reason: discarded` before removing the worktree.
- `agentctl status --json` emits a JSON array of all run records from `.agentctl/runs/`, newest first, conforming to the shape in the issue.
- New `agentctl report` command: period aggregates (last 7 / 30 days) with run count, success/fail, average time, total tokens; a slowest-runs table; `--json` for machine-readable output.
- `diagnostics: enabled: false` in `.agentctl.yml` opts out of all recording.

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `go vet ./...` — no issues
- [x] `go test ./...` — all packages pass (including new `internal/diagnostics` tests)
- [x] `agentctl report` on a repo with no `.agentctl/runs/` prints empty tables without error
- [x] `agentctl status --json` on a repo with no runs returns `[]`
- [x] Manually: `agentctl start <issue>`, verify `.agentctl/runs/<issue>-*.json` created with `exit_reason: in_progress`
- [x] Manually: wait for agent to open PR, run `agentctl logs <issue>` until exit — verify record updated with `pr_opened` and `pr_url`
- [x] Manually: `agentctl discard <issue>` — verify record updated with `exit_reason: discarded`
- [x] `agentctl report` displays aggregated periods and slowest runs
- [x] `agentctl report --json` emits valid JSON array

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)