### PR TITLE
docs: README diagram, agentctl merge reference, config fields, package list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,14 @@ cmd/agentctl/     ← Go CLI entry point (cobra); one file: main.go
 internal/
   adapters/       ← YAML adapter loader, built-in YAMLs, tests
   cmd/            ← subcommand implementations + tests
+  config/         ← .agentctl.yml schema, read/write helpers
   git/            ← git worktree operations + tests
+  notify/         ← desktop notification helpers (macOS osascript, Linux notify-send)
   process/        ← process management + tests
   sdd/            ← SDD methodology loader, built-in YAMLs, tests
   state/          ← .agent metadata read/write + tests
+  vcs/            ← VCS provider abstraction (GitHub, GitLab); detect, auth, PR ops
+  xdg/            ← XDG base-directory helpers for config/data paths
 docs/
   cli.md          ← command reference and workflows
   adapters.md     ← adapter YAML schema and built-in adapter reference

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ agentctl cleanup 42
 
 ```mermaid
 flowchart TD
-    issue["GitHub / GitLab issue"] --> start["agentctl start &lt;issue&gt;"]
-    start --> wt["Isolated git worktree\n+ reserved port"]
+    issue["GitHub / GitLab issue"] --> start["agentctl start &lt;issue&gt;\n--headless: agent runs in background"]
+    start --> wt["Isolated git worktree"]
+    wt -.->|"if dev_server set\nin .agentctl.yml"| port["Reserved port\n+ dev server"]
     wt --> agent["Coding agent\n(Claude, Codex, Copilot…)"]
+    port --> agent
 
     agent -->|"--sdd=plain / --sdd=speckit"| spec["Agent writes spec\nspecs/spec.md"]
     spec --> specreview{"Spec review\n(checkpoint 1)"}
@@ -73,7 +75,9 @@ flowchart TD
     code --> pr["Pull request opened"]
     pr --> prereview{"PR review\n(checkpoint 2)"}
     prereview -->|"agentctl resume 'feedback'"| agent
-    prereview -->|approved & merged| cleanup["agentctl cleanup"]
+    prereview -->|"merge on GitHub / GitLab"| cleanup["agentctl cleanup"]
+    prereview -->|"agentctl merge\nmerge + cleanup in one step"| done["Done ✓"]
+    cleanup --> done
 ```
 
 For a deeper walkthrough see **[Introducing agentctl](docs/articles/introducing-agentctl.md)** and **[docs/cli.md](docs/cli.md)**.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,26 @@ agentctl cleanup 42
 
 `agentctl --help` and `agentctl <command> --help` list all flags.
 
+## How it works
+
+```mermaid
+flowchart LR
+    issue["GitHub / GitLab\nissue"] --> start["agentctl start &lt;issue&gt;"]
+    start --> wt["Isolated git worktree\n+ reserved port"]
+    start --> agent["Coding agent\n(Claude, Codex, Copilot…)"]
+    wt --> agent
+    agent --> code["Code written\ntests run"]
+    code --> pr["Pull request\nopened"]
+    pr --> review{"Human\nreview"}
+    review -->|"agentctl resume 'feedback'"| agent
+    review -->|approved & merged| cleanup["agentctl cleanup"]
+```
+
+For a deeper walkthrough see **[Introducing agentctl](docs/articles/introducing-agentctl.md)** and **[docs/cli.md](docs/cli.md)**.
+
 ## Documentation
 
+- **[docs/articles/introducing-agentctl.md](docs/articles/introducing-agentctl.md)** — full walkthrough: the problem, how it works, quick start, batch mode, and SDD  
 - **[docs/install.md](docs/install.md)** — prerequisites, install paths, releases  
 - **[docs/cli.md](docs/cli.md)** — command reference and workflows  
 - **[docs/sdd.md](docs/sdd.md)** — SDD overview, methodology YAML schema, resolution chain, drop-in locations  

--- a/README.md
+++ b/README.md
@@ -58,16 +58,22 @@ agentctl cleanup 42
 ## How it works
 
 ```mermaid
-flowchart LR
-    issue["GitHub / GitLab\nissue"] --> start["agentctl start &lt;issue&gt;"]
+flowchart TD
+    issue["GitHub / GitLab issue"] --> start["agentctl start &lt;issue&gt;"]
     start --> wt["Isolated git worktree\n+ reserved port"]
-    start --> agent["Coding agent\n(Claude, Codex, Copilot…)"]
-    wt --> agent
-    agent --> code["Code written\ntests run"]
-    code --> pr["Pull request\nopened"]
-    pr --> review{"Human\nreview"}
-    review -->|"agentctl resume 'feedback'"| agent
-    review -->|approved & merged| cleanup["agentctl cleanup"]
+    wt --> agent["Coding agent\n(Claude, Codex, Copilot…)"]
+
+    agent -->|"--sdd=plain / --sdd=speckit"| spec["Agent writes spec\nspecs/spec.md"]
+    spec --> specreview{"Spec review\n(checkpoint 1)"}
+    specreview -->|"agentctl resume 'feedback'"| spec
+    specreview -->|"agentctl resume"| code
+
+    agent -->|no SDD| code["Code written\ntests run"]
+
+    code --> pr["Pull request opened"]
+    pr --> prereview{"PR review\n(checkpoint 2)"}
+    prereview -->|"agentctl resume 'feedback'"| agent
+    prereview -->|approved & merged| cleanup["agentctl cleanup"]
 ```
 
 For a deeper walkthrough see **[Introducing agentctl](docs/articles/introducing-agentctl.md)** and **[docs/cli.md](docs/cli.md)**.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,17 +15,22 @@ Run `agentctl --help` or `agentctl <command> --help` for generated help from the
   - [Spec-driven development (SDD)](#spec-driven-development-sdd)
   - [Recovery and maintenance](#recovery-and-maintenance)
 - [Command reference](#command-reference)
-  - [agentctl start](#agentctl-start)
-  - [agentctl logs](#agentctl-logs)
-  - [agentctl attach](#agentctl-attach)
-  - [agentctl diff](#agentctl-diff)
-  - [agentctl open](#agentctl-open)
-  - [agentctl resume](#agentctl-resume)
-  - [agentctl status](#agentctl-status)
-  - [agentctl merge](#agentctl-merge)
-  - [agentctl cleanup](#agentctl-cleanup)
-  - [agentctl discard](#agentctl-discard)
-  - [agentctl dev start](#agentctl-dev-start)
+  - [Start](#start)
+    - [agentctl start](#agentctl-start)
+  - [Monitor](#monitor)
+    - [agentctl status](#agentctl-status)
+    - [agentctl logs](#agentctl-logs)
+    - [agentctl attach](#agentctl-attach)
+    - [agentctl diff](#agentctl-diff)
+    - [agentctl open](#agentctl-open)
+  - [Interact](#interact)
+    - [agentctl resume](#agentctl-resume)
+  - [Finish](#finish)
+    - [agentctl merge](#agentctl-merge)
+    - [agentctl cleanup](#agentctl-cleanup)
+    - [agentctl discard](#agentctl-discard)
+  - [Dev server](#dev-server)
+    - [agentctl dev start](#agentctl-dev-start)
 - [`.agentctl.yml` configuration](#agentctlyml-configuration)
 - [Desktop notifications](#desktop-notifications)
 - [Worktree state files](#worktree-state-files)
@@ -204,7 +209,9 @@ tail -f ../<repo>-42-<slug>/dev.log
 
 ## Command reference
 
-### `agentctl start`
+### Start
+
+#### `agentctl start`
 
 ```bash
 agentctl start [--agent <name>] [--headless] [--notify] [--quiet] <issue-number-or-url> [slug] [--sdd=<name>]
@@ -234,7 +241,40 @@ Side effects:
 - Launches the selected adapter.
 - In issue mode, when the agent exits, appends `Closes #<issue>` to the PR body retrieved via `gh pr view <branch>`, unless the body already contains `closes #<issue>` or `fixes #<issue>` (case-insensitive).
 
-### `agentctl logs`
+### Monitor
+
+#### `agentctl status`
+
+```bash
+agentctl status
+agentctl status --verbose
+agentctl list
+```
+
+Shows all linked worktrees and their current state.
+
+Default columns:
+
+```text
+ISSUE  BRANCH  AGENT  PORT  SPEC  PR
+```
+
+Verbose columns:
+
+```text
+ISSUE  BRANCH  AGENT  PATH  PORT  DEV-PID  AGENT-PID  SPEC  PR  SESSION
+```
+
+Spec states:
+
+- `no-spec`: no spec found for the issue.
+- `paused`: `spec.md` exists, but no `plan.md` or `tasks.md`.
+- `in-progress`: `plan.md` exists, but no `tasks.md`.
+- `done`: `tasks.md` exists.
+
+PR column shows the PR number and state from `gh pr view <branch>`, e.g. `#42 OPEN`, `#42 MERGED`. Shows `none` when no PR exists for the branch.
+
+#### `agentctl logs`
 
 ```bash
 agentctl logs <issue-number-or-url>
@@ -265,7 +305,7 @@ Error cases:
 | Issue not found | `no worktree found for issue N — has it been started?` |
 | `agent.log` missing after 10s | `agent log not found — is the agent running? (looked for <path>)` |
 
-### `agentctl attach`
+#### `agentctl attach`
 
 ```bash
 agentctl attach <issue-number-or-url>
@@ -288,7 +328,7 @@ Error cases:
 | `.agent` file missing or no PID | `no agent PID recorded for issue N — was it started headless?` |
 | `agent.log` missing after 10s | `agent log not found — is the agent running? (looked for <path>)` |
 
-### `agentctl diff`
+#### `agentctl diff`
 
 ```bash
 agentctl diff <issue-number-or-url>
@@ -321,7 +361,7 @@ Error cases:
 |-----------|---------------|
 | Issue not found | `no worktree found for issue N — has it been started?` |
 
-### `agentctl open`
+#### `agentctl open`
 
 ```bash
 agentctl open <issue-number-or-url>
@@ -363,7 +403,9 @@ Error cases:
 | Issue not found | `no worktree found for issue N — has it been started?` |
 | Editor binary not found | `cannot open editor "<name>": ...` |
 
-### `agentctl resume`
+### Interact
+
+#### `agentctl resume`
 
 ```bash
 agentctl resume [--headless] [--notify] [--quiet] <issue-number-or-url>
@@ -389,38 +431,9 @@ The command requires:
 - A `.agent` metadata file with the selected agent and session ID.
 - A generated spec at `specs/*/spec.md`.
 
-### `agentctl status`
+### Finish
 
-```bash
-agentctl status
-agentctl status --verbose
-agentctl list
-```
-
-Shows all linked worktrees and their current state.
-
-Default columns:
-
-```text
-ISSUE  BRANCH  AGENT  PORT  SPEC  PR
-```
-
-Verbose columns:
-
-```text
-ISSUE  BRANCH  AGENT  PATH  PORT  DEV-PID  AGENT-PID  SPEC  PR  SESSION
-```
-
-Spec states:
-
-- `no-spec`: no spec found for the issue.
-- `paused`: `spec.md` exists, but no `plan.md` or `tasks.md`.
-- `in-progress`: `plan.md` exists, but no `tasks.md`.
-- `done`: `tasks.md` exists.
-
-PR column shows the PR number and state from `gh pr view <branch>`, e.g. `#42 OPEN`, `#42 MERGED`. Shows `none` when no PR exists for the branch.
-
-### `agentctl merge`
+#### `agentctl merge`
 
 ```bash
 agentctl merge [issue-number-or-url]
@@ -452,7 +465,7 @@ Error cases:
 | PR not merged-ready | `PR is not in a mergeable state` |
 | Unknown strategy | `unknown merge strategy "<name>": must be squash, merge, or rebase` |
 
-### `agentctl cleanup`
+#### `agentctl cleanup`
 
 ```bash
 agentctl cleanup [issue-number-or-url]
@@ -475,7 +488,7 @@ Use `--all` to scan all linked worktrees and run the cleanup flow for every bran
 
 If the PR is not merged, use `agentctl discard` for abandoned work.
 
-### `agentctl discard`
+#### `agentctl discard`
 
 ```bash
 agentctl discard [issue-number-or-url]
@@ -500,7 +513,9 @@ When `agentctl cleanup --all` skips worktrees with no PR, it prints a hint if an
 Note: N stale worktree(s) found with no agent and no PR — run `agentctl discard --stale` to remove them.
 ```
 
-### `agentctl dev start`
+### Dev server
+
+#### `agentctl dev start`
 
 ```bash
 agentctl dev start [issue]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,7 @@ Run `agentctl --help` or `agentctl <command> --help` for generated help from the
   - [agentctl open](#agentctl-open)
   - [agentctl resume](#agentctl-resume)
   - [agentctl status](#agentctl-status)
+  - [agentctl merge](#agentctl-merge)
   - [agentctl cleanup](#agentctl-cleanup)
   - [agentctl discard](#agentctl-discard)
   - [agentctl dev start](#agentctl-dev-start)
@@ -419,6 +420,38 @@ Spec states:
 
 PR column shows the PR number and state from `gh pr view <branch>`, e.g. `#42 OPEN`, `#42 MERGED`. Shows `none` when no PR exists for the branch.
 
+### `agentctl merge`
+
+```bash
+agentctl merge [issue-number-or-url]
+agentctl merge [issue-number-or-url] --strategy squash|merge|rebase
+agentctl merge [issue-number-or-url] --dry-run
+agentctl merge [issue-number-or-url] --no-delete
+```
+
+One-step merge: verifies the PR is approved and mergeable, runs `gh pr merge`, pulls `main`, and removes the worktree and branches. Equivalent to merging on GitHub/GitLab and then running `agentctl cleanup`, but in a single command.
+
+Run without arguments inside a linked worktree to infer the issue from the current branch.
+
+Flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--strategy <name>` | `squash` | Merge strategy: `squash`, `merge`, or `rebase`. Overrides `merge_strategy` in `.agentctl.yml`. |
+| `--no-delete` | `false` | Skip worktree and branch deletion after merge; leaves the worktree intact |
+| `--dry-run` | `false` | Show what would happen without executing any destructive steps |
+| `--agent <name>` | — | Disambiguate when multiple worktrees exist for the same issue |
+
+Strategy resolution order: `--strategy` flag → `merge_strategy` in `.agentctl.yml` → `squash`.
+
+Error cases:
+
+| Condition | Error message |
+|-----------|---------------|
+| Issue not found | `no worktree or local branch found for issue N` |
+| PR not merged-ready | `PR is not in a mergeable state` |
+| Unknown strategy | `unknown merge strategy "<name>": must be squash, merge, or rebase` |
+
 ### `agentctl cleanup`
 
 ```bash
@@ -526,6 +559,21 @@ notify: true
 # Editor opened by agentctl open. Overridden per-invocation with --editor.
 # Examples: "cursor", "code", "idea"
 editor: cursor
+
+# Default coding agent for agentctl start. Overrides the built-in default
+# ("claude"). Overridden per-invocation with --agent.
+# Examples: "codex", "copilot", "gemini"
+default_agent: claude
+
+# Command agents use to run the test suite before opening a PR. When set,
+# agents use this instead of inferring the command from AGENTS.md or README.md.
+# Use {output} as a placeholder for the binary path (agentctl build only).
+# Examples: "go test ./...", "npm test", "pytest tests/ -v"
+test_cmd: pytest tests/ -v
+
+# Default merge strategy for agentctl merge. Overridden per-invocation with
+# --strategy. Valid values: squash (default when omitted), merge, rebase.
+merge_strategy: squash
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **README.md**: adds a `## How it works` mermaid diagram showing the full issue→start→agent→PR→review→cleanup lifecycle; links to `docs/articles/introducing-agentctl.md` inline and in the Documentation list
- **docs/cli.md**: adds `agentctl merge` to the TOC and command reference (flags: `--strategy`, `--no-delete`, `--dry-run`, `--agent`; strategy resolution order; error cases); adds `default_agent`, `test_cmd`, and `merge_strategy` to the `.agentctl.yml` configuration section; reorganises commands into lifecycle groups (Start / Monitor / Interact / Finish / Dev server)
- **AGENTS.md**: adds `config/`, `vcs/`, `notify/`, and `xdg/` to the project shape diagram

## Test plan

### Automated
- [x] `go build ./...` — no code changes; compilation check only

### Manual
- [x] Mermaid diagram renders correctly on GitHub
- [x] All internal doc links resolve (`docs/articles/introducing-agentctl.md`, anchors in cli.md TOC)
- [x] `agentctl merge` flags match the implementation in `internal/cmd/commands.go` — confirmed: `--strategy` (default `squash`), `--no-delete`, `--dry-run`, `--agent` all present and descriptions consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)