### PR TITLE
fix: diagnostics.List always returns non-nil slice on success

### DIFF
--- a/internal/diagnostics/diagnostics.go
+++ b/internal/diagnostics/diagnostics.go
@@ -119,17 +119,17 @@ func Read(repoRoot, filename string) (RunRecord, error) {
 }
 
 // List reads all run records from <repoRoot>/.agentctl/runs/, returning them
-// sorted by StartedAt ascending. An absent directory returns nil, nil.
+// sorted by StartedAt ascending. Always returns a non-nil slice on success.
 func List(repoRoot string) ([]*RunRecord, error) {
 	dir := filepath.Join(repoRoot, runsSubdir)
 	entries, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
-		return nil, nil
+		return []*RunRecord{}, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	var records []*RunRecord
+	records := []*RunRecord{}
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue

--- a/internal/diagnostics/diagnostics_test.go
+++ b/internal/diagnostics/diagnostics_test.go
@@ -116,6 +116,26 @@ func TestListEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List on empty dir: %v", err)
 	}
+	if records == nil {
+		t.Error("List returned nil, want non-nil empty slice")
+	}
+	if len(records) != 0 {
+		t.Errorf("expected 0 records, got %d", len(records))
+	}
+}
+
+func TestListEmptyRunsDir(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".agentctl", "runs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	records, err := diagnostics.List(repoRoot)
+	if err != nil {
+		t.Fatalf("List on empty runs dir: %v", err)
+	}
+	if records == nil {
+		t.Error("List returned nil, want non-nil empty slice")
+	}
 	if len(records) != 0 {
 		t.Errorf("expected 0 records, got %d", len(records))
 	}


### PR DESCRIPTION
## Summary

- `diagnostics.List` was returning a `nil` slice in two empty-state cases (absent directory, empty directory), causing `json.Marshal(nil)` → `"null"` instead of `"[]"`.
- Changed the function to initialise the result as `[]*RunRecord{}` (non-nil) and return `[]*RunRecord{}, nil` when the directory is absent, so all success paths return a non-nil slice.
- Added two new tests (`TestListEmpty`, `TestListEmptyRunsDir`) that assert the non-nil invariant, written as failing tests before the implementation fix (TDD).

The existing nil-guard in `runReport` remains as belt-and-suspenders but is no longer necessary for correctness.

Closes #277

## Test plan

- [x] `go test ./internal/diagnostics/... -run TestListEmpty` passes
- [x] `go test ./internal/diagnostics/... -run TestListEmptyRunsDir` passes
- [x] `go test ./internal/cmd/... -run TestRunReportJSONEmptyArray` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)