### PR TITLE
fix: skip non-agentctl worktrees in status and info

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -9,6 +9,7 @@
 //	agentctl cleanup    [issue | --all]
 //	agentctl merge      [--strategy squash|merge|rebase] [--no-delete] [--dry-run] [issue]
 //	agentctl status     [--verbose] [--json]
+//	agentctl info
 //	agentctl logs       [--lines N] [--no-follow] <issue>
 //	agentctl attach     <issue>
 //	agentctl diff       [--stat] [--base branch] [--no-pager] <issue>
@@ -52,6 +53,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewCleanupCmd(),
 		cmd.NewMergeCmd(),
 		cmd.NewStatusCmd(),
+		cmd.NewInfoCmd(version),
 		cmd.NewLogsCmd(),
 		cmd.NewAttachCmd(),
 		cmd.NewDiffCmd(),

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1574,13 +1574,20 @@ func runStatus(verbose bool) error {
 	if err != nil {
 		return fmt.Errorf("cannot determine repo root: %w", err)
 	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	return runStatusTable(repoRoot, verbose, w)
+}
 
+// runStatusTable writes the status table for all agentctl-managed worktrees in
+// repoRoot to out. Worktrees with no .agent file (e.g. created manually with
+// git worktree add) are silently skipped.
+func runStatusTable(repoRoot string, verbose bool, out io.Writer) error {
 	wts, err := git.LinkedWorktrees(repoRoot)
 	if err != nil {
 		return err
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	if verbose {
 		fmt.Fprintln(w, "ISSUE\tBRANCH\tAGENT\tPATH\tPORT\tDEV-PID\tAGENT-PID\tSPEC\tPR\tSESSION")
 	} else {
@@ -1588,6 +1595,11 @@ func runStatus(verbose bool) error {
 	}
 
 	for _, wt := range wts {
+		af, _ := state.Read(wt.Path)
+		if af.Agent == "" {
+			continue // skip worktrees not managed by agentctl
+		}
+
 		issue := wt.Issue
 		if issue == "" {
 			issue = "-"
@@ -1596,8 +1608,6 @@ func runStatus(verbose bool) error {
 		if branch == "" {
 			branch = "?"
 		}
-
-		af, _ := state.Read(wt.Path)
 
 		agentName := dash(af.Agent)
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -6028,3 +6028,37 @@ func TestCountFilesChangedFallbackIncludesStagedAndUnstaged(t *testing.T) {
 		t.Fatalf("countFilesChanged() = %d, want 2", got)
 	}
 }
+
+// ─── runStatusTable filtering ─────────────────────────────────────────────────
+
+func TestRunStatus_skipsWorktreesWithoutAgentFile(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	wtPath := filepath.Join(t.TempDir(), "42-no-agent")
+	addWorktree(t, repo, wtPath, "42-no-agent")
+	// No .agent file written — simulates a manually-created worktree.
+
+	var buf bytes.Buffer
+	if err := runStatusTable(repo, false, &buf); err != nil {
+		t.Fatalf("runStatusTable: %v", err)
+	}
+	if strings.Contains(buf.String(), "42-no-agent") {
+		t.Errorf("worktree without .agent file should be skipped; got:\n%s", buf.String())
+	}
+}
+
+func TestRunStatus_showsWorktreesWithAgentFile(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	wtPath := filepath.Join(t.TempDir(), "99-with-agent")
+	addWorktree(t, repo, wtPath, "99-with-agent")
+	if err := state.Write(wtPath, state.AgentFile{Agent: "claude", SessionID: "abc12345"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runStatusTable(repo, false, &buf); err != nil {
+		t.Fatalf("runStatusTable: %v", err)
+	}
+	if !strings.Contains(buf.String(), "99-with-agent") {
+		t.Errorf("worktree with .agent file should appear; got:\n%s", buf.String())
+	}
+}

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -82,9 +82,9 @@ func runInfo(out io.Writer, version, repoRoot string) error {
 		}
 		if binErr := adapter.CheckBinary(); binErr != nil {
 			if adapter.Install != "" {
-				fmt.Fprintf(out, "  ✗ %-12s (not installed) — install with: %s\n", name, adapter.Install)
+				fmt.Fprintf(out, "  ✗ %-12s (not installed)%s — install with: %s\n", name, defaultLabel, adapter.Install)
 			} else {
-				fmt.Fprintf(out, "  ✗ %-12s (not installed)\n", name)
+				fmt.Fprintf(out, "  ✗ %-12s (not installed)%s\n", name, defaultLabel)
 			}
 		} else {
 			fmt.Fprintf(out, "  ✓ %-12s%s\n", name, defaultLabel)

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -1,0 +1,223 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arun-gupta/agentctl/internal/adapters"
+	"github.com/arun-gupta/agentctl/internal/config"
+	"github.com/arun-gupta/agentctl/internal/git"
+	"github.com/arun-gupta/agentctl/internal/state"
+)
+
+// NewInfoCmd creates the `info` subcommand. version is the agentctl version string.
+func NewInfoCmd(version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "info",
+		Short: "Show system diagnostics and configuration",
+		Long: `Show system environment and configuration diagnostics.
+
+Prints the agentctl version, OS/arch, prerequisite tools (git, gh),
+available coding agents, current configuration, and active worktrees.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repoRoot, _ := git.RepoRoot()
+			return runInfo(cmd.OutOrStdout(), version, repoRoot)
+		},
+	}
+}
+
+func runInfo(out io.Writer, version, repoRoot string) error {
+	fmt.Fprintf(out, "agentctl %s\n", version)
+	fmt.Fprintf(out, "System: %s (%s)\n", systemOS(), runtime.GOARCH)
+	fmt.Fprintln(out)
+
+	// Git
+	if gitVer, err := runToolCmd("git", "--version"); err != nil {
+		fmt.Fprintln(out, "Git: not found ✗")
+	} else {
+		ver := strings.TrimPrefix(strings.TrimSpace(gitVer), "git version ")
+		fmt.Fprintf(out, "Git: %s ✓\n", ver)
+	}
+
+	// GitHub CLI
+	if _, err := exec.LookPath("gh"); err != nil {
+		fmt.Fprintln(out, "GitHub CLI: not found ✗")
+	} else {
+		ghOut, _ := runToolCmd("gh", "--version")
+		ver := parseGHVersion(ghOut)
+		if user := ghAuthUser(); user != "" {
+			fmt.Fprintf(out, "GitHub CLI: %s ✓ (authenticated as %s)\n", ver, user)
+		} else {
+			fmt.Fprintf(out, "GitHub CLI: %s (not authenticated)\n", ver)
+		}
+	}
+	fmt.Fprintln(out)
+
+	// Determine default agent (config overrides built-in default of "claude")
+	defaultAgent := "claude"
+	if repoRoot != "" {
+		if cfg, err := config.Read(repoRoot); err == nil && cfg.DefaultAgent != "" {
+			defaultAgent = cfg.DefaultAgent
+		}
+	}
+
+	// Coding Agents
+	fmt.Fprintln(out, "Coding Agents:")
+	for _, name := range adapters.List() {
+		adapter, err := adapters.Get(name)
+		if err != nil {
+			continue
+		}
+		defaultLabel := ""
+		if name == defaultAgent {
+			defaultLabel = " (default)"
+		}
+		if binErr := adapter.CheckBinary(); binErr != nil {
+			if adapter.Install != "" {
+				fmt.Fprintf(out, "  ✗ %-12s (not installed) — install with: %s\n", name, adapter.Install)
+			} else {
+				fmt.Fprintf(out, "  ✗ %-12s (not installed)\n", name)
+			}
+		} else {
+			fmt.Fprintf(out, "  ✓ %-12s%s\n", name, defaultLabel)
+		}
+	}
+	fmt.Fprintln(out)
+
+	// Configuration and Active Worktrees require a repo root
+	if repoRoot == "" {
+		return nil
+	}
+
+	cfgPath := filepath.Join(repoRoot, config.Filename)
+	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
+		fmt.Fprintln(out, "Configuration: no .agentctl.yml found")
+	} else {
+		cfg, err := config.Read(repoRoot)
+		if err != nil {
+			fmt.Fprintf(out, "Configuration: error reading .agentctl.yml: %v\n", err)
+		} else {
+			fmt.Fprintln(out, "Configuration: .agentctl.yml found")
+			printConfigFields(out, cfg)
+		}
+	}
+	fmt.Fprintln(out)
+
+	// Active Worktrees — only those managed by agentctl (have a .agent file with an agent name)
+	wts, err := git.LinkedWorktrees(repoRoot)
+	if err != nil {
+		fmt.Fprintln(out, "Active Worktrees: 0")
+		return nil
+	}
+	var managed []git.Worktree
+	for _, wt := range wts {
+		af, _ := state.Read(wt.Path)
+		if af.Agent != "" {
+			managed = append(managed, wt)
+		}
+	}
+	if len(managed) == 0 {
+		fmt.Fprintln(out, "Active Worktrees: 0")
+	} else {
+		fmt.Fprintf(out, "Active Worktrees: %d\n", len(managed))
+		for _, wt := range managed {
+			af, _ := state.Read(wt.Path)
+			fmt.Fprintf(out, "  %-30s (%s)\n", wt.Branch, af.Agent)
+		}
+	}
+
+	return nil
+}
+
+// printConfigFields writes non-zero config fields to out, one per line, indented.
+func printConfigFields(out io.Writer, cfg *config.AgentctlConfig) {
+	if cfg.Editor != "" {
+		fmt.Fprintf(out, "  editor: %s\n", cfg.Editor)
+	}
+	if cfg.DefaultAgent != "" {
+		fmt.Fprintf(out, "  default_agent: %s\n", cfg.DefaultAgent)
+	}
+	if cfg.DevServer != "" {
+		fmt.Fprintf(out, "  dev_server: %s\n", cfg.DevServer)
+	}
+	if cfg.MergeStrategy != "" {
+		fmt.Fprintf(out, "  merge_strategy: %s\n", cfg.MergeStrategy)
+	}
+	if cfg.TestCmd != "" {
+		fmt.Fprintf(out, "  test_cmd: %s\n", cfg.TestCmd)
+	}
+	if cfg.Notify {
+		fmt.Fprintln(out, "  notify: true")
+	}
+	if cfg.VCS.Provider != "" {
+		fmt.Fprintf(out, "  vcs.provider: %s\n", cfg.VCS.Provider)
+	}
+	if cfg.VCS.Server != "" {
+		fmt.Fprintf(out, "  vcs.server: %s\n", cfg.VCS.Server)
+	}
+}
+
+// systemOS returns "GOOS kernel-version" where kernel-version comes from
+// `uname -r`. Falls back to just GOOS if uname is unavailable.
+func systemOS() string {
+	osName := runtime.GOOS
+	out, err := runToolCmd("uname", "-r")
+	if err != nil {
+		return osName
+	}
+	// Trim to major.minor: "6.6.51-rt50" → "6.6"
+	parts := strings.SplitN(out, ".", 3)
+	if len(parts) >= 2 {
+		return fmt.Sprintf("%s %s.%s", osName, parts[0], parts[1])
+	}
+	return fmt.Sprintf("%s %s", osName, out)
+}
+
+// parseGHVersion extracts the version number from `gh --version` output.
+// "gh version 2.45.0 (2024-01-15)\n..." → "2.45.0"
+func parseGHVersion(ghOut string) string {
+	if ghOut == "" {
+		return ""
+	}
+	firstLine := strings.SplitN(ghOut, "\n", 2)[0]
+	parts := strings.Fields(firstLine)
+	// ["gh", "version", "2.45.0", "(2024-...)"]
+	if len(parts) >= 3 {
+		return parts[2]
+	}
+	return firstLine
+}
+
+// ghAuthUser returns the authenticated GitHub username from `gh auth status`,
+// or empty string if not authenticated or gh is not available.
+func ghAuthUser() string {
+	cmd := exec.Command("gh", "auth", "status") //nolint:gosec
+	out, _ := cmd.CombinedOutput()
+	for _, line := range strings.Split(string(out), "\n") {
+		if idx := strings.Index(line, "account "); idx >= 0 {
+			parts := strings.Fields(line[idx:])
+			if len(parts) >= 2 {
+				return parts[1]
+			}
+		}
+	}
+	return ""
+}
+
+// runToolCmd runs an external command and returns trimmed stdout, or an error.
+func runToolCmd(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...) //nolint:gosec
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/cmd/info_test.go
+++ b/internal/cmd/info_test.go
@@ -1,0 +1,384 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arun-gupta/agentctl/internal/config"
+	"github.com/arun-gupta/agentctl/internal/state"
+)
+
+func TestRunInfo_versionInOutput(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "v1.2.3", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "agentctl v1.2.3") {
+		t.Errorf("output missing version line; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_systemInOutput(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "System:") {
+		t.Errorf("output missing System: line; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_agentSectionInOutput(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Coding Agents:") {
+		t.Errorf("output missing Coding Agents: section; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_noConfigWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Configuration: no .agentctl.yml found") {
+		t.Errorf("expected no-config message; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_withConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{
+		Editor:    "cursor",
+		DevServer: "npm run dev -- --port {port}",
+	}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Configuration: .agentctl.yml found") {
+		t.Errorf("expected config-found message; got:\n%s", out)
+	}
+	if !strings.Contains(out, "editor: cursor") {
+		t.Errorf("expected editor field in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "dev_server:") {
+		t.Errorf("expected dev_server field in output; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_noWorktreesForPlainDir(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Active Worktrees: 0") {
+		t.Errorf("expected 'Active Worktrees: 0' for non-git dir; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_defaultAgentMarked(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	// "claude" is the built-in default; it should be marked "(default)"
+	out := buf.String()
+	if !strings.Contains(out, "(default)") {
+		t.Errorf("expected default agent marker in output; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_customDefaultAgentFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{DefaultAgent: "codex"}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	lines := strings.Split(out, "\n")
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "codex") && strings.Contains(line, "(default)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected codex marked as default; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_emptyRepoRootSkipsConfigSection(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "Configuration:") {
+		t.Errorf("expected no Configuration: section for empty repoRoot; got:\n%s", out)
+	}
+}
+
+func TestPrintConfigFields_allFields(t *testing.T) {
+	cfg := &config.AgentctlConfig{
+		Editor:        "cursor",
+		DefaultAgent:  "codex",
+		DevServer:     "npm run dev",
+		MergeStrategy: "squash",
+		TestCmd:       "go test ./...",
+		Notify:        true,
+		VCS:           config.VCSConfig{Provider: "gitlab", Server: "https://gl.example.com"},
+	}
+
+	var buf bytes.Buffer
+	printConfigFields(&buf, cfg)
+	out := buf.String()
+
+	checks := []string{
+		"editor: cursor",
+		"default_agent: codex",
+		"dev_server: npm run dev",
+		"merge_strategy: squash",
+		"test_cmd: go test ./...",
+		"notify: true",
+		"vcs.provider: gitlab",
+		"vcs.server: https://gl.example.com",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("printConfigFields missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintConfigFields_emptyConfig(t *testing.T) {
+	cfg := &config.AgentctlConfig{}
+	var buf bytes.Buffer
+	printConfigFields(&buf, cfg)
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for empty config; got: %q", buf.String())
+	}
+}
+
+func TestParseGHVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"gh version 2.45.0 (2024-01-15)\nhttps://github.com/cli/cli/releases/tag/v2.45.0", "2.45.0"},
+		{"gh version 2.10.1 (2023-06-20)", "2.10.1"},
+		{"unexpected output", "unexpected output"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := parseGHVersion(tt.input)
+		if got != tt.want {
+			t.Errorf("parseGHVersion(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestInfoCmd_exists(t *testing.T) {
+	c := NewInfoCmd("test-version")
+	if c.Use != "info" {
+		t.Errorf("command Use = %q, want %q", c.Use, "info")
+	}
+}
+
+func TestRunInfo_gitSection(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Git:") {
+		t.Errorf("output missing Git: line; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_ghSection(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "GitHub CLI:") {
+		t.Errorf("output missing GitHub CLI: line; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_configWithDefaultAgent(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{DefaultAgent: "gemini"}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "default_agent: gemini") {
+		t.Errorf("expected default_agent shown in config; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_installHintShown(t *testing.T) {
+	dir := t.TempDir()
+	adapterDir := filepath.Join(dir, ".agentctl", "adapters")
+	if err := os.MkdirAll(adapterDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	adapterYAML := "binary: nonexistent-agent-xyz-999\ninstall: npm install -g nonexistent-agent-xyz-999\n"
+	if err := os.WriteFile(filepath.Join(adapterDir, "nonexistent-agent-xyz-999.yml"), []byte(adapterYAML), 0o644); err != nil {
+		t.Fatalf("write adapter: %v", err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "install with:") {
+		t.Errorf("expected install hint in output; got:\n%s", out)
+	}
+}
+
+// ─── worktree filtering ───────────────────────────────────────────────────────
+
+func initGitRepoForInfo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	dir := t.TempDir()
+	gitRunInfo := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	gitRunInfo("init")
+	gitRunInfo("config", "user.email", "test@example.com")
+	gitRunInfo("config", "user.name", "Test")
+	gitRunInfo("config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "README"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRunInfo("add", ".")
+	gitRunInfo("commit", "-m", "init")
+	return dir
+}
+
+func TestRunInfo_skipsWorktreesWithoutAgentFile(t *testing.T) {
+	repo := initGitRepoForInfo(t)
+	wtPath := filepath.Join(t.TempDir(), "42-no-agent")
+	cmd := exec.Command("git", "-C", repo, "worktree", "add", wtPath, "-b", "42-no-agent")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	// No .agent file written — simulates a manually-created worktree.
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", repo); err != nil {
+		t.Fatalf("runInfo: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "42-no-agent") {
+		t.Errorf("worktree without .agent file should be skipped in info output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Active Worktrees: 0") {
+		t.Errorf("expected 'Active Worktrees: 0' when all worktrees lack .agent; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_showsWorktreesWithAgentFile(t *testing.T) {
+	repo := initGitRepoForInfo(t)
+	wtPath := filepath.Join(t.TempDir(), "99-with-agent")
+	cmd := exec.Command("git", "-C", repo, "worktree", "add", wtPath, "-b", "99-with-agent")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	if err := state.Write(wtPath, state.AgentFile{Agent: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", repo); err != nil {
+		t.Fatalf("runInfo: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "99-with-agent") {
+		t.Errorf("worktree with .agent file should appear in info output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Active Worktrees: 1") {
+		t.Errorf("expected 'Active Worktrees: 1'; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_mixedWorktrees_onlyManagedShown(t *testing.T) {
+	repo := initGitRepoForInfo(t)
+
+	// Manual worktree without .agent file
+	manualPath := filepath.Join(t.TempDir(), "manual-review")
+	cmd := exec.Command("git", "-C", repo, "worktree", "add", manualPath, "-b", "manual-review")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add (manual): %v\n%s", err, out)
+	}
+
+	// Agentctl-managed worktree with .agent file
+	managedPath := filepath.Join(t.TempDir(), "55-my-feature")
+	cmd = exec.Command("git", "-C", repo, "worktree", "add", managedPath, "-b", "55-my-feature")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add (managed): %v\n%s", err, out)
+	}
+	if err := state.Write(managedPath, state.AgentFile{Agent: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", repo); err != nil {
+		t.Fatalf("runInfo: %v", err)
+	}
+	out := buf.String()
+
+	if strings.Contains(out, "manual-review") {
+		t.Errorf("manual worktree (no .agent) should be skipped; got:\n%s", out)
+	}
+	if !strings.Contains(out, "55-my-feature") {
+		t.Errorf("managed worktree should appear; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Active Worktrees: 1") {
+		t.Errorf("expected 'Active Worktrees: 1' (only managed ones counted); got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- `agentctl status` now skips worktrees with no `.agent` file (e.g. created manually with `git worktree add` for PR review or testing) — they no longer appear as confusing `HEAD / -` rows
- `agentctl info` (new command, implements #263) also applies the same filter: only agentctl-managed worktrees (those with a non-empty `agent=` in `.agent`) are counted and listed
- Refactored `runStatus` into a testable `runStatusTable(repoRoot, verbose, out)` helper; the public `runStatus` is now a thin wrapper

## Root cause

Both commands iterated all linked worktrees from `git worktree list` without checking whether a `.agent` file exists. Any worktree not managed by agentctl leaked through as a confusing entry.

## Fix

In `runStatusTable`: read the `.agent` file first; `continue` if `af.Agent == ""`.
In `runInfo`: collect only worktrees where `af.Agent != ""`; use that filtered slice for both the count and the listing.

## Test plan

### Automated

- `go build ./...` — passes
- `go vet ./...` — no issues
- `go test ./...` — all 12 packages pass

New tests added:
- `TestRunStatus_skipsWorktreesWithoutAgentFile` — worktree with no `.agent` is absent from status output
- `TestRunStatus_showsWorktreesWithAgentFile` — worktree with `.agent` does appear
- `TestRunInfo_skipsWorktreesWithoutAgentFile` — worktree with no `.agent` is absent; count shows 0
- `TestRunInfo_showsWorktreesWithAgentFile` — worktree with `.agent` appears; count shows 1
- `TestRunInfo_mixedWorktrees_onlyManagedShown` — mixed scenario: manual worktree skipped, managed worktree shown, count = 1

### Manual

- `git worktree add /tmp/test-review origin/some-branch` then `agentctl status` — the new worktree should not appear
- `agentctl info` — same worktree should not appear in Active Worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #279