### PR TITLE
fix: agentctl info shows all adapters including those not installed

### DIFF
--- a/cmd/agentctl/main.go
+++ b/cmd/agentctl/main.go
@@ -15,6 +15,7 @@
 //	agentctl open       [--editor name] [--path] [--agent name] <issue>
 //	agentctl dev start  [--quiet] [issue]
 //	agentctl report     [--json]
+//	agentctl info
 package main
 
 import (
@@ -61,6 +62,7 @@ func newRootCmd() *cobra.Command {
 		cmd.NewStreamLogCmd(),
 		cmd.NewStreamLogOpenHandsCmd(),
 		cmd.NewBuildCmd(),
+		cmd.NewInfoCmd(version),
 	)
 
 	// Pre-register --version without a short alias so that cobra's lazy

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -51,12 +51,16 @@ func runInfo(out io.Writer, version, repoRoot string) error {
 	if _, err := exec.LookPath("gh"); err != nil {
 		fmt.Fprintln(out, "GitHub CLI: not found ✗")
 	} else {
-		ghOut, _ := runToolCmd("gh", "--version")
-		ver := parseGHVersion(ghOut)
-		if user := ghAuthUser(); user != "" {
-			fmt.Fprintf(out, "GitHub CLI: %s ✓ (authenticated as %s)\n", ver, user)
+		ghOut, err := runToolCmd("gh", "--version")
+		if err != nil {
+			fmt.Fprintln(out, "GitHub CLI: unknown version ✗")
 		} else {
-			fmt.Fprintf(out, "GitHub CLI: %s (not authenticated)\n", ver)
+			ver := parseGHVersion(ghOut)
+			if user := ghAuthUser(); user != "" {
+				fmt.Fprintf(out, "GitHub CLI: %s ✓ (authenticated as %s)\n", ver, user)
+			} else {
+				fmt.Fprintf(out, "GitHub CLI: %s (not authenticated)\n", ver)
+			}
 		}
 	}
 	fmt.Fprintln(out)
@@ -66,6 +70,14 @@ func runInfo(out io.Writer, version, repoRoot string) error {
 	if repoRoot != "" {
 		if cfg, err := config.Read(repoRoot); err == nil && cfg.DefaultAgent != "" {
 			defaultAgent = cfg.DefaultAgent
+		}
+	}
+
+	if repoRoot != "" {
+		if cwd, err := os.Getwd(); err == nil {
+			if err := os.Chdir(repoRoot); err == nil {
+				defer func() { _ = os.Chdir(cwd) }()
+			}
 		}
 	}
 

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -53,7 +53,11 @@ func runInfo(out io.Writer, version, repoRoot string) error {
 	} else {
 		ghOut, err := runToolCmd("gh", "--version")
 		if err != nil {
-			fmt.Fprintln(out, "GitHub CLI: unknown version ✗")
+			if user := ghAuthUser(); user != "" {
+				fmt.Fprintf(out, "GitHub CLI: unknown version (authenticated as %s)\n", user)
+			} else {
+				fmt.Fprintln(out, "GitHub CLI: unknown version (not authenticated)")
+			}
 		} else {
 			ver := parseGHVersion(ghOut)
 			if user := ghAuthUser(); user != "" {
@@ -73,12 +77,13 @@ func runInfo(out io.Writer, version, repoRoot string) error {
 		}
 	}
 
-	if repoRoot != "" {
-		if cwd, err := os.Getwd(); err == nil {
-			if err := os.Chdir(repoRoot); err == nil {
-				defer func() { _ = os.Chdir(cwd) }()
-			}
-		}
+	adapterLookupWarning := ""
+	restoreCWD, warning := switchToRepoRoot(repoRoot)
+	if warning != "" {
+		adapterLookupWarning = warning
+	}
+	if restoreCWD != nil {
+		defer restoreCWD()
 	}
 
 	// Coding Agents — show ALL known adapters, including those not installed.
@@ -86,6 +91,9 @@ func runInfo(out io.Writer, version, repoRoot string) error {
 	// Adapters that fail to load (e.g. invalid YAML) show an error indicator
 	// rather than being silently omitted.
 	fmt.Fprintln(out, "Coding Agents:")
+	if adapterLookupWarning != "" {
+		fmt.Fprintf(out, "  ! %s\n", adapterLookupWarning)
+	}
 	for _, name := range adapters.List() {
 		defaultLabel := ""
 		if name == defaultAgent {
@@ -236,4 +244,25 @@ func runToolCmd(name string, args ...string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+func switchToRepoRoot(repoRoot string) (func(), string) {
+	if repoRoot == "" {
+		return nil, ""
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Sprintf("cannot get current directory for adapter lookup: %v", err)
+	}
+
+	if err := os.Chdir(repoRoot); err != nil {
+		return nil, fmt.Sprintf("cannot switch to repo root for adapter lookup: %v", err)
+	}
+
+	return func() {
+		if err := os.Chdir(cwd); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: cannot restore working directory after adapter lookup: %v\n", err)
+		}
+	}, ""
 }

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -1,0 +1,220 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/arun-gupta/agentctl/internal/adapters"
+	"github.com/arun-gupta/agentctl/internal/config"
+	"github.com/arun-gupta/agentctl/internal/git"
+	"github.com/arun-gupta/agentctl/internal/state"
+)
+
+// NewInfoCmd creates the `info` subcommand. version is the agentctl version string.
+func NewInfoCmd(version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "info",
+		Short: "Show system diagnostics and configuration",
+		Long: `Show system environment and configuration diagnostics.
+
+Prints the agentctl version, OS/arch, prerequisite tools (git, gh),
+available coding agents, current configuration, and active worktrees.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repoRoot, _ := git.RepoRoot()
+			return runInfo(cmd.OutOrStdout(), version, repoRoot)
+		},
+	}
+}
+
+func runInfo(out io.Writer, version, repoRoot string) error {
+	fmt.Fprintf(out, "agentctl %s\n", version)
+	fmt.Fprintf(out, "System: %s (%s)\n", systemOS(), runtime.GOARCH)
+	fmt.Fprintln(out)
+
+	// Git
+	if gitVer, err := runToolCmd("git", "--version"); err != nil {
+		fmt.Fprintln(out, "Git: not found ✗")
+	} else {
+		ver := strings.TrimPrefix(strings.TrimSpace(gitVer), "git version ")
+		fmt.Fprintf(out, "Git: %s ✓\n", ver)
+	}
+
+	// GitHub CLI
+	if _, err := exec.LookPath("gh"); err != nil {
+		fmt.Fprintln(out, "GitHub CLI: not found ✗")
+	} else {
+		ghOut, _ := runToolCmd("gh", "--version")
+		ver := parseGHVersion(ghOut)
+		if user := ghAuthUser(); user != "" {
+			fmt.Fprintf(out, "GitHub CLI: %s ✓ (authenticated as %s)\n", ver, user)
+		} else {
+			fmt.Fprintf(out, "GitHub CLI: %s (not authenticated)\n", ver)
+		}
+	}
+	fmt.Fprintln(out)
+
+	// Determine default agent (config overrides built-in default of "claude")
+	defaultAgent := "claude"
+	if repoRoot != "" {
+		if cfg, err := config.Read(repoRoot); err == nil && cfg.DefaultAgent != "" {
+			defaultAgent = cfg.DefaultAgent
+		}
+	}
+
+	// Coding Agents — show ALL known adapters, including those not installed.
+	// Adapters whose binary is not on PATH show ✗ with the install hint.
+	// Adapters that fail to load (e.g. invalid YAML) show an error indicator
+	// rather than being silently omitted.
+	fmt.Fprintln(out, "Coding Agents:")
+	for _, name := range adapters.List() {
+		defaultLabel := ""
+		if name == defaultAgent {
+			defaultLabel = " (default)"
+		}
+
+		adapter, err := adapters.Get(name)
+		if err != nil {
+			fmt.Fprintf(out, "  ✗ %-12s%s (adapter error)\n", name, defaultLabel)
+			continue
+		}
+
+		if binErr := adapter.CheckBinary(); binErr != nil {
+			if adapter.Install != "" {
+				fmt.Fprintf(out, "  ✗ %-12s%s (not installed) — install with: %s\n", name, defaultLabel, adapter.Install)
+			} else {
+				fmt.Fprintf(out, "  ✗ %-12s%s (not installed)\n", name, defaultLabel)
+			}
+		} else {
+			fmt.Fprintf(out, "  ✓ %-12s%s\n", name, defaultLabel)
+		}
+	}
+	fmt.Fprintln(out)
+
+	// Configuration and Active Worktrees require a repo root.
+	if repoRoot == "" {
+		return nil
+	}
+
+	cfgPath := filepath.Join(repoRoot, config.Filename)
+	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
+		fmt.Fprintln(out, "Configuration: no .agentctl.yml found")
+	} else {
+		cfg, err := config.Read(repoRoot)
+		if err != nil {
+			fmt.Fprintf(out, "Configuration: error reading .agentctl.yml: %v\n", err)
+		} else {
+			fmt.Fprintln(out, "Configuration: .agentctl.yml found")
+			printConfigFields(out, cfg)
+		}
+	}
+	fmt.Fprintln(out)
+
+	// Active Worktrees
+	wts, err := git.LinkedWorktrees(repoRoot)
+	if err != nil || len(wts) == 0 {
+		fmt.Fprintln(out, "Active Worktrees: 0")
+	} else {
+		fmt.Fprintf(out, "Active Worktrees: %d\n", len(wts))
+		for _, wt := range wts {
+			af, _ := state.Read(wt.Path)
+			agentName := af.Agent
+			if agentName == "" {
+				agentName = "unknown"
+			}
+			fmt.Fprintf(out, "  %-30s (%s)\n", wt.Branch, agentName)
+		}
+	}
+
+	return nil
+}
+
+// printConfigFields writes non-zero config fields to out, one per line, indented.
+func printConfigFields(out io.Writer, cfg *config.AgentctlConfig) {
+	if cfg.Editor != "" {
+		fmt.Fprintf(out, "  editor: %s\n", cfg.Editor)
+	}
+	if cfg.DefaultAgent != "" {
+		fmt.Fprintf(out, "  default_agent: %s\n", cfg.DefaultAgent)
+	}
+	if cfg.DevServer != "" {
+		fmt.Fprintf(out, "  dev_server: %s\n", cfg.DevServer)
+	}
+	if cfg.MergeStrategy != "" {
+		fmt.Fprintf(out, "  merge_strategy: %s\n", cfg.MergeStrategy)
+	}
+	if cfg.TestCmd != "" {
+		fmt.Fprintf(out, "  test_cmd: %s\n", cfg.TestCmd)
+	}
+	if cfg.Notify {
+		fmt.Fprintln(out, "  notify: true")
+	}
+	if cfg.VCS.Provider != "" {
+		fmt.Fprintf(out, "  vcs.provider: %s\n", cfg.VCS.Provider)
+	}
+	if cfg.VCS.Server != "" {
+		fmt.Fprintf(out, "  vcs.server: %s\n", cfg.VCS.Server)
+	}
+}
+
+// systemOS returns "GOOS kernel-version" where kernel-version comes from
+// `uname -r`. Falls back to just GOOS if uname is unavailable.
+func systemOS() string {
+	osName := runtime.GOOS
+	out, err := runToolCmd("uname", "-r")
+	if err != nil {
+		return osName
+	}
+	parts := strings.SplitN(out, ".", 3)
+	if len(parts) >= 2 {
+		return fmt.Sprintf("%s %s.%s", osName, parts[0], parts[1])
+	}
+	return fmt.Sprintf("%s %s", osName, out)
+}
+
+// parseGHVersion extracts the version number from `gh --version` output.
+// "gh version 2.45.0 (2024-01-15)\n..." → "2.45.0"
+func parseGHVersion(ghOut string) string {
+	if ghOut == "" {
+		return ""
+	}
+	firstLine := strings.SplitN(ghOut, "\n", 2)[0]
+	parts := strings.Fields(firstLine)
+	if len(parts) >= 3 {
+		return parts[2]
+	}
+	return firstLine
+}
+
+// ghAuthUser returns the authenticated GitHub username from `gh auth status`,
+// or empty string if not authenticated or gh is not available.
+func ghAuthUser() string {
+	cmd := exec.Command("gh", "auth", "status") //nolint:gosec
+	out, _ := cmd.CombinedOutput()
+	for _, line := range strings.Split(string(out), "\n") {
+		if idx := strings.Index(line, "account "); idx >= 0 {
+			parts := strings.Fields(line[idx:])
+			if len(parts) >= 2 {
+				return parts[1]
+			}
+		}
+	}
+	return ""
+}
+
+// runToolCmd runs an external command and returns trimmed stdout, or an error.
+func runToolCmd(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...) //nolint:gosec
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/cmd/info_test.go
+++ b/internal/cmd/info_test.go
@@ -225,6 +225,28 @@ func TestRunInfo_ghSection(t *testing.T) {
 	}
 }
 
+func TestRunInfo_ghVersionErrorShown(t *testing.T) {
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	script := "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then exit 1; fi\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"status\" ]; then echo \"Logged in to github.com account fake-user\"; exit 0; fi\nexit 1\n"
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write gh script: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "GitHub CLI: unknown version ✗") {
+		t.Errorf("expected gh version error indicator; got:\n%s", out)
+	}
+	if strings.Contains(out, "authenticated as") {
+		t.Errorf("did not expect authenticated status when gh --version fails; got:\n%s", out)
+	}
+}
+
 func TestRunInfo_configWithDefaultAgent(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.AgentctlConfig{DefaultAgent: "gemini"}
@@ -269,6 +291,39 @@ func TestRunInfo_installHintShown(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "install with:") {
 		t.Errorf("expected install hint in output; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_projectLocalAdapterFoundFromSubdir(t *testing.T) {
+	repoRoot := t.TempDir()
+	adapterDir := filepath.Join(repoRoot, ".agentctl", "adapters")
+	if err := os.MkdirAll(adapterDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(adapterDir, "local-only-adapter.yml"), []byte("binary: nonexistent-local-only-adapter\n"), 0o644); err != nil {
+		t.Fatalf("write adapter: %v", err)
+	}
+	subdir := filepath.Join(repoRoot, "nested", "dir")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(subdir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", repoRoot); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "local-only-adapter") {
+		t.Errorf("expected project-local adapter to appear from subdir; got:\n%s", out)
 	}
 }
 

--- a/internal/cmd/info_test.go
+++ b/internal/cmd/info_test.go
@@ -1,0 +1,328 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/arun-gupta/agentctl/internal/config"
+)
+
+func TestRunInfo_versionInOutput(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "v1.2.3", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "agentctl v1.2.3") {
+		t.Errorf("output missing version line; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_systemInOutput(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "System:") {
+		t.Errorf("output missing System: line; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_agentSectionInOutput(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Coding Agents:") {
+		t.Errorf("output missing Coding Agents: section; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_noConfigWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Configuration: no .agentctl.yml found") {
+		t.Errorf("expected no-config message; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_withConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{
+		Editor:    "cursor",
+		DevServer: "npm run dev -- --port {port}",
+	}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Configuration: .agentctl.yml found") {
+		t.Errorf("expected config-found message; got:\n%s", out)
+	}
+	if !strings.Contains(out, "editor: cursor") {
+		t.Errorf("expected editor field in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "dev_server:") {
+		t.Errorf("expected dev_server field in output; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_noWorktreesForPlainDir(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Active Worktrees: 0") {
+		t.Errorf("expected 'Active Worktrees: 0' for non-git dir; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_defaultAgentMarked(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "(default)") {
+		t.Errorf("expected default agent marker in output; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_customDefaultAgentFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{DefaultAgent: "codex"}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	lines := strings.Split(out, "\n")
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "codex") && strings.Contains(line, "(default)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected codex marked as default; got:\n%s", out)
+	}
+}
+
+func TestRunInfo_emptyRepoRootSkipsConfigSection(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "Configuration:") {
+		t.Errorf("expected no Configuration: section for empty repoRoot; got:\n%s", out)
+	}
+}
+
+func TestPrintConfigFields_allFields(t *testing.T) {
+	cfg := &config.AgentctlConfig{
+		Editor:        "cursor",
+		DefaultAgent:  "codex",
+		DevServer:     "npm run dev",
+		MergeStrategy: "squash",
+		TestCmd:       "go test ./...",
+		Notify:        true,
+		VCS:           config.VCSConfig{Provider: "gitlab", Server: "https://gl.example.com"},
+	}
+
+	var buf bytes.Buffer
+	printConfigFields(&buf, cfg)
+	out := buf.String()
+
+	checks := []string{
+		"editor: cursor",
+		"default_agent: codex",
+		"dev_server: npm run dev",
+		"merge_strategy: squash",
+		"test_cmd: go test ./...",
+		"notify: true",
+		"vcs.provider: gitlab",
+		"vcs.server: https://gl.example.com",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("printConfigFields missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintConfigFields_emptyConfig(t *testing.T) {
+	cfg := &config.AgentctlConfig{}
+	var buf bytes.Buffer
+	printConfigFields(&buf, cfg)
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for empty config; got: %q", buf.String())
+	}
+}
+
+func TestParseGHVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"gh version 2.45.0 (2024-01-15)\nhttps://github.com/cli/cli/releases/tag/v2.45.0", "2.45.0"},
+		{"gh version 2.10.1 (2023-06-20)", "2.10.1"},
+		{"unexpected output", "unexpected output"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := parseGHVersion(tt.input)
+		if got != tt.want {
+			t.Errorf("parseGHVersion(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestInfoCmd_exists(t *testing.T) {
+	c := NewInfoCmd("test-version")
+	if c.Use != "info" {
+		t.Errorf("command Use = %q, want %q", c.Use, "info")
+	}
+}
+
+func TestRunInfo_gitSection(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Git:") {
+		t.Errorf("output missing Git: line; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_ghSection(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", ""); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "GitHub CLI:") {
+		t.Errorf("output missing GitHub CLI: line; got:\n%s", buf.String())
+	}
+}
+
+func TestRunInfo_configWithDefaultAgent(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{DefaultAgent: "gemini"}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "default_agent: gemini") {
+		t.Errorf("expected default_agent shown in config; got:\n%s", out)
+	}
+}
+
+// TestRunInfo_uninstalledAdapterShown verifies that adapters whose binary is
+// not on PATH are shown with ✗ and the install hint — not silently omitted.
+func TestRunInfo_uninstalledAdapterShown(t *testing.T) {
+	dir := t.TempDir()
+	adapterDir := filepath.Join(dir, ".agentctl", "adapters")
+	if err := os.MkdirAll(adapterDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	adapterYAML := "binary: nonexistent-agent-xyz-999\ninstall: pip install nonexistent-agent-xyz-999\n"
+	if err := os.WriteFile(filepath.Join(adapterDir, "nonexistent-agent-xyz-999.yml"), []byte(adapterYAML), 0o644); err != nil {
+		t.Fatalf("write adapter: %v", err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+
+	// The adapter must appear in the output, not be silently omitted.
+	if !strings.Contains(out, "nonexistent-agent-xyz-999") {
+		t.Errorf("expected uninstalled adapter to appear in output; got:\n%s", out)
+	}
+	// It must show ✗ (not ✓).
+	lines := strings.Split(out, "\n")
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "nonexistent-agent-xyz-999") {
+			if !strings.Contains(line, "✗") {
+				t.Errorf("expected ✗ for uninstalled adapter; got line: %q", line)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("adapter line not found in output:\n%s", out)
+	}
+	// The install hint must appear.
+	if !strings.Contains(out, "pip install nonexistent-agent-xyz-999") {
+		t.Errorf("expected install hint in output; got:\n%s", out)
+	}
+}
+
+// TestRunInfo_adapterLoadErrorNotSilentlySkipped verifies that an adapter whose
+// YAML is invalid appears in the output rather than being silently omitted.
+func TestRunInfo_adapterLoadErrorNotSilentlySkipped(t *testing.T) {
+	dir := t.TempDir()
+	adapterDir := filepath.Join(dir, ".agentctl", "adapters")
+	if err := os.MkdirAll(adapterDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Write an adapter YAML that is missing the required 'binary' field.
+	badYAML := "install: some-install-cmd\n"
+	if err := os.WriteFile(filepath.Join(adapterDir, "broken-adapter.yml"), []byte(badYAML), 0o644); err != nil {
+		t.Fatalf("write adapter: %v", err)
+	}
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+
+	// The broken adapter must appear in the output, not be silently skipped.
+	if !strings.Contains(out, "broken-adapter") {
+		t.Errorf("expected broken adapter to appear in output; got:\n%s", out)
+	}
+}

--- a/internal/cmd/info_test.go
+++ b/internal/cmd/info_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/arun-gupta/agentctl/internal/state"
 )
 
+func writeFakeGHScript(t *testing.T, script string) string {
+	t.Helper()
+	dir := t.TempDir()
+	ghPath := filepath.Join(dir, "gh")
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write gh script: %v", err)
+	}
+	return dir
+}
+
 func TestRunInfo_versionInOutput(t *testing.T) {
 	var buf bytes.Buffer
 	if err := runInfo(&buf, "v1.2.3", ""); err != nil {
@@ -226,24 +236,26 @@ func TestRunInfo_ghSection(t *testing.T) {
 }
 
 func TestRunInfo_ghVersionErrorShown(t *testing.T) {
-	dir := t.TempDir()
-	ghPath := filepath.Join(dir, "gh")
-	script := "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then exit 1; fi\nif [ \"$1\" = \"auth\" ] && [ \"$2\" = \"status\" ]; then echo \"Logged in to github.com account fake-user\"; exit 0; fi\nexit 1\n"
-	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
-		t.Fatalf("write gh script: %v", err)
-	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	scriptDir := writeFakeGHScript(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then exit 1; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+	echo "Logged in to github.com account fake-user"
+	exit 0
+fi
+exit 1
+`)
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	var buf bytes.Buffer
 	if err := runInfo(&buf, "dev", ""); err != nil {
 		t.Fatalf("runInfo error: %v", err)
 	}
 	out := buf.String()
-	if !strings.Contains(out, "GitHub CLI: unknown version ✗") {
+	if !strings.Contains(out, "GitHub CLI: unknown version (authenticated as fake-user)") {
 		t.Errorf("expected gh version error indicator; got:\n%s", out)
 	}
-	if strings.Contains(out, "authenticated as") {
-		t.Errorf("did not expect authenticated status when gh --version fails; got:\n%s", out)
+	if strings.Contains(out, "GitHub CLI: unknown version ✓") {
+		t.Errorf("did not expect success marker when gh --version fails; got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `agentctl info` command (`internal/cmd/info.go`) with correct behaviour for uninstalled agents
- Every adapter from `adapters.List()` is shown; none are silently omitted
- Adapters not on PATH display `✗  <name> (not installed) — install with: <hint>` (or without the hint when the `install` field is absent)
- Adapters whose YAML fails to load display `✗  <name> (adapter error)` instead of being silently skipped — this is the specific bug fixed by #281
- Registers `NewInfoCmd` in `cmd/agentctl/main.go`
- 19 tests covering version output, system section, git/gh sections, agent listing (installed, uninstalled, load-error), configuration section, worktree section, and helper functions

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./...` — all 12 packages pass (19 new tests in `internal/cmd`)
- [x] `go vet ./...` — no issues

Fixes #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)