### PR TITLE
feat: agentctl cleanup accepts multiple issues

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1208,12 +1208,12 @@ func runMerge(issue, strategy, agentSuffix string, noDelete, dryRun bool) error 
 
 // NewCleanupMergedCmd creates the `cleanup-merged` subcommand.
 // NewCleanupCmd creates the `cleanup` subcommand.
-// With --all it sweeps all merged worktrees; otherwise it cleans up a single issue.
+// With --all it sweeps all merged worktrees; otherwise it cleans up one or more issues.
 func NewCleanupCmd() *cobra.Command {
 	var all bool
 	var agentSuffix string
 	c := &cobra.Command{
-		Use:   "cleanup [issue]",
+		Use:   "cleanup [issue[,issue...]]...",
 		Short: "Remove a merged worktree and its branches",
 		Long: `Post-merge cleanup: pull main, remove the worktree, and delete the local
 and remote branches.
@@ -1221,8 +1221,12 @@ and remote branches.
 Run without arguments inside a linked worktree to infer the issue number
 from the current branch.
 
+Multiple issues may be given as a comma-separated list or as separate
+arguments (e.g. "agentctl cleanup 240,277" or "agentctl cleanup 240 277").
+Each issue is cleaned up in sequence; all failures are reported at the end.
+
 Use --all to sweep every linked worktree whose PR is MERGED in one pass.`,
-		Args: cobra.RangeArgs(0, 1),
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if all {
 				if len(args) > 0 {
@@ -1230,16 +1234,51 @@ Use --all to sweep every linked worktree whose PR is MERGED in one pass.`,
 				}
 				return runCleanupAllMerged()
 			}
-			issue, err := resolveIssueArg("cleanup", args)
-			if err != nil {
-				return err
+			if len(args) == 0 {
+				// No args: infer from current worktree branch.
+				issue, err := resolveIssueArg("cleanup", args)
+				if err != nil {
+					return err
+				}
+				return runCleanupMerged(issue, agentSuffix)
 			}
-			return runCleanupMerged(issue, agentSuffix)
+			issues := parseCleanupIssues(args)
+			if len(issues) == 0 {
+				return fmt.Errorf("no valid issue tokens found in %q", strings.Join(args, " "))
+			}
+			if len(issues) == 1 {
+				return runCleanupMerged(issues[0], agentSuffix)
+			}
+			var errs []string
+			for _, iss := range issues {
+				if err := runCleanupMerged(iss, agentSuffix); err != nil {
+					fmt.Fprintf(os.Stderr, "cleanup %s: %v\n", iss, err)
+					errs = append(errs, iss)
+				}
+			}
+			if len(errs) > 0 {
+				return fmt.Errorf("%d cleanup(s) failed: %s", len(errs), strings.Join(errs, ", "))
+			}
+			return nil
 		},
 	}
 	c.Flags().BoolVar(&all, "all", false, "Clean up all worktrees whose PR is MERGED")
 	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to target a specific worktree when multiple agents ran on the same issue")
 	return c
+}
+
+// parseCleanupIssues expands a mix of space-separated args and comma-separated
+// tokens into a flat, trimmed list of issue identifiers.
+func parseCleanupIssues(args []string) []string {
+	var issues []string
+	for _, arg := range args {
+		for _, tok := range strings.Split(arg, ",") {
+			if s := strings.TrimSpace(tok); s != "" {
+				issues = append(issues, s)
+			}
+		}
+	}
+	return issues
 }
 
 func runCleanupMerged(issue, agentSuffix string) error {

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1230,7 +1230,7 @@ Use --all to sweep every linked worktree whose PR is MERGED in one pass.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if all {
 				if len(args) > 0 {
-					return fmt.Errorf("--all and an issue number are mutually exclusive")
+					return fmt.Errorf("--all and issue arguments are mutually exclusive")
 				}
 				return runCleanupAllMerged()
 			}
@@ -1274,6 +1274,9 @@ func parseCleanupIssues(args []string) []string {
 	for _, arg := range args {
 		for _, tok := range strings.Split(arg, ",") {
 			if s := strings.TrimSpace(tok); s != "" {
+				if _, _, num, ok := parseIssueURL(s); ok {
+					s = num
+				}
 				issues = append(issues, s)
 			}
 		}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5688,6 +5688,67 @@ func TestCleanupCmd_agentFlagExists(t *testing.T) {
 	}
 }
 
+// TestCleanupCmd_acceptsMultipleArgs verifies that the cleanup command accepts
+// multiple space-separated issue arguments (cobra Args validator must not reject them).
+func TestCleanupCmd_acceptsMultipleArgs(t *testing.T) {
+	c := NewCleanupCmd()
+	// cobra.Args validation runs during Execute; we can call Args directly.
+	if err := c.Args(c, []string{"240", "277"}); err != nil {
+		t.Errorf("cleanup should accept multiple space-separated args, got: %v", err)
+	}
+}
+
+// TestCleanupCmd_acceptsCommaSeparated verifies that a single comma-separated arg is valid.
+func TestCleanupCmd_acceptsCommaSeparated(t *testing.T) {
+	c := NewCleanupCmd()
+	if err := c.Args(c, []string{"240,277"}); err != nil {
+		t.Errorf("cleanup should accept a comma-separated arg, got: %v", err)
+	}
+}
+
+// TestCleanupCmd_rejectsAllWithIssues verifies --all and issue args are mutually exclusive.
+func TestCleanupCmd_rejectsAllWithIssues(t *testing.T) {
+	c := NewCleanupCmd()
+	c.SilenceUsage = true
+	c.SilenceErrors = true
+	if err := c.Flags().Set("all", "true"); err != nil {
+		t.Fatalf("set --all: %v", err)
+	}
+	err := c.RunE(c, []string{"240", "277"})
+	if err == nil {
+		t.Error("expected error when --all is combined with issue args")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestParseCleanupIssues verifies the comma+space issue list parsing logic.
+func TestParseCleanupIssues(t *testing.T) {
+	tests := []struct {
+		args []string
+		want []string
+	}{
+		{[]string{"240,277"}, []string{"240", "277"}},
+		{[]string{"240", "277"}, []string{"240", "277"}},
+		{[]string{"240,277", "300"}, []string{"240", "277", "300"}},
+		{[]string{"42"}, []string{"42"}},
+		{[]string{" 42 , 43 "}, []string{"42", "43"}},
+	}
+	for _, tt := range tests {
+		got := parseCleanupIssues(tt.args)
+		if len(got) != len(tt.want) {
+			t.Errorf("parseCleanupIssues(%v) = %v, want %v", tt.args, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("parseCleanupIssues(%v)[%d] = %q, want %q", tt.args, i, got[i], tt.want[i])
+			}
+		}
+	}
+}
+
 func TestStartCmd_multiAgent_rejectsSlug(t *testing.T) {
 	c := NewStartCmd()
 	if err := c.Flags().Set("agent", "claude,codex"); err != nil {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5718,7 +5718,7 @@ func TestCleanupCmd_rejectsAllWithIssues(t *testing.T) {
 	if err == nil {
 		t.Error("expected error when --all is combined with issue args")
 	}
-	if !strings.Contains(err.Error(), "mutually exclusive") {
+	if !strings.Contains(err.Error(), "--all and issue arguments are mutually exclusive") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -5734,6 +5734,14 @@ func TestParseCleanupIssues(t *testing.T) {
 		{[]string{"240,277", "300"}, []string{"240", "277", "300"}},
 		{[]string{"42"}, []string{"42"}},
 		{[]string{" 42 , 43 "}, []string{"42", "43"}},
+		{
+			[]string{"https://github.com/org/repo/issues/42"},
+			[]string{"42"},
+		},
+		{
+			[]string{"240, https://github.com/org/repo/issues/42", "https://github.com/org/repo/issues/43,277"},
+			[]string{"240", "42", "43", "277"},
+		},
 	}
 	for _, tt := range tests {
 		got := parseCleanupIssues(tt.args)


### PR DESCRIPTION
## Summary

- Extend `agentctl cleanup` to accept a comma-separated list (`cleanup 240,277`) or multiple space-separated args (`cleanup 240 277`), matching the batch syntax already supported by `agentctl start`
- Added `parseCleanupIssues` helper that expands all args through comma-splitting and trimming into a flat issue list
- Issues are processed in sequence; per-issue errors are printed to stderr and all failures are reported together at the end
- `--all` flag remains mutually exclusive with explicit issue args

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes
- [x] `go test ./...` all pass (new tests: `TestCleanupCmd_acceptsMultipleArgs`, `TestCleanupCmd_acceptsCommaSeparated`, `TestCleanupCmd_rejectsAllWithIssues`, `TestParseCleanupIssues`)

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)