### PR TITLE
feat: global user config (~/.config/agentctl/config.yml) with project-local override

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,6 +31,7 @@ Run `agentctl --help` or `agentctl <command> --help` for generated help from the
     - [agentctl discard](#agentctl-discard)
   - [Dev server](#dev-server)
     - [agentctl dev start](#agentctl-dev-start)
+- [Global user config](#global-user-config)
 - [`.agentctl.yml` configuration](#agentctlyml-configuration)
 - [Desktop notifications](#desktop-notifications)
 - [Worktree state files](#worktree-state-files)
@@ -551,6 +552,67 @@ Error cases:
 | `.agent` has no port recorded | `no port recorded in .agent — run agentctl start first` |
 | Dev server already running | `dev server already running (PID N) — stop that process and clear the recorded dev-pid before restarting` |
 | Port already in use | `port N already in use` (with PID if detectable) |
+
+---
+
+## Global user config
+
+Place a config file at `~/.config/agentctl/config.yml` (or `$XDG_CONFIG_HOME/agentctl/config.yml`) to set personal defaults that apply across all repositories.
+
+### Config resolution chain
+
+```
+CLI flags  >  project-local .agentctl.yml  >  global config.yml  >  built-in defaults
+```
+
+This matches the pattern used by `git`, `gh`, `npm`, and `kubectl`. Project-local `.agentctl.yml` always wins for any field it explicitly sets.
+
+### Global-eligible fields
+
+Only user-preference fields belong in the global config. Repo-specific fields (`dev_server`, `test_cmd`, `build_cmd`, `vcs`) are ignored in the global file.
+
+```yaml
+# ~/.config/agentctl/config.yml
+
+# Personal default agent for agentctl start.
+default_agent: codex
+
+# Send desktop notifications when headless agents finish.
+notify: true
+
+# Personal default merge strategy.
+merge_strategy: squash
+
+# Editor opened by agentctl open.
+editor: cursor
+
+# Opt out of per-run diagnostics globally.
+diagnostics:
+  enabled: false
+```
+
+### `notify` and `*bool` semantics
+
+`notify` is stored as a nullable boolean so an explicit `notify: false` in a project-local `.agentctl.yml` can override a global `notify: true`. Omitting `notify` in `.agentctl.yml` means "inherit from global".
+
+### Viewing effective config
+
+`agentctl info` shows both the global config and the project-local config:
+
+```
+Global config: ~/.config/agentctl/config.yml
+  default_agent: codex
+  notify: true
+
+Configuration: .agentctl.yml found
+  dev_server: npm run dev -- --port {port}
+```
+
+If the global config file does not exist, `agentctl info` shows:
+
+```
+Global config: none
+```
 
 ---
 

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -67,7 +67,7 @@ func runBuild(issue, outputPath, agentSuffix string, out io.Writer) error {
 		outputPath = filepath.Join(os.TempDir(), repoName+"-"+issue)
 	}
 
-	cfg, err := config.Read(repoRoot)
+	cfg, err := config.ReadMerged(repoRoot)
 	if err != nil {
 		return fmt.Errorf("cannot read config: %w", err)
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -84,7 +84,7 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 					return fmt.Errorf("failed to determine repository for configuration: %w", err)
 				}
 				if root != "" {
-					cfg, cfgErr := config.Read(root)
+					cfg, cfgErr := config.ReadMerged(root)
 					if cfgErr != nil {
 						return fmt.Errorf("read %s: %w", filepath.Join(root, config.Filename), cfgErr)
 					}
@@ -312,7 +312,7 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 	// Combine --notify flag with the per-repo config setting (either enables it).
 	// notify: true in .agentctl.yml is only meaningful in headless mode.
 	if !sendNotify {
-		if cfg, cfgErr := config.Read(repoRoot); cfgErr == nil && cfg.Notify {
+		if cfg, cfgErr := config.ReadMerged(repoRoot); cfgErr == nil && cfg.Notify != nil && *cfg.Notify {
 			sendNotify = true
 		}
 	}
@@ -452,7 +452,7 @@ func startTask(task, branch, agentName, sddName string, headless, quiet, sendNot
 	repoName := filepath.Base(repoRoot)
 
 	if !sendNotify {
-		if cfg, cfgErr := config.Read(repoRoot); cfgErr == nil && cfg.Notify {
+		if cfg, cfgErr := config.ReadMerged(repoRoot); cfgErr == nil && cfg.Notify != nil && *cfg.Notify {
 			sendNotify = true
 		}
 	}
@@ -739,7 +739,7 @@ func runReleasePausedSession(issue, feedback, agentSuffix string, headless, quie
 	// Combine --notify flag with the per-repo config setting (either enables it).
 	// notify: true in .agentctl.yml is only meaningful in headless mode.
 	if !sendNotify {
-		if cfg, cfgErr := config.Read(repoRoot); cfgErr == nil && cfg.Notify {
+		if cfg, cfgErr := config.ReadMerged(repoRoot); cfgErr == nil && cfg.Notify != nil && *cfg.Notify {
 			sendNotify = true
 		}
 	}
@@ -1112,7 +1112,7 @@ func runMerge(issue, strategy, agentSuffix string, noDelete, dryRun bool) error 
 		return fmt.Errorf("cannot determine repo root: %w", err)
 	}
 
-	cfg, err := config.Read(repoRoot)
+	cfg, err := config.ReadMerged(repoRoot)
 	if err != nil {
 		return fmt.Errorf("cannot read config: %w", err)
 	}
@@ -1966,7 +1966,7 @@ real time. Use --quiet to suppress log streaming and only print the URL.`,
 // recorded in the .agent state file. It updates dev-pid in .agent after
 // a successful launch.
 func runDevStart(wtPath string, quiet bool, out io.Writer) error {
-	cfg, err := config.Read(wtPath)
+	cfg, err := config.ReadMerged(wtPath)
 	if err != nil {
 		return fmt.Errorf("reading .agentctl.yml: %w", err)
 	}
@@ -2005,7 +2005,7 @@ func runDevStart(wtPath string, quiet bool, out io.Writer) error {
 
 	fmt.Fprintf(out, "Dev server: http://localhost:%s (log: %s/dev.log)\n", af.DevPort, wtPath)
 
-	if cfg.Notify {
+	if cfg.Notify != nil && *cfg.Notify {
 		msg := fmt.Sprintf("Dev server: http://localhost:%s", af.DevPort)
 		if quiet {
 			notify.Send("agentctl", msg)
@@ -2749,7 +2749,7 @@ func seedEnvLocal(src, dst string) error {
 // On success the URL is printed to out and the PID/port are returned to the
 // caller for storage in the .agent state file. .agentctl.yml is not modified.
 func startDevServer(dir string, out io.Writer) (devPID, portStr string, err error) {
-	cfg, err := config.Read(dir)
+	cfg, err := config.ReadMerged(dir)
 	if err != nil {
 		return "", "", fmt.Errorf("reading .agentctl.yml: %w", err)
 	}
@@ -4631,7 +4631,7 @@ func formatTokens(t float64) string {
 // isDiagnosticsEnabled reports whether per-run diagnostics are enabled for repoRoot.
 // Diagnostics are on by default; set diagnostics.enabled: false in .agentctl.yml to opt out.
 func isDiagnosticsEnabled(repoRoot string) bool {
-	cfg, err := config.Read(repoRoot)
+	cfg, err := config.ReadMerged(repoRoot)
 	if err != nil || cfg.Diagnostics.Enabled == nil {
 		return true
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -86,7 +86,7 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 				if root != "" {
 					cfg, cfgErr := config.ReadMerged(root)
 					if cfgErr != nil {
-						return fmt.Errorf("read %s: %w", filepath.Join(root, config.Filename), cfgErr)
+						return fmt.Errorf("read merged configuration (.agentctl.yml and global config) for %s: %w", root, cfgErr)
 					}
 					if cfg.DefaultAgent != "" {
 						agentName = cfg.DefaultAgent

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -86,7 +86,7 @@ Use --sdd <name> to opt into a spec-driven development (SDD) methodology
 				if root != "" {
 					cfg, cfgErr := config.ReadMerged(root)
 					if cfgErr != nil {
-						return fmt.Errorf("read merged configuration (.agentctl.yml and global config) for %s: %w", root, cfgErr)
+						return fmt.Errorf("read merged configuration (%s, %s): %w", filepath.Join(root, config.Filename), config.GlobalPath(), cfgErr)
 					}
 					if cfg.DefaultAgent != "" {
 						agentName = cfg.DefaultAgent

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -97,15 +97,13 @@ func runInfo(out io.Writer, version, repoRoot string, ascii bool) error {
 
 	// Determine default agent (config overrides built-in default of "claude").
 	defaultAgent := "claude"
+	if globalCfg, err := config.ReadGlobal(); err == nil && globalCfg.DefaultAgent != "" {
+		defaultAgent = globalCfg.DefaultAgent
+	}
 	if repoRoot != "" {
-		if cfg, err := config.ReadMerged(repoRoot); err == nil && cfg.DefaultAgent != "" {
-			defaultAgent = cfg.DefaultAgent
-		} else if localCfg, localErr := config.Read(repoRoot); localErr == nil && localCfg.DefaultAgent != "" {
-			// If merged read fails (e.g. malformed global config), keep local default_agent.
+		if localCfg, err := config.Read(repoRoot); err == nil && localCfg.DefaultAgent != "" {
 			defaultAgent = localCfg.DefaultAgent
 		}
-	} else if globalCfg, err := config.ReadGlobal(); err == nil && globalCfg.DefaultAgent != "" {
-		defaultAgent = globalCfg.DefaultAgent
 	}
 
 	adapterLookupWarning := ""

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -98,7 +98,7 @@ fmt.Fprintln(out)
 // Determine default agent (config overrides built-in default of "claude")
 defaultAgent := "claude"
 if repoRoot != "" {
-if cfg, err := config.Read(repoRoot); err == nil && cfg.DefaultAgent != "" {
+if cfg, err := config.ReadMerged(repoRoot); err == nil && cfg.DefaultAgent != "" {
 defaultAgent = cfg.DefaultAgent
 }
 }
@@ -140,6 +140,21 @@ fmt.Fprintf(out, "  %s %-12s%s(not installed)\n", sym.cross, name, defaultLabel)
 }
 } else {
 fmt.Fprintf(out, "  %s %-12s%s\n", sym.check, name, defaultLabel)
+}
+}
+fmt.Fprintln(out)
+
+// Global config — always shown, even outside a repo.
+globalPath := config.GlobalPath()
+if _, statErr := os.Stat(globalPath); os.IsNotExist(statErr) {
+fmt.Fprintln(out, "Global config: none")
+} else {
+globalCfg, globalErr := config.ReadGlobal()
+if globalErr != nil {
+fmt.Fprintf(out, "Global config: error reading %s: %v\n", globalPath, globalErr)
+} else {
+fmt.Fprintf(out, "Global config: %s\n", globalPath)
+printGlobalConfigFields(out, globalCfg)
 }
 }
 fmt.Fprintln(out)
@@ -209,7 +224,7 @@ fmt.Fprintf(out, "  test_cmd: %s\n", cfg.TestCmd)
 if cfg.BuildCmd != "" {
 fmt.Fprintf(out, "  build_cmd: %s\n", cfg.BuildCmd)
 }
-if cfg.Notify {
+if cfg.Notify != nil && *cfg.Notify {
 fmt.Fprintln(out, "  notify: true")
 }
 if cfg.VCS.Provider != "" {
@@ -217,6 +232,24 @@ fmt.Fprintf(out, "  vcs.provider: %s\n", cfg.VCS.Provider)
 }
 if cfg.VCS.Server != "" {
 fmt.Fprintf(out, "  vcs.server: %s\n", cfg.VCS.Server)
+}
+}
+
+// printGlobalConfigFields writes non-zero global config fields to out, one per line, indented.
+func printGlobalConfigFields(out io.Writer, cfg *config.GlobalConfig) {
+if cfg.DefaultAgent != "" {
+fmt.Fprintf(out, "  default_agent: %s\n", cfg.DefaultAgent)
+}
+if cfg.Editor != "" {
+fmt.Fprintf(out, "  editor: %s\n", cfg.Editor)
+}
+if cfg.MergeStrategy != "" {
+fmt.Fprintf(out, "  merge_strategy: %s\n", cfg.MergeStrategy)
+}
+if cfg.Notify != nil && *cfg.Notify {
+fmt.Fprintln(out, "  notify: true")
+} else if cfg.Notify != nil && !*cfg.Notify {
+fmt.Fprintln(out, "  notify: false")
 }
 }
 

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -1,21 +1,21 @@
 package cmd
 
 import (
-"fmt"
-"io"
-"os"
-"os/exec"
-"path/filepath"
-"regexp"
-"runtime"
-"strings"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
 
-"github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 
-"github.com/arun-gupta/agentctl/internal/adapters"
-"github.com/arun-gupta/agentctl/internal/config"
-"github.com/arun-gupta/agentctl/internal/git"
-"github.com/arun-gupta/agentctl/internal/state"
+	"github.com/arun-gupta/agentctl/internal/adapters"
+	"github.com/arun-gupta/agentctl/internal/config"
+	"github.com/arun-gupta/agentctl/internal/git"
+	"github.com/arun-gupta/agentctl/internal/state"
 )
 
 // kernelVersionRe extracts "major.minor" from uname output (e.g. "6.6.51-rt50" → groups "6","6").
@@ -23,234 +23,246 @@ var kernelVersionRe = regexp.MustCompile(`^(\d+)\.(\d+)`)
 
 // Injected functions — overridden in tests to avoid running real external tools.
 var (
-runToolCmdFn = runToolCmd
-lookPathFn   = exec.LookPath
-ghAuthUserFn = ghAuthUser
+	runToolCmdFn = runToolCmd
+	lookPathFn   = exec.LookPath
+	ghAuthUserFn = ghAuthUser
 )
 
 // infoSymbols holds status marker strings used in info output.
 type infoSymbols struct {
-check string // installed / found
-cross string // not installed / not found
+	check string // installed / found
+	cross string // not installed / not found
 }
 
 func newSymbols(ascii bool) infoSymbols {
-if ascii {
-return infoSymbols{check: "OK", cross: "X"}
-}
-return infoSymbols{check: "✓", cross: "✗"}
+	if ascii {
+		return infoSymbols{check: "OK", cross: "X"}
+	}
+	return infoSymbols{check: "✓", cross: "✗"}
 }
 
 // NewInfoCmd creates the `info` subcommand. version is the agentctl version string.
 func NewInfoCmd(version string) *cobra.Command {
-var noUnicode bool
-cmd := &cobra.Command{
-Use:   "info",
-Short: "Show system diagnostics and configuration",
-Long: `Show system environment and configuration diagnostics.
+	var noUnicode bool
+	cmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show system diagnostics and configuration",
+		Long: `Show system environment and configuration diagnostics.
 
 Prints the agentctl version, OS/arch, prerequisite tools (git, gh),
 available coding agents, current configuration, and active worktrees.`,
-Args: cobra.NoArgs,
-RunE: func(cmd *cobra.Command, args []string) error {
-repoRoot, _ := git.RepoRoot()
-ascii := noUnicode || os.Getenv("AGENTCTL_ASCII") == "1"
-return runInfo(cmd.OutOrStdout(), version, repoRoot, ascii)
-},
-}
-cmd.Flags().BoolVar(&noUnicode, "no-unicode", false, "Use ASCII markers instead of Unicode glyphs (also honored via AGENTCTL_ASCII=1)")
-return cmd
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repoRoot, _ := git.RepoRoot()
+			ascii := noUnicode || os.Getenv("AGENTCTL_ASCII") == "1"
+			return runInfo(cmd.OutOrStdout(), version, repoRoot, ascii)
+		},
+	}
+	cmd.Flags().BoolVar(&noUnicode, "no-unicode", false, "Use ASCII markers instead of Unicode glyphs (also honored via AGENTCTL_ASCII=1)")
+	return cmd
 }
 
 func runInfo(out io.Writer, version, repoRoot string, ascii bool) error {
-sym := newSymbols(ascii)
+	sym := newSymbols(ascii)
 
-fmt.Fprintf(out, "agentctl %s\n", version)
-fmt.Fprintf(out, "System: %s (%s)\n", systemOS(), runtime.GOARCH)
-fmt.Fprintln(out)
+	fmt.Fprintf(out, "agentctl %s\n", version)
+	fmt.Fprintf(out, "System: %s (%s)\n", systemOS(), runtime.GOARCH)
+	fmt.Fprintln(out)
 
-// Git
-if gitVer, err := runToolCmdFn("git", "--version"); err != nil {
-fmt.Fprintf(out, "Git: not found %s\n", sym.cross)
-} else {
-ver := strings.TrimPrefix(strings.TrimSpace(gitVer), "git version ")
-fmt.Fprintf(out, "Git: %s %s\n", ver, sym.check)
-}
+	// Git
+	if gitVer, err := runToolCmdFn("git", "--version"); err != nil {
+		fmt.Fprintf(out, "Git: not found %s\n", sym.cross)
+	} else {
+		ver := strings.TrimPrefix(strings.TrimSpace(gitVer), "git version ")
+		fmt.Fprintf(out, "Git: %s %s\n", ver, sym.check)
+	}
 
-// GitHub CLI
-if _, err := lookPathFn("gh"); err != nil {
-fmt.Fprintf(out, "GitHub CLI: not found %s\n", sym.cross)
-} else {
-ghOut, err := runToolCmdFn("gh", "--version")
-if err != nil {
-fmt.Fprintf(out, "GitHub CLI: error running gh --version: %v\n", err)
-} else {
-ver := parseGHVersion(ghOut)
-if user := ghAuthUserFn(); user != "" {
-fmt.Fprintf(out, "GitHub CLI: %s %s (authenticated as %s)\n", ver, sym.check, user)
-} else {
-fmt.Fprintf(out, "GitHub CLI: %s (not authenticated)\n", ver)
-}
-}
-}
-fmt.Fprintln(out)
+	// GitHub CLI
+	if _, err := lookPathFn("gh"); err != nil {
+		fmt.Fprintf(out, "GitHub CLI: not found %s\n", sym.cross)
+	} else {
+		ghOut, err := runToolCmdFn("gh", "--version")
+		if err != nil {
+			fmt.Fprintf(out, "GitHub CLI: error running gh --version: %v\n", err)
+		} else {
+			ver := parseGHVersion(ghOut)
+			if user := ghAuthUserFn(); user != "" {
+				fmt.Fprintf(out, "GitHub CLI: %s %s (authenticated as %s)\n", ver, sym.check, user)
+			} else {
+				fmt.Fprintf(out, "GitHub CLI: %s (not authenticated)\n", ver)
+			}
+		}
+	}
+	fmt.Fprintln(out)
 
-// Determine default agent (config overrides built-in default of "claude")
-defaultAgent := "claude"
-if repoRoot != "" {
-if cfg, err := config.ReadMerged(repoRoot); err == nil && cfg.DefaultAgent != "" {
-defaultAgent = cfg.DefaultAgent
-}
-}
+	// Determine default agent (config overrides built-in default of "claude").
+	defaultAgent := "claude"
+	if repoRoot != "" {
+		if cfg, err := config.ReadMerged(repoRoot); err == nil && cfg.DefaultAgent != "" {
+			defaultAgent = cfg.DefaultAgent
+		} else if localCfg, localErr := config.Read(repoRoot); localErr == nil && localCfg.DefaultAgent != "" {
+			// If merged read fails (e.g. malformed global config), keep local default_agent.
+			defaultAgent = localCfg.DefaultAgent
+		}
+	} else if globalCfg, err := config.ReadGlobal(); err == nil && globalCfg.DefaultAgent != "" {
+		defaultAgent = globalCfg.DefaultAgent
+	}
 
-adapterLookupWarning := ""
-restoreCWD, warning := switchToRepoRoot(repoRoot)
-if warning != "" {
-adapterLookupWarning = warning
-}
-if restoreCWD != nil {
-defer restoreCWD()
-}
+	adapterLookupWarning := ""
+	restoreCWD, warning := switchToRepoRoot(repoRoot)
+	if warning != "" {
+		adapterLookupWarning = warning
+	}
+	if restoreCWD != nil {
+		defer restoreCWD()
+	}
 
-// Coding Agents — show ALL known adapters, including those not installed.
-// Adapters whose binary is not on PATH show ✗ with the install hint.
-// Adapters that fail to load (e.g. invalid YAML) show an error indicator
-// rather than being silently omitted.
-fmt.Fprintln(out, "Coding Agents:")
-if adapterLookupWarning != "" {
-fmt.Fprintf(out, "  ! %s\n", adapterLookupWarning)
-}
-for _, name := range adapters.List() {
-defaultLabel := ""
-if name == defaultAgent {
-defaultLabel = " (default)"
-}
+	// Coding Agents — show ALL known adapters, including those not installed.
+	// Adapters whose binary is not on PATH show ✗ with the install hint.
+	// Adapters that fail to load (e.g. invalid YAML) show an error indicator
+	// rather than being silently omitted.
+	fmt.Fprintln(out, "Coding Agents:")
+	if adapterLookupWarning != "" {
+		fmt.Fprintf(out, "  ! %s\n", adapterLookupWarning)
+	}
+	for _, name := range adapters.List() {
+		defaultLabel := ""
+		if name == defaultAgent {
+			defaultLabel = " (default)"
+		}
 
-adapter, err := adapters.Get(name)
-if err != nil {
-fmt.Fprintf(out, "  %s %-12s%s(adapter error)\n", sym.cross, name, defaultLabel)
-continue
-}
+		adapter, err := adapters.Get(name)
+		if err != nil {
+			fmt.Fprintf(out, "  %s %-12s%s(adapter error)\n", sym.cross, name, defaultLabel)
+			continue
+		}
 
-if binErr := adapter.CheckBinary(); binErr != nil {
-if adapter.Install != "" {
-fmt.Fprintf(out, "  %s %-12s%s(not installed) — install with: %s\n", sym.cross, name, defaultLabel, adapter.Install)
-} else {
-fmt.Fprintf(out, "  %s %-12s%s(not installed)\n", sym.cross, name, defaultLabel)
-}
-} else {
-fmt.Fprintf(out, "  %s %-12s%s\n", sym.check, name, defaultLabel)
-}
-}
-fmt.Fprintln(out)
+		if binErr := adapter.CheckBinary(); binErr != nil {
+			if adapter.Install != "" {
+				fmt.Fprintf(out, "  %s %-12s%s(not installed) — install with: %s\n", sym.cross, name, defaultLabel, adapter.Install)
+			} else {
+				fmt.Fprintf(out, "  %s %-12s%s(not installed)\n", sym.cross, name, defaultLabel)
+			}
+		} else {
+			fmt.Fprintf(out, "  %s %-12s%s\n", sym.check, name, defaultLabel)
+		}
+	}
+	fmt.Fprintln(out)
 
-// Global config — always shown, even outside a repo.
-globalPath := config.GlobalPath()
-if _, statErr := os.Stat(globalPath); os.IsNotExist(statErr) {
-fmt.Fprintln(out, "Global config: none")
-} else {
-globalCfg, globalErr := config.ReadGlobal()
-if globalErr != nil {
-fmt.Fprintf(out, "Global config: error reading %s: %v\n", globalPath, globalErr)
-} else {
-fmt.Fprintf(out, "Global config: %s\n", globalPath)
-printGlobalConfigFields(out, globalCfg)
-}
-}
-fmt.Fprintln(out)
+	// Global config — always shown, even outside a repo.
+	globalPath := config.GlobalPath()
+	if _, statErr := os.Stat(globalPath); os.IsNotExist(statErr) {
+		fmt.Fprintln(out, "Global config: none")
+	} else {
+		globalCfg, globalErr := config.ReadGlobal()
+		if globalErr != nil {
+			fmt.Fprintf(out, "Global config: error reading %s: %v\n", globalPath, globalErr)
+		} else {
+			fmt.Fprintf(out, "Global config: %s\n", globalPath)
+			printGlobalConfigFields(out, globalCfg)
+		}
+	}
+	fmt.Fprintln(out)
 
-// Configuration and Active Worktrees require a repo root.
-if repoRoot == "" {
-return nil
-}
+	// Configuration and Active Worktrees require a repo root.
+	if repoRoot == "" {
+		return nil
+	}
 
-cfgPath := filepath.Join(repoRoot, config.Filename)
-if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
-fmt.Fprintln(out, "Configuration: no .agentctl.yml found")
-} else {
-cfg, err := config.Read(repoRoot)
-if err != nil {
-fmt.Fprintf(out, "Configuration: error reading .agentctl.yml: %v\n", err)
-} else {
-fmt.Fprintln(out, "Configuration: .agentctl.yml found")
-printConfigFields(out, cfg)
-}
-}
-fmt.Fprintln(out)
+	cfgPath := filepath.Join(repoRoot, config.Filename)
+	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
+		fmt.Fprintln(out, "Configuration: no .agentctl.yml found")
+	} else {
+		cfg, err := config.Read(repoRoot)
+		if err != nil {
+			fmt.Fprintf(out, "Configuration: error reading .agentctl.yml: %v\n", err)
+		} else {
+			fmt.Fprintln(out, "Configuration: .agentctl.yml found")
+			printConfigFields(out, cfg)
+		}
+	}
+	fmt.Fprintln(out)
 
-// Active Worktrees — only those managed by agentctl (have a .agent file with an agent name)
-wts, err := git.LinkedWorktrees(repoRoot)
-if err != nil {
-fmt.Fprintln(out, "Active Worktrees: 0")
-return nil
-}
-var managed []git.Worktree
-for _, wt := range wts {
-af, _ := state.Read(wt.Path)
-if af.Agent != "" {
-managed = append(managed, wt)
-}
-}
-if len(managed) == 0 {
-fmt.Fprintln(out, "Active Worktrees: 0")
-} else {
-fmt.Fprintf(out, "Active Worktrees: %d\n", len(managed))
-for _, wt := range managed {
-af, _ := state.Read(wt.Path)
-fmt.Fprintf(out, "  %-30s (%s)\n", wt.Branch, af.Agent)
-}
-}
+	// Active Worktrees — only those managed by agentctl (have a .agent file with an agent name)
+	wts, err := git.LinkedWorktrees(repoRoot)
+	if err != nil {
+		fmt.Fprintln(out, "Active Worktrees: 0")
+		return nil
+	}
+	var managed []git.Worktree
+	for _, wt := range wts {
+		af, _ := state.Read(wt.Path)
+		if af.Agent != "" {
+			managed = append(managed, wt)
+		}
+	}
+	if len(managed) == 0 {
+		fmt.Fprintln(out, "Active Worktrees: 0")
+	} else {
+		fmt.Fprintf(out, "Active Worktrees: %d\n", len(managed))
+		for _, wt := range managed {
+			af, _ := state.Read(wt.Path)
+			fmt.Fprintf(out, "  %-30s (%s)\n", wt.Branch, af.Agent)
+		}
+	}
 
-return nil
+	return nil
 }
 
 // printConfigFields writes non-zero config fields to out, one per line, indented.
 func printConfigFields(out io.Writer, cfg *config.AgentctlConfig) {
-if cfg.Editor != "" {
-fmt.Fprintf(out, "  editor: %s\n", cfg.Editor)
-}
-if cfg.DefaultAgent != "" {
-fmt.Fprintf(out, "  default_agent: %s\n", cfg.DefaultAgent)
-}
-if cfg.DevServer != "" {
-fmt.Fprintf(out, "  dev_server: %s\n", cfg.DevServer)
-}
-if cfg.MergeStrategy != "" {
-fmt.Fprintf(out, "  merge_strategy: %s\n", cfg.MergeStrategy)
-}
-if cfg.TestCmd != "" {
-fmt.Fprintf(out, "  test_cmd: %s\n", cfg.TestCmd)
-}
-if cfg.BuildCmd != "" {
-fmt.Fprintf(out, "  build_cmd: %s\n", cfg.BuildCmd)
-}
-if cfg.Notify != nil && *cfg.Notify {
-fmt.Fprintln(out, "  notify: true")
-}
-if cfg.VCS.Provider != "" {
-fmt.Fprintf(out, "  vcs.provider: %s\n", cfg.VCS.Provider)
-}
-if cfg.VCS.Server != "" {
-fmt.Fprintf(out, "  vcs.server: %s\n", cfg.VCS.Server)
-}
+	if cfg.Editor != "" {
+		fmt.Fprintf(out, "  editor: %s\n", cfg.Editor)
+	}
+	if cfg.DefaultAgent != "" {
+		fmt.Fprintf(out, "  default_agent: %s\n", cfg.DefaultAgent)
+	}
+	if cfg.DevServer != "" {
+		fmt.Fprintf(out, "  dev_server: %s\n", cfg.DevServer)
+	}
+	if cfg.MergeStrategy != "" {
+		fmt.Fprintf(out, "  merge_strategy: %s\n", cfg.MergeStrategy)
+	}
+	if cfg.TestCmd != "" {
+		fmt.Fprintf(out, "  test_cmd: %s\n", cfg.TestCmd)
+	}
+	if cfg.BuildCmd != "" {
+		fmt.Fprintf(out, "  build_cmd: %s\n", cfg.BuildCmd)
+	}
+	if cfg.Notify != nil && *cfg.Notify {
+		fmt.Fprintln(out, "  notify: true")
+	} else if cfg.Notify != nil && !*cfg.Notify {
+		fmt.Fprintln(out, "  notify: false")
+	}
+	if cfg.VCS.Provider != "" {
+		fmt.Fprintf(out, "  vcs.provider: %s\n", cfg.VCS.Provider)
+	}
+	if cfg.VCS.Server != "" {
+		fmt.Fprintf(out, "  vcs.server: %s\n", cfg.VCS.Server)
+	}
 }
 
 // printGlobalConfigFields writes non-zero global config fields to out, one per line, indented.
 func printGlobalConfigFields(out io.Writer, cfg *config.GlobalConfig) {
-if cfg.DefaultAgent != "" {
-fmt.Fprintf(out, "  default_agent: %s\n", cfg.DefaultAgent)
-}
-if cfg.Editor != "" {
-fmt.Fprintf(out, "  editor: %s\n", cfg.Editor)
-}
-if cfg.MergeStrategy != "" {
-fmt.Fprintf(out, "  merge_strategy: %s\n", cfg.MergeStrategy)
-}
-if cfg.Notify != nil && *cfg.Notify {
-fmt.Fprintln(out, "  notify: true")
-} else if cfg.Notify != nil && !*cfg.Notify {
-fmt.Fprintln(out, "  notify: false")
-}
+	if cfg.DefaultAgent != "" {
+		fmt.Fprintf(out, "  default_agent: %s\n", cfg.DefaultAgent)
+	}
+	if cfg.Editor != "" {
+		fmt.Fprintf(out, "  editor: %s\n", cfg.Editor)
+	}
+	if cfg.MergeStrategy != "" {
+		fmt.Fprintf(out, "  merge_strategy: %s\n", cfg.MergeStrategy)
+	}
+	if cfg.Notify != nil && *cfg.Notify {
+		fmt.Fprintln(out, "  notify: true")
+	} else if cfg.Notify != nil && !*cfg.Notify {
+		fmt.Fprintln(out, "  notify: false")
+	}
+	if cfg.Diagnostics.Enabled != nil && *cfg.Diagnostics.Enabled {
+		fmt.Fprintln(out, "  diagnostics.enabled: true")
+	} else if cfg.Diagnostics.Enabled != nil && !*cfg.Diagnostics.Enabled {
+		fmt.Fprintln(out, "  diagnostics.enabled: false")
+	}
 }
 
 // systemOS returns "GOOS major.minor" where the kernel version comes from
@@ -258,76 +270,76 @@ fmt.Fprintln(out, "  notify: false")
 // Falls back to GOOS alone when uname is unavailable, and to "GOOS raw-output"
 // when the output contains no dot-separated version numbers.
 func systemOS() string {
-osName := runtime.GOOS
-out, err := runToolCmdFn("uname", "-r")
-if err != nil {
-return osName
-}
-out = strings.TrimSpace(out)
-if m := kernelVersionRe.FindStringSubmatch(out); m != nil {
-return fmt.Sprintf("%s %s.%s", osName, m[1], m[2])
-}
-return fmt.Sprintf("%s %s", osName, out)
+	osName := runtime.GOOS
+	out, err := runToolCmdFn("uname", "-r")
+	if err != nil {
+		return osName
+	}
+	out = strings.TrimSpace(out)
+	if m := kernelVersionRe.FindStringSubmatch(out); m != nil {
+		return fmt.Sprintf("%s %s.%s", osName, m[1], m[2])
+	}
+	return fmt.Sprintf("%s %s", osName, out)
 }
 
 // parseGHVersion extracts the version number from `gh --version` output.
 // "gh version 2.45.0 (2024-01-15)\n..." → "2.45.0"
 func parseGHVersion(ghOut string) string {
-if ghOut == "" {
-return ""
-}
-firstLine := strings.SplitN(ghOut, "\n", 2)[0]
-parts := strings.Fields(firstLine)
-// ["gh", "version", "2.45.0", "(2024-...)"]
-if len(parts) >= 3 {
-return parts[2]
-}
-return firstLine
+	if ghOut == "" {
+		return ""
+	}
+	firstLine := strings.SplitN(ghOut, "\n", 2)[0]
+	parts := strings.Fields(firstLine)
+	// ["gh", "version", "2.45.0", "(2024-...)"]
+	if len(parts) >= 3 {
+		return parts[2]
+	}
+	return firstLine
 }
 
 // ghAuthUser returns the authenticated GitHub username from `gh auth status`,
 // or empty string if not authenticated or gh is not available.
 func ghAuthUser() string {
-cmd := exec.Command("gh", "auth", "status") //nolint:gosec
-out, _ := cmd.CombinedOutput()
-for _, line := range strings.Split(string(out), "\n") {
-if idx := strings.Index(line, "account "); idx >= 0 {
-parts := strings.Fields(line[idx:])
-if len(parts) >= 2 {
-return parts[1]
-}
-}
-}
-return ""
+	cmd := exec.Command("gh", "auth", "status") //nolint:gosec
+	out, _ := cmd.CombinedOutput()
+	for _, line := range strings.Split(string(out), "\n") {
+		if idx := strings.Index(line, "account "); idx >= 0 {
+			parts := strings.Fields(line[idx:])
+			if len(parts) >= 2 {
+				return parts[1]
+			}
+		}
+	}
+	return ""
 }
 
 // runToolCmd runs an external command and returns trimmed stdout, or an error.
 func runToolCmd(name string, args ...string) (string, error) {
-cmd := exec.Command(name, args...) //nolint:gosec
-out, err := cmd.Output()
-if err != nil {
-return "", err
-}
-return strings.TrimSpace(string(out)), nil
+	cmd := exec.Command(name, args...) //nolint:gosec
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 func switchToRepoRoot(repoRoot string) (func(), string) {
-if repoRoot == "" {
-return nil, ""
-}
+	if repoRoot == "" {
+		return nil, ""
+	}
 
-cwd, err := os.Getwd()
-if err != nil {
-return nil, fmt.Sprintf("cannot get current directory for adapter lookup: %v", err)
-}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Sprintf("cannot get current directory for adapter lookup: %v", err)
+	}
 
-if err := os.Chdir(repoRoot); err != nil {
-return nil, fmt.Sprintf("cannot switch to repo root for adapter lookup: %v", err)
-}
+	if err := os.Chdir(repoRoot); err != nil {
+		return nil, fmt.Sprintf("cannot switch to repo root for adapter lookup: %v", err)
+	}
 
-return func() {
-if err := os.Chdir(cwd); err != nil {
-fmt.Fprintf(os.Stderr, "warning: cannot restore working directory after adapter lookup: %v\n", err)
-}
-}, ""
+	return func() {
+		if err := os.Chdir(cwd); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: cannot restore working directory after adapter lookup: %v\n", err)
+		}
+	}, ""
 }

--- a/internal/cmd/info_test.go
+++ b/internal/cmd/info_test.go
@@ -174,6 +174,7 @@ t.Errorf("expected no Configuration: section for empty repoRoot; got:\n%s", out)
 }
 
 func TestPrintConfigFields_allFields(t *testing.T) {
+notifyTrue := true
 cfg := &config.AgentctlConfig{
 Editor:        "cursor",
 DefaultAgent:  "codex",
@@ -181,7 +182,7 @@ DevServer:     "npm run dev",
 MergeStrategy: "squash",
 TestCmd:       "go test ./...",
 BuildCmd:      "go build ./...",
-Notify:        true,
+Notify:        &notifyTrue,
 VCS:           config.VCSConfig{Provider: "gitlab", Server: "https://gl.example.com"},
 }
 
@@ -604,5 +605,77 @@ got := systemOS()
 // Should fall back to GOOS alone (no spaces/extra tokens)
 if strings.Contains(got, " ") {
 t.Errorf("systemOS() = %q, expected GOOS-only (no space) when uname fails", got)
+}
+}
+
+// ─── Global config section ────────────────────────────────────────────────────
+
+func TestRunInfo_globalConfigNoneWhenAbsent(t *testing.T) {
+tmp := t.TempDir()
+t.Setenv("XDG_CONFIG_HOME", tmp)
+
+var buf bytes.Buffer
+if err := runInfo(&buf, "dev", "", false); err != nil {
+t.Fatalf("runInfo error: %v", err)
+}
+out := buf.String()
+if !strings.Contains(out, "Global config: none") {
+t.Errorf("expected 'Global config: none' when file absent; got:\n%s", out)
+}
+}
+
+func TestRunInfo_globalConfigShownWhenPresent(t *testing.T) {
+tmp := t.TempDir()
+t.Setenv("XDG_CONFIG_HOME", tmp)
+globalDir := filepath.Join(tmp, "agentctl")
+if err := os.MkdirAll(globalDir, 0o755); err != nil {
+t.Fatalf("mkdir: %v", err)
+}
+if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("default_agent: codex\nnotify: true\n"), 0o644); err != nil {
+t.Fatalf("write: %v", err)
+}
+
+var buf bytes.Buffer
+if err := runInfo(&buf, "dev", "", false); err != nil {
+t.Fatalf("runInfo error: %v", err)
+}
+out := buf.String()
+if !strings.Contains(out, "Global config:") {
+t.Errorf("expected 'Global config:' header; got:\n%s", out)
+}
+if !strings.Contains(out, "default_agent: codex") {
+t.Errorf("expected 'default_agent: codex' in global config section; got:\n%s", out)
+}
+if !strings.Contains(out, "notify: true") {
+t.Errorf("expected 'notify: true' in global config section; got:\n%s", out)
+}
+}
+
+func TestRunInfo_globalConfigAboveProjectLocal(t *testing.T) {
+tmp := t.TempDir()
+t.Setenv("XDG_CONFIG_HOME", tmp)
+
+dir := t.TempDir()
+cfg := &config.AgentctlConfig{Editor: "cursor"}
+if err := config.Write(dir, cfg); err != nil {
+t.Fatalf("write config: %v", err)
+}
+
+var buf bytes.Buffer
+if err := runInfo(&buf, "dev", dir, false); err != nil {
+t.Fatalf("runInfo error: %v", err)
+}
+out := buf.String()
+// Both sections must appear; Global config must come before Configuration.
+globalIdx := strings.Index(out, "Global config:")
+configIdx := strings.Index(out, "Configuration:")
+if globalIdx < 0 {
+t.Errorf("expected 'Global config:' in output; got:\n%s", out)
+}
+if configIdx < 0 {
+t.Errorf("expected 'Configuration:' in output; got:\n%s", out)
+}
+if globalIdx > configIdx {
+t.Errorf("Global config section should appear before Configuration section; got:\n%s", out)
 }
 }

--- a/internal/cmd/info_test.go
+++ b/internal/cmd/info_test.go
@@ -1,681 +1,766 @@
 package cmd
 
 import (
-"bytes"
-"errors"
-"os"
-"os/exec"
-"path/filepath"
-"strings"
-"testing"
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
 
-"github.com/arun-gupta/agentctl/internal/config"
-"github.com/arun-gupta/agentctl/internal/state"
+	"github.com/arun-gupta/agentctl/internal/config"
+	"github.com/arun-gupta/agentctl/internal/state"
 )
 
 // stubToolRunner temporarily replaces runToolCmdFn for the duration of the test.
 func stubToolRunner(t *testing.T, fn func(name string, args ...string) (string, error)) {
-t.Helper()
-orig := runToolCmdFn
-runToolCmdFn = fn
-t.Cleanup(func() { runToolCmdFn = orig })
+	t.Helper()
+	orig := runToolCmdFn
+	runToolCmdFn = fn
+	t.Cleanup(func() { runToolCmdFn = orig })
 }
 
 // stubLookPath temporarily replaces lookPathFn for the duration of the test.
 func stubLookPath(t *testing.T, fn func(string) (string, error)) {
-t.Helper()
-orig := lookPathFn
-lookPathFn = fn
-t.Cleanup(func() { lookPathFn = orig })
+	t.Helper()
+	orig := lookPathFn
+	lookPathFn = fn
+	t.Cleanup(func() { lookPathFn = orig })
 }
 
 // stubGHAuthUser temporarily replaces ghAuthUserFn for the duration of the test.
 func stubGHAuthUser(t *testing.T, fn func() string) {
-t.Helper()
-orig := ghAuthUserFn
-ghAuthUserFn = fn
-t.Cleanup(func() { ghAuthUserFn = orig })
+	t.Helper()
+	orig := ghAuthUserFn
+	ghAuthUserFn = fn
+	t.Cleanup(func() { ghAuthUserFn = orig })
 }
 
 func TestRunInfo_versionInOutput(t *testing.T) {
-var buf bytes.Buffer
-if err := runInfo(&buf, "v1.2.3", "", false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-if !strings.Contains(buf.String(), "agentctl v1.2.3") {
-t.Errorf("output missing version line; got:\n%s", buf.String())
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "v1.2.3", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "agentctl v1.2.3") {
+		t.Errorf("output missing version line; got:\n%s", buf.String())
+	}
 }
 
 func TestRunInfo_systemInOutput(t *testing.T) {
-stubToolRunner(t, func(name string, args ...string) (string, error) {
-if name == "uname" {
-return "5.15.0-91-generic", nil
-}
-return "", errors.New("not found")
-})
+	stubToolRunner(t, func(name string, args ...string) (string, error) {
+		if name == "uname" {
+			return "5.15.0-91-generic", nil
+		}
+		return "", errors.New("not found")
+	})
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", "", false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-if !strings.Contains(buf.String(), "System:") {
-t.Errorf("output missing System: line; got:\n%s", buf.String())
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "System:") {
+		t.Errorf("output missing System: line; got:\n%s", buf.String())
+	}
 }
 
 func TestRunInfo_agentSectionInOutput(t *testing.T) {
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", "", false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-if !strings.Contains(buf.String(), "Coding Agents:") {
-t.Errorf("output missing Coding Agents: section; got:\n%s", buf.String())
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Coding Agents:") {
+		t.Errorf("output missing Coding Agents: section; got:\n%s", buf.String())
+	}
 }
 
 func TestRunInfo_noConfigWhenMissing(t *testing.T) {
-dir := t.TempDir()
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", dir, false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-if !strings.Contains(buf.String(), "Configuration: no .agentctl.yml found") {
-t.Errorf("expected no-config message; got:\n%s", buf.String())
-}
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir, false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Configuration: no .agentctl.yml found") {
+		t.Errorf("expected no-config message; got:\n%s", buf.String())
+	}
 }
 
 func TestRunInfo_withConfig(t *testing.T) {
-dir := t.TempDir()
-cfg := &config.AgentctlConfig{
-Editor:    "cursor",
-DevServer: "npm run dev -- --port {port}",
-}
-if err := config.Write(dir, cfg); err != nil {
-t.Fatalf("write config: %v", err)
-}
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{
+		Editor:    "cursor",
+		DevServer: "npm run dev -- --port {port}",
+	}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", dir, false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "Configuration: .agentctl.yml found") {
-t.Errorf("expected config-found message; got:\n%s", out)
-}
-if !strings.Contains(out, "editor: cursor") {
-t.Errorf("expected editor field in output; got:\n%s", out)
-}
-if !strings.Contains(out, "dev_server:") {
-t.Errorf("expected dev_server field in output; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir, false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Configuration: .agentctl.yml found") {
+		t.Errorf("expected config-found message; got:\n%s", out)
+	}
+	if !strings.Contains(out, "editor: cursor") {
+		t.Errorf("expected editor field in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "dev_server:") {
+		t.Errorf("expected dev_server field in output; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_noWorktreesForPlainDir(t *testing.T) {
-dir := t.TempDir()
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", dir, false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "Active Worktrees: 0") {
-t.Errorf("expected 'Active Worktrees: 0' for non-git dir; got:\n%s", out)
-}
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir, false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Active Worktrees: 0") {
+		t.Errorf("expected 'Active Worktrees: 0' for non-git dir; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_defaultAgentMarked(t *testing.T) {
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", "", false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-// "claude" is the built-in default; it should be marked "(default)"
-out := buf.String()
-if !strings.Contains(out, "(default)") {
-t.Errorf("expected default agent marker in output; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	// "claude" is the built-in default; it should be marked "(default)"
+	out := buf.String()
+	if !strings.Contains(out, "(default)") {
+		t.Errorf("expected default agent marker in output; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_customDefaultAgentFromConfig(t *testing.T) {
-dir := t.TempDir()
-cfg := &config.AgentctlConfig{DefaultAgent: "codex"}
-if err := config.Write(dir, cfg); err != nil {
-t.Fatalf("write config: %v", err)
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{DefaultAgent: "codex"}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir, false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	// codex should be the default now; look for "codex" with "(default)" nearby
+	lines := strings.Split(out, "\n")
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "codex") && strings.Contains(line, "(default)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected codex marked as default; got:\n%s", out)
+	}
 }
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", dir, false); err != nil {
-t.Fatalf("runInfo error: %v", err)
+func TestRunInfo_defaultAgentFromGlobalOutsideRepo(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	globalDir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("default_agent: codex\n"), 0o644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	lines := strings.Split(out, "\n")
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "codex") && strings.Contains(line, "(default)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected codex marked as default outside repo when set globally; got:\n%s", out)
+	}
 }
-out := buf.String()
-// codex should be the default now; look for "codex" with "(default)" nearby
-lines := strings.Split(out, "\n")
-found := false
-for _, line := range lines {
-if strings.Contains(line, "codex") && strings.Contains(line, "(default)") {
-found = true
-break
-}
-}
-if !found {
-t.Errorf("expected codex marked as default; got:\n%s", out)
-}
+
+func TestRunInfo_defaultAgentFallsBackToLocalWhenGlobalMalformed(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	globalDir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("default_agent: [\n"), 0o644); err != nil {
+		t.Fatalf("write malformed global config: %v", err)
+	}
+
+	repoDir := t.TempDir()
+	if err := config.Write(repoDir, &config.AgentctlConfig{DefaultAgent: "gemini"}); err != nil {
+		t.Fatalf("write local config: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", repoDir, false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	lines := strings.Split(out, "\n")
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "gemini") && strings.Contains(line, "(default)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected gemini marked as default when global config is malformed; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_emptyRepoRootSkipsConfigSection(t *testing.T) {
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", "", false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-// With empty repoRoot, config and worktrees sections should be absent
-out := buf.String()
-if strings.Contains(out, "Configuration:") {
-t.Errorf("expected no Configuration: section for empty repoRoot; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	// With empty repoRoot, config and worktrees sections should be absent
+	out := buf.String()
+	if strings.Contains(out, "Configuration:") {
+		t.Errorf("expected no Configuration: section for empty repoRoot; got:\n%s", out)
+	}
 }
 
 func TestPrintConfigFields_allFields(t *testing.T) {
-notifyTrue := true
-cfg := &config.AgentctlConfig{
-Editor:        "cursor",
-DefaultAgent:  "codex",
-DevServer:     "npm run dev",
-MergeStrategy: "squash",
-TestCmd:       "go test ./...",
-BuildCmd:      "go build ./...",
-Notify:        &notifyTrue,
-VCS:           config.VCSConfig{Provider: "gitlab", Server: "https://gl.example.com"},
-}
+	notifyTrue := true
+	cfg := &config.AgentctlConfig{
+		Editor:        "cursor",
+		DefaultAgent:  "codex",
+		DevServer:     "npm run dev",
+		MergeStrategy: "squash",
+		TestCmd:       "go test ./...",
+		BuildCmd:      "go build ./...",
+		Notify:        &notifyTrue,
+		VCS:           config.VCSConfig{Provider: "gitlab", Server: "https://gl.example.com"},
+	}
 
-var buf bytes.Buffer
-printConfigFields(&buf, cfg)
-out := buf.String()
+	var buf bytes.Buffer
+	printConfigFields(&buf, cfg)
+	out := buf.String()
 
-checks := []string{
-"editor: cursor",
-"default_agent: codex",
-"dev_server: npm run dev",
-"merge_strategy: squash",
-"test_cmd: go test ./...",
-"build_cmd: go build ./...",
-"notify: true",
-"vcs.provider: gitlab",
-"vcs.server: https://gl.example.com",
-}
-for _, want := range checks {
-if !strings.Contains(out, want) {
-t.Errorf("printConfigFields missing %q; got:\n%s", want, out)
-}
-}
+	checks := []string{
+		"editor: cursor",
+		"default_agent: codex",
+		"dev_server: npm run dev",
+		"merge_strategy: squash",
+		"test_cmd: go test ./...",
+		"build_cmd: go build ./...",
+		"notify: true",
+		"vcs.provider: gitlab",
+		"vcs.server: https://gl.example.com",
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("printConfigFields missing %q; got:\n%s", want, out)
+		}
+	}
 }
 
 func TestPrintConfigFields_emptyConfig(t *testing.T) {
-cfg := &config.AgentctlConfig{}
-var buf bytes.Buffer
-printConfigFields(&buf, cfg)
-if buf.Len() != 0 {
-t.Errorf("expected empty output for empty config; got: %q", buf.String())
+	cfg := &config.AgentctlConfig{}
+	var buf bytes.Buffer
+	printConfigFields(&buf, cfg)
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for empty config; got: %q", buf.String())
+	}
 }
+
+func TestPrintConfigFields_notifyFalse(t *testing.T) {
+	notifyFalse := false
+	cfg := &config.AgentctlConfig{Notify: &notifyFalse}
+	var buf bytes.Buffer
+	printConfigFields(&buf, cfg)
+	if !strings.Contains(buf.String(), "notify: false") {
+		t.Errorf("expected notify: false, got %q", buf.String())
+	}
+}
+
+func TestPrintGlobalConfigFields_diagnosticsEnabled(t *testing.T) {
+	enabled := false
+	cfg := &config.GlobalConfig{
+		Diagnostics: config.DiagnosticsConfig{Enabled: &enabled},
+	}
+	var buf bytes.Buffer
+	printGlobalConfigFields(&buf, cfg)
+	if !strings.Contains(buf.String(), "diagnostics.enabled: false") {
+		t.Errorf("expected diagnostics.enabled: false, got %q", buf.String())
+	}
 }
 
 func TestParseGHVersion(t *testing.T) {
-tests := []struct {
-input string
-want  string
-}{
-{"gh version 2.45.0 (2024-01-15)\nhttps://github.com/cli/cli/releases/tag/v2.45.0", "2.45.0"},
-{"gh version 2.10.1 (2023-06-20)", "2.10.1"},
-{"unexpected output", "unexpected output"},
-{"", ""},
-}
-for _, tt := range tests {
-got := parseGHVersion(tt.input)
-if got != tt.want {
-t.Errorf("parseGHVersion(%q) = %q, want %q", tt.input, got, tt.want)
-}
-}
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"gh version 2.45.0 (2024-01-15)\nhttps://github.com/cli/cli/releases/tag/v2.45.0", "2.45.0"},
+		{"gh version 2.10.1 (2023-06-20)", "2.10.1"},
+		{"unexpected output", "unexpected output"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := parseGHVersion(tt.input)
+		if got != tt.want {
+			t.Errorf("parseGHVersion(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
 }
 
 func TestInfoCmd_exists(t *testing.T) {
-c := NewInfoCmd("test-version")
-if c.Use != "info" {
-t.Errorf("command Use = %q, want %q", c.Use, "info")
-}
+	c := NewInfoCmd("test-version")
+	if c.Use != "info" {
+		t.Errorf("command Use = %q, want %q", c.Use, "info")
+	}
 }
 
 func TestRunInfo_gitSection(t *testing.T) {
-stubToolRunner(t, func(name string, args ...string) (string, error) {
-if name == "git" {
-return "git version 2.50.0", nil
-}
-return "", errors.New("not found")
-})
+	stubToolRunner(t, func(name string, args ...string) (string, error) {
+		if name == "git" {
+			return "git version 2.50.0", nil
+		}
+		return "", errors.New("not found")
+	})
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", "", false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "Git:") {
-t.Errorf("output missing Git: line; got:\n%s", out)
-}
-if !strings.Contains(out, "2.50.0") {
-t.Errorf("expected git version in output; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Git:") {
+		t.Errorf("output missing Git: line; got:\n%s", out)
+	}
+	if !strings.Contains(out, "2.50.0") {
+		t.Errorf("expected git version in output; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_ghSection(t *testing.T) {
-stubToolRunner(t, func(name string, args ...string) (string, error) {
-if name == "gh" {
-return "gh version 2.78.0 (2025-01-01)", nil
-}
-return "", errors.New("not found")
-})
-stubLookPath(t, func(name string) (string, error) {
-if name == "gh" {
-return "/usr/bin/gh", nil
-}
-return "", errors.New("not found")
-})
-stubGHAuthUser(t, func() string { return "testuser" })
+	stubToolRunner(t, func(name string, args ...string) (string, error) {
+		if name == "gh" {
+			return "gh version 2.78.0 (2025-01-01)", nil
+		}
+		return "", errors.New("not found")
+	})
+	stubLookPath(t, func(name string) (string, error) {
+		if name == "gh" {
+			return "/usr/bin/gh", nil
+		}
+		return "", errors.New("not found")
+	})
+	stubGHAuthUser(t, func() string { return "testuser" })
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", "", false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "GitHub CLI:") {
-t.Errorf("output missing GitHub CLI: line; got:\n%s", out)
-}
-if !strings.Contains(out, "2.78.0") {
-t.Errorf("expected gh version in output; got:\n%s", out)
-}
-if !strings.Contains(out, "authenticated as testuser") {
-t.Errorf("expected auth user in output; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "GitHub CLI:") {
+		t.Errorf("output missing GitHub CLI: line; got:\n%s", out)
+	}
+	if !strings.Contains(out, "2.78.0") {
+		t.Errorf("expected gh version in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "authenticated as testuser") {
+		t.Errorf("expected auth user in output; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_ghVersionErrorShown(t *testing.T) {
-stubLookPath(t, func(name string) (string, error) {
-if name == "gh" {
-return "/usr/bin/gh", nil
-}
-return "", errors.New("not found")
-})
-stubToolRunner(t, func(name string, args ...string) (string, error) {
-if name == "gh" {
-return "", errors.New("exec format error")
-}
-return "", errors.New("not found")
-})
+	stubLookPath(t, func(name string) (string, error) {
+		if name == "gh" {
+			return "/usr/bin/gh", nil
+		}
+		return "", errors.New("not found")
+	})
+	stubToolRunner(t, func(name string, args ...string) (string, error) {
+		if name == "gh" {
+			return "", errors.New("exec format error")
+		}
+		return "", errors.New("not found")
+	})
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", "", false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "GitHub CLI: error running gh --version:") {
-t.Errorf("expected gh version error indicator; got:\n%s", out)
-}
-for _, line := range strings.Split(out, "\n") {
-	if strings.Contains(line, "GitHub CLI") && (strings.Contains(line, "✓") || strings.Contains(line, "OK")) {
-		t.Errorf("did not expect success marker in GitHub CLI line; got: %s", line)
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
 	}
-}
+	out := buf.String()
+	if !strings.Contains(out, "GitHub CLI: error running gh --version:") {
+		t.Errorf("expected gh version error indicator; got:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "GitHub CLI") && (strings.Contains(line, "✓") || strings.Contains(line, "OK")) {
+			t.Errorf("did not expect success marker in GitHub CLI line; got: %s", line)
+		}
+	}
 }
 
 func TestRunInfo_asciiMode(t *testing.T) {
-stubToolRunner(t, func(name string, args ...string) (string, error) {
-if name == "git" {
-return "git version 2.50.0", nil
-}
-return "", errors.New("not found")
-})
+	stubToolRunner(t, func(name string, args ...string) (string, error) {
+		if name == "git" {
+			return "git version 2.50.0", nil
+		}
+		return "", errors.New("not found")
+	})
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", "", true); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-// ASCII mode should use "OK"/"X" not Unicode glyphs
-if strings.Contains(out, "✓") || strings.Contains(out, "✗") {
-t.Errorf("expected no Unicode glyphs in ASCII mode; got:\n%s", out)
-}
-if !strings.Contains(out, "OK") && !strings.Contains(out, "X") {
-t.Errorf("expected ASCII markers (OK/X) in output; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", true); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	// ASCII mode should use "OK"/"X" not Unicode glyphs
+	if strings.Contains(out, "✓") || strings.Contains(out, "✗") {
+		t.Errorf("expected no Unicode glyphs in ASCII mode; got:\n%s", out)
+	}
+	if !strings.Contains(out, "OK") && !strings.Contains(out, "X") {
+		t.Errorf("expected ASCII markers (OK/X) in output; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_configWithDefaultAgent(t *testing.T) {
-dir := t.TempDir()
-cfg := &config.AgentctlConfig{DefaultAgent: "gemini"}
-if err := config.Write(dir, cfg); err != nil {
-t.Fatalf("write config: %v", err)
-}
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{DefaultAgent: "gemini"}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", dir, false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "default_agent: gemini") {
-t.Errorf("expected default_agent shown in config; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir, false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "default_agent: gemini") {
+		t.Errorf("expected default_agent shown in config; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_installHintShown(t *testing.T) {
-// Create a temp dir with a custom adapter that won't be on PATH
-dir := t.TempDir()
-adapterDir := filepath.Join(dir, ".agentctl", "adapters")
-if err := os.MkdirAll(adapterDir, 0o755); err != nil {
-t.Fatalf("mkdir: %v", err)
-}
-adapterYAML := "binary: nonexistent-agent-xyz-999\ninstall: npm install -g nonexistent-agent-xyz-999\n"
-if err := os.WriteFile(filepath.Join(adapterDir, "nonexistent-agent-xyz-999.yml"), []byte(adapterYAML), 0o644); err != nil {
-t.Fatalf("write adapter: %v", err)
-}
+	// Create a temp dir with a custom adapter that won't be on PATH
+	dir := t.TempDir()
+	adapterDir := filepath.Join(dir, ".agentctl", "adapters")
+	if err := os.MkdirAll(adapterDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	adapterYAML := "binary: nonexistent-agent-xyz-999\ninstall: npm install -g nonexistent-agent-xyz-999\n"
+	if err := os.WriteFile(filepath.Join(adapterDir, "nonexistent-agent-xyz-999.yml"), []byte(adapterYAML), 0o644); err != nil {
+		t.Fatalf("write adapter: %v", err)
+	}
 
-// Change to dir so adapters.List() picks up the local adapter
-orig, err := os.Getwd()
-if err != nil {
-t.Fatalf("getwd: %v", err)
-}
-if err := os.Chdir(dir); err != nil {
-t.Fatalf("chdir: %v", err)
-}
-t.Cleanup(func() { _ = os.Chdir(orig) })
+	// Change to dir so adapters.List() picks up the local adapter
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", dir, false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "install with:") {
-t.Errorf("expected install hint in output; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir, false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "install with:") {
+		t.Errorf("expected install hint in output; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_projectLocalAdapterFoundFromSubdir(t *testing.T) {
-repoRoot := t.TempDir()
-adapterDir := filepath.Join(repoRoot, ".agentctl", "adapters")
-if err := os.MkdirAll(adapterDir, 0o755); err != nil {
-t.Fatalf("mkdir: %v", err)
-}
-if err := os.WriteFile(filepath.Join(adapterDir, "local-only-adapter.yml"), []byte("binary: nonexistent-local-only-adapter\n"), 0o644); err != nil {
-t.Fatalf("write adapter: %v", err)
-}
-subdir := filepath.Join(repoRoot, "nested", "dir")
-if err := os.MkdirAll(subdir, 0o755); err != nil {
-t.Fatalf("mkdir subdir: %v", err)
-}
+	repoRoot := t.TempDir()
+	adapterDir := filepath.Join(repoRoot, ".agentctl", "adapters")
+	if err := os.MkdirAll(adapterDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(adapterDir, "local-only-adapter.yml"), []byte("binary: nonexistent-local-only-adapter\n"), 0o644); err != nil {
+		t.Fatalf("write adapter: %v", err)
+	}
+	subdir := filepath.Join(repoRoot, "nested", "dir")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
 
-orig, err := os.Getwd()
-if err != nil {
-t.Fatalf("getwd: %v", err)
-}
-if err := os.Chdir(subdir); err != nil {
-t.Fatalf("chdir: %v", err)
-}
-t.Cleanup(func() { _ = os.Chdir(orig) })
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(subdir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", repoRoot, false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "local-only-adapter") {
-t.Errorf("expected project-local adapter to appear from subdir; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", repoRoot, false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "local-only-adapter") {
+		t.Errorf("expected project-local adapter to appear from subdir; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_adapterLoadErrorShown(t *testing.T) {
-dir := t.TempDir()
-adapterDir := filepath.Join(dir, ".agentctl", "adapters")
-if err := os.MkdirAll(adapterDir, 0o755); err != nil {
-t.Fatalf("mkdir: %v", err)
-}
-if err := os.WriteFile(filepath.Join(adapterDir, "broken-adapter.yml"), []byte("install: some-install-cmd\n"), 0o644); err != nil {
-t.Fatalf("write adapter: %v", err)
-}
+	dir := t.TempDir()
+	adapterDir := filepath.Join(dir, ".agentctl", "adapters")
+	if err := os.MkdirAll(adapterDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(adapterDir, "broken-adapter.yml"), []byte("install: some-install-cmd\n"), 0o644); err != nil {
+		t.Fatalf("write adapter: %v", err)
+	}
 
-orig, err := os.Getwd()
-if err != nil {
-t.Fatalf("getwd: %v", err)
-}
-if err := os.Chdir(dir); err != nil {
-t.Fatalf("chdir: %v", err)
-}
-t.Cleanup(func() { _ = os.Chdir(orig) })
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", dir, false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "broken-adapter") || !strings.Contains(out, "(adapter error)") {
-t.Errorf("expected adapter load error status in output; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir, false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "broken-adapter") || !strings.Contains(out, "(adapter error)") {
+		t.Errorf("expected adapter load error status in output; got:\n%s", out)
+	}
 }
 
 // ─── worktree filtering ───────────────────────────────────────────────────────
 
 func initGitRepoForInfo(t *testing.T) string {
-t.Helper()
-if _, err := exec.LookPath("git"); err != nil {
-t.Skip("git not found in PATH")
-}
-dir := t.TempDir()
-gitRunInfo := func(args ...string) {
-t.Helper()
-cmd := exec.Command("git", args...)
-cmd.Dir = dir
-if out, err := cmd.CombinedOutput(); err != nil {
-t.Fatalf("git %v: %v\n%s", args, err, out)
-}
-}
-gitRunInfo("init")
-gitRunInfo("config", "user.email", "test@example.com")
-gitRunInfo("config", "user.name", "Test")
-gitRunInfo("config", "commit.gpgsign", "false")
-if err := os.WriteFile(filepath.Join(dir, "README"), []byte("test\n"), 0o644); err != nil {
-t.Fatal(err)
-}
-gitRunInfo("add", ".")
-gitRunInfo("commit", "-m", "init")
-return dir
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH")
+	}
+	dir := t.TempDir()
+	gitRunInfo := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	gitRunInfo("init")
+	gitRunInfo("config", "user.email", "test@example.com")
+	gitRunInfo("config", "user.name", "Test")
+	gitRunInfo("config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "README"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRunInfo("add", ".")
+	gitRunInfo("commit", "-m", "init")
+	return dir
 }
 
 func TestRunInfo_skipsWorktreesWithoutAgentFile(t *testing.T) {
-repo := initGitRepoForInfo(t)
-wtPath := filepath.Join(t.TempDir(), "42-no-agent")
-cmd := exec.Command("git", "-C", repo, "worktree", "add", wtPath, "-b", "42-no-agent")
-if out, err := cmd.CombinedOutput(); err != nil {
-t.Fatalf("git worktree add: %v\n%s", err, out)
-}
-// No .agent file written — simulates a manually-created worktree.
+	repo := initGitRepoForInfo(t)
+	wtPath := filepath.Join(t.TempDir(), "42-no-agent")
+	cmd := exec.Command("git", "-C", repo, "worktree", "add", wtPath, "-b", "42-no-agent")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	// No .agent file written — simulates a manually-created worktree.
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", repo, false); err != nil {
-t.Fatalf("runInfo: %v", err)
-}
-out := buf.String()
-if strings.Contains(out, "42-no-agent") {
-t.Errorf("worktree without .agent file should be skipped in info output; got:\n%s", out)
-}
-if !strings.Contains(out, "Active Worktrees: 0") {
-t.Errorf("expected 'Active Worktrees: 0' when all worktrees lack .agent; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", repo, false); err != nil {
+		t.Fatalf("runInfo: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "42-no-agent") {
+		t.Errorf("worktree without .agent file should be skipped in info output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Active Worktrees: 0") {
+		t.Errorf("expected 'Active Worktrees: 0' when all worktrees lack .agent; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_showsWorktreesWithAgentFile(t *testing.T) {
-repo := initGitRepoForInfo(t)
-wtPath := filepath.Join(t.TempDir(), "99-with-agent")
-cmd := exec.Command("git", "-C", repo, "worktree", "add", wtPath, "-b", "99-with-agent")
-if out, err := cmd.CombinedOutput(); err != nil {
-t.Fatalf("git worktree add: %v\n%s", err, out)
-}
-if err := state.Write(wtPath, state.AgentFile{Agent: "claude"}); err != nil {
-t.Fatal(err)
-}
+	repo := initGitRepoForInfo(t)
+	wtPath := filepath.Join(t.TempDir(), "99-with-agent")
+	cmd := exec.Command("git", "-C", repo, "worktree", "add", wtPath, "-b", "99-with-agent")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	if err := state.Write(wtPath, state.AgentFile{Agent: "claude"}); err != nil {
+		t.Fatal(err)
+	}
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", repo, false); err != nil {
-t.Fatalf("runInfo: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "99-with-agent") {
-t.Errorf("worktree with .agent file should appear in info output; got:\n%s", out)
-}
-if !strings.Contains(out, "Active Worktrees: 1") {
-t.Errorf("expected 'Active Worktrees: 1'; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", repo, false); err != nil {
+		t.Fatalf("runInfo: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "99-with-agent") {
+		t.Errorf("worktree with .agent file should appear in info output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Active Worktrees: 1") {
+		t.Errorf("expected 'Active Worktrees: 1'; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_mixedWorktrees_onlyManagedShown(t *testing.T) {
-repo := initGitRepoForInfo(t)
+	repo := initGitRepoForInfo(t)
 
-// Manual worktree without .agent file
-manualPath := filepath.Join(t.TempDir(), "manual-review")
-cmd := exec.Command("git", "-C", repo, "worktree", "add", manualPath, "-b", "manual-review")
-if out, err := cmd.CombinedOutput(); err != nil {
-t.Fatalf("git worktree add (manual): %v\n%s", err, out)
-}
+	// Manual worktree without .agent file
+	manualPath := filepath.Join(t.TempDir(), "manual-review")
+	cmd := exec.Command("git", "-C", repo, "worktree", "add", manualPath, "-b", "manual-review")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add (manual): %v\n%s", err, out)
+	}
 
-// Agentctl-managed worktree with .agent file
-managedPath := filepath.Join(t.TempDir(), "55-my-feature")
-cmd = exec.Command("git", "-C", repo, "worktree", "add", managedPath, "-b", "55-my-feature")
-if out, err := cmd.CombinedOutput(); err != nil {
-t.Fatalf("git worktree add (managed): %v\n%s", err, out)
-}
-if err := state.Write(managedPath, state.AgentFile{Agent: "claude"}); err != nil {
-t.Fatal(err)
-}
+	// Agentctl-managed worktree with .agent file
+	managedPath := filepath.Join(t.TempDir(), "55-my-feature")
+	cmd = exec.Command("git", "-C", repo, "worktree", "add", managedPath, "-b", "55-my-feature")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add (managed): %v\n%s", err, out)
+	}
+	if err := state.Write(managedPath, state.AgentFile{Agent: "claude"}); err != nil {
+		t.Fatal(err)
+	}
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", repo, false); err != nil {
-t.Fatalf("runInfo: %v", err)
-}
-out := buf.String()
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", repo, false); err != nil {
+		t.Fatalf("runInfo: %v", err)
+	}
+	out := buf.String()
 
-if strings.Contains(out, "manual-review") {
-t.Errorf("manual worktree (no .agent) should be skipped; got:\n%s", out)
-}
-if !strings.Contains(out, "55-my-feature") {
-t.Errorf("managed worktree should appear; got:\n%s", out)
-}
-if !strings.Contains(out, "Active Worktrees: 1") {
-t.Errorf("expected 'Active Worktrees: 1' (only managed ones counted); got:\n%s", out)
-}
+	if strings.Contains(out, "manual-review") {
+		t.Errorf("manual worktree (no .agent) should be skipped; got:\n%s", out)
+	}
+	if !strings.Contains(out, "55-my-feature") {
+		t.Errorf("managed worktree should appear; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Active Worktrees: 1") {
+		t.Errorf("expected 'Active Worktrees: 1' (only managed ones counted); got:\n%s", out)
+	}
 }
 
 func TestSystemOS_majorMinorExtracted(t *testing.T) {
-stubToolRunner(t, func(name string, args ...string) (string, error) {
-if name == "uname" {
-return "6.6.51-rt50", nil
-}
-return "", errors.New("not found")
-})
-got := systemOS()
-if !strings.Contains(got, "6.6") {
-t.Errorf("systemOS() = %q, want major.minor 6.6", got)
-}
-if strings.Contains(got, "51") {
-t.Errorf("systemOS() = %q, should not include patch/suffix 51", got)
-}
+	stubToolRunner(t, func(name string, args ...string) (string, error) {
+		if name == "uname" {
+			return "6.6.51-rt50", nil
+		}
+		return "", errors.New("not found")
+	})
+	got := systemOS()
+	if !strings.Contains(got, "6.6") {
+		t.Errorf("systemOS() = %q, want major.minor 6.6", got)
+	}
+	if strings.Contains(got, "51") {
+		t.Errorf("systemOS() = %q, should not include patch/suffix 51", got)
+	}
 }
 
 func TestSystemOS_noDot(t *testing.T) {
-stubToolRunner(t, func(name string, args ...string) (string, error) {
-if name == "uname" {
-return "5", nil
-}
-return "", errors.New("not found")
-})
-got := systemOS()
-// No dot: should fall back to raw uname output appended to GOOS
-if !strings.Contains(got, "5") {
-t.Errorf("systemOS() = %q, want raw kernel string '5'", got)
-}
+	stubToolRunner(t, func(name string, args ...string) (string, error) {
+		if name == "uname" {
+			return "5", nil
+		}
+		return "", errors.New("not found")
+	})
+	got := systemOS()
+	// No dot: should fall back to raw uname output appended to GOOS
+	if !strings.Contains(got, "5") {
+		t.Errorf("systemOS() = %q, want raw kernel string '5'", got)
+	}
 }
 
 func TestSystemOS_unameFails(t *testing.T) {
-stubToolRunner(t, func(name string, args ...string) (string, error) {
-return "", errors.New("uname not available")
-})
-got := systemOS()
-// Should fall back to GOOS alone (no spaces/extra tokens)
-if strings.Contains(got, " ") {
-t.Errorf("systemOS() = %q, expected GOOS-only (no space) when uname fails", got)
-}
+	stubToolRunner(t, func(name string, args ...string) (string, error) {
+		return "", errors.New("uname not available")
+	})
+	got := systemOS()
+	// Should fall back to GOOS alone (no spaces/extra tokens)
+	if strings.Contains(got, " ") {
+		t.Errorf("systemOS() = %q, expected GOOS-only (no space) when uname fails", got)
+	}
 }
 
 // ─── Global config section ────────────────────────────────────────────────────
 
 func TestRunInfo_globalConfigNoneWhenAbsent(t *testing.T) {
-tmp := t.TempDir()
-t.Setenv("XDG_CONFIG_HOME", tmp)
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", "", false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "Global config: none") {
-t.Errorf("expected 'Global config: none' when file absent; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Global config: none") {
+		t.Errorf("expected 'Global config: none' when file absent; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_globalConfigShownWhenPresent(t *testing.T) {
-tmp := t.TempDir()
-t.Setenv("XDG_CONFIG_HOME", tmp)
-globalDir := filepath.Join(tmp, "agentctl")
-if err := os.MkdirAll(globalDir, 0o755); err != nil {
-t.Fatalf("mkdir: %v", err)
-}
-if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("default_agent: codex\nnotify: true\n"), 0o644); err != nil {
-t.Fatalf("write: %v", err)
-}
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	globalDir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("default_agent: codex\nnotify: true\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", "", false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-if !strings.Contains(out, "Global config:") {
-t.Errorf("expected 'Global config:' header; got:\n%s", out)
-}
-if !strings.Contains(out, "default_agent: codex") {
-t.Errorf("expected 'default_agent: codex' in global config section; got:\n%s", out)
-}
-if !strings.Contains(out, "notify: true") {
-t.Errorf("expected 'notify: true' in global config section; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", "", false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Global config:") {
+		t.Errorf("expected 'Global config:' header; got:\n%s", out)
+	}
+	if !strings.Contains(out, "default_agent: codex") {
+		t.Errorf("expected 'default_agent: codex' in global config section; got:\n%s", out)
+	}
+	if !strings.Contains(out, "notify: true") {
+		t.Errorf("expected 'notify: true' in global config section; got:\n%s", out)
+	}
 }
 
 func TestRunInfo_globalConfigAboveProjectLocal(t *testing.T) {
-tmp := t.TempDir()
-t.Setenv("XDG_CONFIG_HOME", tmp)
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
 
-dir := t.TempDir()
-cfg := &config.AgentctlConfig{Editor: "cursor"}
-if err := config.Write(dir, cfg); err != nil {
-t.Fatalf("write config: %v", err)
-}
+	dir := t.TempDir()
+	cfg := &config.AgentctlConfig{Editor: "cursor"}
+	if err := config.Write(dir, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 
-var buf bytes.Buffer
-if err := runInfo(&buf, "dev", dir, false); err != nil {
-t.Fatalf("runInfo error: %v", err)
-}
-out := buf.String()
-// Both sections must appear; Global config must come before Configuration.
-globalIdx := strings.Index(out, "Global config:")
-configIdx := strings.Index(out, "Configuration:")
-if globalIdx < 0 {
-t.Errorf("expected 'Global config:' in output; got:\n%s", out)
-}
-if configIdx < 0 {
-t.Errorf("expected 'Configuration:' in output; got:\n%s", out)
-}
-if globalIdx > configIdx {
-t.Errorf("Global config section should appear before Configuration section; got:\n%s", out)
-}
+	var buf bytes.Buffer
+	if err := runInfo(&buf, "dev", dir, false); err != nil {
+		t.Fatalf("runInfo error: %v", err)
+	}
+	out := buf.String()
+	// Both sections must appear; Global config must come before Configuration.
+	globalIdx := strings.Index(out, "Global config:")
+	configIdx := strings.Index(out, "Configuration:")
+	if globalIdx < 0 {
+		t.Errorf("expected 'Global config:' in output; got:\n%s", out)
+	}
+	if configIdx < 0 {
+		t.Errorf("expected 'Configuration:' in output; got:\n%s", out)
+	}
+	if globalIdx > configIdx {
+		t.Errorf("Global config section should appear before Configuration section; got:\n%s", out)
+	}
 }

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -92,7 +92,7 @@ func resolveEditorForRepo(flagEditor, repoRoot string) (string, error) {
 	if flagEditor != "" {
 		return flagEditor, nil
 	}
-	cfg, err := config.Read(repoRoot)
+	cfg, err := config.ReadMerged(repoRoot)
 	if err != nil {
 		return "", fmt.Errorf("cannot read config: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,14 +95,23 @@ type GlobalConfig struct {
 // GlobalPath returns the path to the user-level global config file:
 // $XDG_CONFIG_HOME/agentctl/config.yml (or the OS default via xdg.UserConfigDir).
 func GlobalPath() string {
-	return filepath.Join(xdg.UserConfigDir(), "agentctl", "config.yml")
+	dir := xdg.UserConfigDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "agentctl", "config.yml")
 }
 
 // ReadGlobal loads the global config file at GlobalPath().
 // Returns an empty GlobalConfig (no error) when the file does not exist.
 // Returns an error if the file exists but contains invalid YAML.
 func ReadGlobal() (*GlobalConfig, error) {
-	data, err := os.ReadFile(GlobalPath())
+	path := GlobalPath()
+	if path == "" {
+		return &GlobalConfig{}, nil
+	}
+
+	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return &GlobalConfig{}, nil
 	}
@@ -119,6 +128,9 @@ func ReadGlobal() (*GlobalConfig, error) {
 // WriteGlobal serialises cfg to GlobalPath(), creating parent directories as needed.
 func WriteGlobal(cfg *GlobalConfig) error {
 	path := GlobalPath()
+	if path == "" {
+		return fmt.Errorf("global config path unavailable")
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,15 @@
-// Package config handles reading and writing the per-repo .agentctl.yml file.
+// Package config handles reading and writing the per-repo .agentctl.yml file
+// as well as the user-level global config at $XDG_CONFIG_HOME/agentctl/config.yml.
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/arun-gupta/agentctl/internal/xdg"
 )
 
 const Filename = ".agentctl.yml"
@@ -31,7 +35,9 @@ type AgentctlConfig struct {
 	// When true, agentctl fires an OS notification (macOS: osascript,
 	// Linux: notify-send) after each agent exits. Can also be enabled
 	// per-invocation with the --notify flag.
-	Notify bool `yaml:"notify,omitempty"`
+	// Uses *bool so that an explicit false in project-local config can
+	// override a global notify: true.
+	Notify *bool `yaml:"notify,omitempty"`
 
 	// MergeStrategy is the default merge strategy used by agentctl merge.
 	// Valid values: "squash" (default when empty), "merge", "rebase".
@@ -71,6 +77,113 @@ type DiagnosticsConfig struct {
 	// Enabled controls whether per-run diagnostics are written.
 	// Defaults to true when the field is absent.
 	Enabled *bool `yaml:"enabled,omitempty"`
+}
+
+// GlobalConfig holds only the user-wide settings that belong in the global
+// config file. Using a dedicated struct prevents accidentally reading or
+// writing repo-specific fields through the global path. A new field added to
+// AgentctlConfig is not silently included in global config without an explicit
+// decision here.
+type GlobalConfig struct {
+	DefaultAgent  string            `yaml:"default_agent,omitempty"`
+	Notify        *bool             `yaml:"notify,omitempty"`
+	MergeStrategy string            `yaml:"merge_strategy,omitempty"`
+	Editor        string            `yaml:"editor,omitempty"`
+	Diagnostics   DiagnosticsConfig `yaml:"diagnostics,omitempty"`
+}
+
+// GlobalPath returns the path to the user-level global config file:
+// $XDG_CONFIG_HOME/agentctl/config.yml (or the OS default via xdg.UserConfigDir).
+func GlobalPath() string {
+	return filepath.Join(xdg.UserConfigDir(), "agentctl", "config.yml")
+}
+
+// ReadGlobal loads the global config file at GlobalPath().
+// Returns an empty GlobalConfig (no error) when the file does not exist.
+// Returns an error if the file exists but contains invalid YAML.
+func ReadGlobal() (*GlobalConfig, error) {
+	data, err := os.ReadFile(GlobalPath())
+	if os.IsNotExist(err) {
+		return &GlobalConfig{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var cfg GlobalConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// WriteGlobal serialises cfg to GlobalPath(), creating parent directories as needed.
+func WriteGlobal(cfg *GlobalConfig) error {
+	path := GlobalPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// ReadMerged returns the effective config by merging the global config and the
+// project-local .agentctl.yml. Project-local values win on any non-zero field;
+// the global config fills in the rest. Repo-specific fields (dev_server,
+// test_cmd, build_cmd, vcs) are only read from the project-local file.
+//
+// Error behaviour: a missing global config is silently skipped. If the global
+// config file exists but is malformed, ReadMerged returns an error.
+func ReadMerged(dir string) (*AgentctlConfig, error) {
+	global, err := ReadGlobal()
+	if err != nil {
+		return nil, fmt.Errorf("global config: %w", err)
+	}
+
+	local, err := Read(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AgentctlConfig{
+		// Global-eligible fields: project-local wins on non-zero value.
+		DefaultAgent:  mergeString(local.DefaultAgent, global.DefaultAgent),
+		Notify:        mergeBoolPtr(local.Notify, global.Notify),
+		MergeStrategy: mergeString(local.MergeStrategy, global.MergeStrategy),
+		Editor:        mergeString(local.Editor, global.Editor),
+		Diagnostics:   mergeDiagnostics(local.Diagnostics, global.Diagnostics),
+
+		// Repo-specific fields: always from project-local only.
+		DevServer: local.DevServer,
+		TestCmd:   local.TestCmd,
+		BuildCmd:  local.BuildCmd,
+		VCS:       local.VCS,
+	}, nil
+}
+
+// mergeString returns local if non-empty, otherwise global.
+func mergeString(local, global string) string {
+	if local != "" {
+		return local
+	}
+	return global
+}
+
+// mergeBoolPtr returns local if non-nil, otherwise global.
+func mergeBoolPtr(local, global *bool) *bool {
+	if local != nil {
+		return local
+	}
+	return global
+}
+
+// mergeDiagnostics merges two DiagnosticsConfig values: local wins for non-nil fields.
+func mergeDiagnostics(local, global DiagnosticsConfig) DiagnosticsConfig {
+	return DiagnosticsConfig{
+		Enabled: mergeBoolPtr(local.Enabled, global.Enabled),
+	}
 }
 
 // Read loads .agentctl.yml from dir. If the file does not exist, an empty

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -271,7 +271,7 @@ func TestGlobalPath_usesXDGConfigHome(t *testing.T) {
 	}
 }
 
-func TestGlobalPath_emptyWhenUserConfigDirUnavailable(t *testing.T) {
+func TestGlobalPath_EmptyWhenUserConfigDirUnavailable(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", "")
 	if runtime.GOOS == "windows" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,13 +8,15 @@ import (
 	"github.com/arun-gupta/agentctl/internal/config"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 func TestRead_missingFile_returnsEmpty(t *testing.T) {
 	dir := t.TempDir()
 	cfg, err := config.Read(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.DevServer != "" || cfg.Notify {
+	if cfg.DevServer != "" || cfg.Notify != nil {
 		t.Errorf("expected empty config for missing file, got %+v", cfg)
 	}
 }
@@ -79,8 +81,8 @@ func TestRead_parsesNotify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !cfg.Notify {
-		t.Errorf("Notify = false, want true")
+	if cfg.Notify == nil || !*cfg.Notify {
+		t.Errorf("Notify = %v, want true", cfg.Notify)
 	}
 }
 
@@ -93,8 +95,8 @@ func TestRead_notifyDefaultsFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Notify {
-		t.Errorf("Notify = true, want false (default)")
+	if cfg.Notify != nil {
+		t.Errorf("Notify = %v, want nil (not set)", *cfg.Notify)
 	}
 }
 
@@ -253,5 +255,298 @@ func TestWrite_preservesVCS(t *testing.T) {
 	}
 	if got.VCS.Server != "https://gitlab.company.com" {
 		t.Errorf("VCS.Server = %q, want %q", got.VCS.Server, "https://gitlab.company.com")
+	}
+}
+
+// ─── GlobalPath ───────────────────────────────────────────────────────────────
+
+func TestGlobalPath_usesXDGConfigHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	got := config.GlobalPath()
+	want := filepath.Join(tmp, "agentctl", "config.yml")
+	if got != want {
+		t.Errorf("GlobalPath() = %q, want %q", got, want)
+	}
+}
+
+// ─── ReadGlobal ───────────────────────────────────────────────────────────────
+
+func TestReadGlobal_absentFile_returnsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	cfg, err := config.ReadGlobal()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DefaultAgent != "" || cfg.Notify != nil || cfg.MergeStrategy != "" || cfg.Editor != "" {
+		t.Errorf("expected empty GlobalConfig for absent file, got %+v", cfg)
+	}
+}
+
+func TestReadGlobal_parsesFields(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	dir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "default_agent: codex\nnotify: true\nmerge_strategy: squash\neditor: cursor\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ReadGlobal()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DefaultAgent != "codex" {
+		t.Errorf("DefaultAgent = %q, want %q", cfg.DefaultAgent, "codex")
+	}
+	if cfg.Notify == nil || !*cfg.Notify {
+		t.Errorf("Notify = %v, want true", cfg.Notify)
+	}
+	if cfg.MergeStrategy != "squash" {
+		t.Errorf("MergeStrategy = %q, want %q", cfg.MergeStrategy, "squash")
+	}
+	if cfg.Editor != "cursor" {
+		t.Errorf("Editor = %q, want %q", cfg.Editor, "cursor")
+	}
+}
+
+func TestReadGlobal_malformedFile_returnsError(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	dir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(":\tinvalid:\tyaml\t:\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := config.ReadGlobal()
+	if err == nil {
+		t.Error("expected error for malformed global config, got nil")
+	}
+}
+
+// ─── WriteGlobal ──────────────────────────────────────────────────────────────
+
+func TestWriteGlobal_roundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	in := &config.GlobalConfig{
+		DefaultAgent:  "codex",
+		Notify:        boolPtr(true),
+		MergeStrategy: "rebase",
+		Editor:        "code",
+	}
+	if err := config.WriteGlobal(in); err != nil {
+		t.Fatalf("WriteGlobal error: %v", err)
+	}
+	got, err := config.ReadGlobal()
+	if err != nil {
+		t.Fatalf("ReadGlobal error: %v", err)
+	}
+	if got.DefaultAgent != "codex" {
+		t.Errorf("DefaultAgent = %q, want %q", got.DefaultAgent, "codex")
+	}
+	if got.Notify == nil || !*got.Notify {
+		t.Errorf("Notify = %v, want true", got.Notify)
+	}
+	if got.MergeStrategy != "rebase" {
+		t.Errorf("MergeStrategy = %q, want %q", got.MergeStrategy, "rebase")
+	}
+	if got.Editor != "code" {
+		t.Errorf("Editor = %q, want %q", got.Editor, "code")
+	}
+}
+
+func TestWriteGlobal_createsParentDirs(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	// Parent dir does not exist yet — WriteGlobal must create it.
+	in := &config.GlobalConfig{DefaultAgent: "gemini"}
+	if err := config.WriteGlobal(in); err != nil {
+		t.Fatalf("WriteGlobal error: %v", err)
+	}
+	if _, err := os.Stat(config.GlobalPath()); err != nil {
+		t.Errorf("global config file not created: %v", err)
+	}
+}
+
+// ─── ReadMerged ───────────────────────────────────────────────────────────────
+
+func TestReadMerged_noFiles_returnsDefaults(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	cfg, err := config.ReadMerged(tmp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DefaultAgent != "" || cfg.MergeStrategy != "" || cfg.Editor != "" {
+		t.Errorf("expected zero values for missing files, got %+v", cfg)
+	}
+}
+
+func TestReadMerged_globalOnly_returnsGlobalValues(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	globalDir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("default_agent: codex\nmerge_strategy: squash\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := t.TempDir()
+	cfg, err := config.ReadMerged(projectDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DefaultAgent != "codex" {
+		t.Errorf("DefaultAgent = %q, want %q", cfg.DefaultAgent, "codex")
+	}
+	if cfg.MergeStrategy != "squash" {
+		t.Errorf("MergeStrategy = %q, want %q", cfg.MergeStrategy, "squash")
+	}
+}
+
+func TestReadMerged_projectLocalOnly_returnsLocalValues(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".agentctl.yml"), []byte("default_agent: gemini\nmerge_strategy: rebase\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ReadMerged(projectDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DefaultAgent != "gemini" {
+		t.Errorf("DefaultAgent = %q, want %q", cfg.DefaultAgent, "gemini")
+	}
+	if cfg.MergeStrategy != "rebase" {
+		t.Errorf("MergeStrategy = %q, want %q", cfg.MergeStrategy, "rebase")
+	}
+}
+
+func TestReadMerged_projectLocalWinsOnNonZeroField(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	globalDir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("default_agent: codex\nmerge_strategy: squash\neditor: vim\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".agentctl.yml"), []byte("default_agent: gemini\neditor: cursor\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ReadMerged(projectDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DefaultAgent != "gemini" {
+		t.Errorf("DefaultAgent = %q, want %q (project-local should win)", cfg.DefaultAgent, "gemini")
+	}
+	if cfg.Editor != "cursor" {
+		t.Errorf("Editor = %q, want %q (project-local should win)", cfg.Editor, "cursor")
+	}
+	// Global fills gaps where project-local is empty.
+	if cfg.MergeStrategy != "squash" {
+		t.Errorf("MergeStrategy = %q, want %q (global fills gap)", cfg.MergeStrategy, "squash")
+	}
+}
+
+func TestReadMerged_globalFillsGaps(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	globalDir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("default_agent: codex\nmerge_strategy: squash\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".agentctl.yml"), []byte("dev_server: \"npm run dev\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ReadMerged(projectDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Project-local field preserved.
+	if cfg.DevServer != "npm run dev" {
+		t.Errorf("DevServer = %q, want %q", cfg.DevServer, "npm run dev")
+	}
+	// Global fills missing fields.
+	if cfg.DefaultAgent != "codex" {
+		t.Errorf("DefaultAgent = %q, want %q (global fills gap)", cfg.DefaultAgent, "codex")
+	}
+	if cfg.MergeStrategy != "squash" {
+		t.Errorf("MergeStrategy = %q, want %q (global fills gap)", cfg.MergeStrategy, "squash")
+	}
+}
+
+func TestReadMerged_malformedGlobal_returnsError(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	globalDir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte(":\tinvalid:\tyaml\t:\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := t.TempDir()
+	_, err := config.ReadMerged(projectDir)
+	if err == nil {
+		t.Error("expected error for malformed global config, got nil")
+	}
+}
+
+func TestReadMerged_notifyGlobalTrue_absentInLocal_effectiveTrue(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	globalDir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("notify: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := t.TempDir()
+	cfg, err := config.ReadMerged(projectDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Notify == nil || !*cfg.Notify {
+		t.Errorf("Notify = %v, want true (global fills gap)", cfg.Notify)
+	}
+}
+
+func TestReadMerged_notifyFalseInLocal_overridesGlobalTrue(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	globalDir := filepath.Join(tmp, "agentctl")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yml"), []byte("notify: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".agentctl.yml"), []byte("notify: false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ReadMerged(projectDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Notify == nil || *cfg.Notify {
+		t.Errorf("Notify = %v, want false (project-local explicit false overrides global true)", cfg.Notify)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/arun-gupta/agentctl/internal/config"
@@ -267,6 +268,21 @@ func TestGlobalPath_usesXDGConfigHome(t *testing.T) {
 	want := filepath.Join(tmp, "agentctl", "config.yml")
 	if got != want {
 		t.Errorf("GlobalPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGlobalPath_emptyWhenUserConfigDirUnavailable(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", "")
+		t.Setenv("LOCALAPPDATA", "")
+		t.Setenv("USERPROFILE", "")
+	}
+
+	got := config.GlobalPath()
+	if got != "" {
+		t.Skipf("unable to force empty user config dir on this platform/env, got %q", got)
 	}
 }
 

--- a/internal/vcs/detect.go
+++ b/internal/vcs/detect.go
@@ -20,7 +20,7 @@ import (
 // for backward compatibility with local-only repos.
 func Detect(repoRoot string) (Provider, error) {
 	// Config file override takes priority.
-	if cfg, err := config.Read(repoRoot); err == nil && cfg.VCS.Provider != "" {
+	if cfg, err := config.ReadMerged(repoRoot); err == nil && cfg.VCS.Provider != "" {
 		switch strings.ToLower(cfg.VCS.Provider) {
 		case "github":
 			return githubProvider{server: cfg.VCS.Server}, nil


### PR DESCRIPTION
## Summary

Closes #287.

- Adds `~/.config/agentctl/config.yml` (respecting `$XDG_CONFIG_HOME`) as a user-level config for personal defaults (`default_agent`, `notify`, `merge_strategy`, `editor`, `diagnostics`)
- Project-local `.agentctl.yml` continues to take full precedence for any field it sets; global config fills gaps
- Changes `AgentctlConfig.Notify` from `bool` to `*bool` so an explicit `notify: false` in project-local config can override a global `notify: true`
- Replaces `config.Read` → `config.ReadMerged` at all effective-config call sites; write-path and unit-test call sites intentionally keep `config.Read`
- `agentctl info` now shows a **Global config** section above the project-local Configuration section (shows `none` when the file is absent)

### Config resolution chain

```
CLI flags  >  project-local .agentctl.yml  >  global config.yml  >  built-in defaults
```

## Test plan

### Automated

```
go test ./...
```

All 12 packages pass:

```
ok  github.com/arun-gupta/agentctl/cmd/agentctl
ok  github.com/arun-gupta/agentctl/internal/adapters
ok  github.com/arun-gupta/agentctl/internal/cmd
ok  github.com/arun-gupta/agentctl/internal/config
ok  github.com/arun-gupta/agentctl/internal/diagnostics
ok  github.com/arun-gupta/agentctl/internal/git
ok  github.com/arun-gupta/agentctl/internal/notify
ok  github.com/arun-gupta/agentctl/internal/process
ok  github.com/arun-gupta/agentctl/internal/sdd
ok  github.com/arun-gupta/agentctl/internal/state
ok  github.com/arun-gupta/agentctl/internal/vcs
?   github.com/arun-gupta/agentctl/internal/xdg  [no test files]
```

New tests cover: `GlobalPath`, `ReadGlobal` (absent/present/malformed), `WriteGlobal` (round-trip, parent-dir creation), `ReadMerged` (no files, global-only, local-only, local-wins, global-fills-gaps, malformed-global, notify pointer semantics), and `agentctl info` Global config section (none/present/ordering).

### Manual

- **Global config file absent**: run `agentctl info` with no `~/.config/agentctl/config.yml` present → output shows `Global config: none` — automation cannot guarantee the file is absent on the test runner's real home directory
- **`agentctl start` picks up global `default_agent`**: create `~/.config/agentctl/config.yml` with `default_agent: codex`, run `agentctl start` without `--agent` in a repo with no `.agentctl.yml` → agent should be `codex` — requires a live repo + agent binary, not automatable in unit tests
- **Project-local `notify: false` overrides global `notify: true`**: set global `notify: true`, add `notify: false` to `.agentctl.yml`, run a headless agent → no notification should fire — requires OS notification system, not automatable
- **`XDG_CONFIG_HOME` override respected**: set `XDG_CONFIG_HOME=/tmp/myconfig`, create `/tmp/myconfig/agentctl/config.yml` → `agentctl info` picks it up — environment-level integration, sufficient to verify manually once

🤖 Generated with [Claude Code](https://claude.com/claude-code)