### PR TITLE
feat: add DefaultSDD config field with SDDNone sentinel

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -317,6 +317,15 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 		}
 	}
 
+	// Resolve default SDD from config when --sdd was not passed.
+	// config.SDDNone ("none") means explicitly no SDD, so we leave sddName "".
+	if sddName == "" {
+		if cfg, cfgErr := config.ReadMerged(repoRoot); cfgErr == nil &&
+			cfg.DefaultSDD != "" && cfg.DefaultSDD != config.SDDNone {
+			sddName = cfg.DefaultSDD
+		}
+	}
+
 	// Validate methodology-specific prerequisites before any side effects.
 	if err := validateSDD(sddName, repoRoot); err != nil {
 		return err
@@ -454,6 +463,15 @@ func startTask(task, branch, agentName, sddName string, headless, quiet, sendNot
 	if !sendNotify {
 		if cfg, cfgErr := config.ReadMerged(repoRoot); cfgErr == nil && cfg.Notify != nil && *cfg.Notify {
 			sendNotify = true
+		}
+	}
+
+	// Resolve default SDD from config when --sdd was not passed.
+	// config.SDDNone ("none") means explicitly no SDD, so we leave sddName "".
+	if sddName == "" {
+		if cfg, cfgErr := config.ReadMerged(repoRoot); cfgErr == nil &&
+			cfg.DefaultSDD != "" && cfg.DefaultSDD != config.SDDNone {
+			sddName = cfg.DefaultSDD
 		}
 	}
 

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -6293,3 +6293,80 @@ func TestRunStatus_showsWorktreesWithAgentFile(t *testing.T) {
 		t.Errorf("worktree with .agent file should appear; got:\n%s", buf.String())
 	}
 }
+
+// TestStartTask_defaultSDD_speckit_fromConfig verifies that when default_sdd is
+// "speckit" in .agentctl.yml, startTask resolves it from config and fails with
+// the speckit-not-found error (skill files are absent in the temp repo).
+func TestStartTask_defaultSDD_speckit_fromConfig(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	writeLocalAdapter(t, repo, "echoagent", "binary: echo\nsession: --session\n")
+	chdirTemp(t, repo)
+
+	if err := os.WriteFile(filepath.Join(repo, ".agentctl.yml"), []byte("default_sdd: speckit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := startTask("add OAuth flow", "", "echoagent", "", true, false, false, io.Discard)
+	if err == nil {
+		t.Fatal("expected error for missing speckit skills")
+	}
+	if !strings.Contains(err.Error(), "SpecKit skills not found") {
+		t.Fatalf("expected speckit-not-found error, got: %v", err)
+	}
+}
+
+// TestStartTask_defaultSDD_none_skips_sdd verifies that default_sdd: none in
+// .agentctl.yml leaves sddName empty — no SDD is applied even though the global
+// config could have set one.
+func TestStartTask_defaultSDD_none_skips_sdd(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	writeLocalAdapter(t, repo, "echoagent", "binary: echo\nsession: --session\n")
+	chdirTemp(t, repo)
+
+	if err := os.WriteFile(filepath.Join(repo, ".agentctl.yml"), []byte("default_sdd: none\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	task := "sdd-none sentinel test for agentctl default sdd"
+	wantBranch := "task/sdd-none-sentinel-test-for-agentctl"
+	wantWorktree := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-task-sdd-none-sentinel-test-for-agentctl")
+
+	var out bytes.Buffer
+	if err := startTask(task, "", "echoagent", "", true, false, false, &out); err != nil {
+		t.Fatalf("startTask: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = git.RemoveWorktree(repo, wantWorktree)
+		_ = git.DeleteLocalBranch(repo, wantBranch)
+	})
+
+	af, err := state.Read(wantWorktree)
+	if err != nil {
+		t.Fatalf("state.Read: %v", err)
+	}
+	if af.SDD != "" {
+		t.Fatalf("SDD = %q, want empty (SDDNone sentinel should suppress SDD)", af.SDD)
+	}
+}
+
+// TestStartOne_defaultSDD_speckit_fromConfig verifies that startOne resolves
+// default_sdd from config when --sdd is not passed, failing with the
+// speckit-not-found error when skill files are absent.
+func TestStartOne_defaultSDD_speckit_fromConfig(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	writeLocalAdapter(t, repo, "echoagent", "binary: echo\nsession: --session\n")
+	chdirTemp(t, repo)
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	if err := os.WriteFile(filepath.Join(repo, ".agentctl.yml"), []byte("default_sdd: speckit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := startOne("42", "my-slug", "echoagent", "", "", true, false, false, io.Discard)
+	if err == nil {
+		t.Fatal("expected error for missing speckit skills")
+	}
+	if !strings.Contains(err.Error(), "SpecKit skills not found") {
+		t.Fatalf("expected speckit-not-found error, got: %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,11 @@ import (
 
 const Filename = ".agentctl.yml"
 
+// SDDNone is the sentinel value for explicitly disabling SDD as the default.
+// It is distinct from the empty string ("not set") so that a project-local
+// default_sdd: none can override a global default_sdd: speckit.
+const SDDNone = "none"
+
 // VCSConfig holds optional VCS provider overrides. Useful for self-hosted
 // GitLab instances where the origin URL does not contain "gitlab.com".
 type VCSConfig struct {
@@ -59,6 +64,12 @@ type AgentctlConfig struct {
 	// Overridden per-invocation by the --agent flag.
 	DefaultAgent string `yaml:"default_agent,omitempty"`
 
+	// DefaultSDD sets the default SDD methodology for agentctl start when
+	// --sdd is not passed. Valid values: "plain", "speckit", a custom name,
+	// or the sentinel "none" (config.SDDNone) to explicitly disable SDD.
+	// Empty string means "not set" and falls through to the built-in default (no SDD).
+	DefaultSDD string `yaml:"default_sdd,omitempty"`
+
 	// BuildCmd is the command used by agentctl build to compile the project.
 	// Use {output} as a placeholder for the output binary path.
 	// Example: "go build -o {output} ./cmd/myapp"
@@ -86,6 +97,7 @@ type DiagnosticsConfig struct {
 // decision here.
 type GlobalConfig struct {
 	DefaultAgent  string            `yaml:"default_agent,omitempty"`
+	DefaultSDD    string            `yaml:"default_sdd,omitempty"`
 	Notify        *bool             `yaml:"notify,omitempty"`
 	MergeStrategy string            `yaml:"merge_strategy,omitempty"`
 	Editor        string            `yaml:"editor,omitempty"`
@@ -162,6 +174,7 @@ func ReadMerged(dir string) (*AgentctlConfig, error) {
 	return &AgentctlConfig{
 		// Global-eligible fields: project-local wins on non-zero value.
 		DefaultAgent:  mergeString(local.DefaultAgent, global.DefaultAgent),
+		DefaultSDD:    mergeString(local.DefaultSDD, global.DefaultSDD),
 		Notify:        mergeBoolPtr(local.Notify, global.Notify),
 		MergeStrategy: mergeString(local.MergeStrategy, global.MergeStrategy),
 		Editor:        mergeString(local.Editor, global.Editor),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -566,3 +566,83 @@ func TestReadMerged_notifyFalseInLocal_overridesGlobalTrue(t *testing.T) {
 		t.Errorf("Notify = %v, want false (project-local explicit false overrides global true)", cfg.Notify)
 	}
 }
+
+func TestGlobalConfig_defaultSDD_roundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	in := &config.GlobalConfig{DefaultSDD: "speckit"}
+	if err := config.WriteGlobal(in); err != nil {
+		t.Fatalf("WriteGlobal: %v", err)
+	}
+	out, err := config.ReadGlobal()
+	if err != nil {
+		t.Fatalf("ReadGlobal: %v", err)
+	}
+	if out.DefaultSDD != "speckit" {
+		t.Errorf("DefaultSDD = %q, want %q", out.DefaultSDD, "speckit")
+	}
+}
+
+func TestGlobalConfig_defaultSDD_noneConstant(t *testing.T) {
+	if config.SDDNone != "none" {
+		t.Errorf("SDDNone = %q, want %q", config.SDDNone, "none")
+	}
+}
+
+func TestReadMerged_defaultSDD_globalFillsIn(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	if err := config.WriteGlobal(&config.GlobalConfig{DefaultSDD: "plain"}); err != nil {
+		t.Fatalf("WriteGlobal: %v", err)
+	}
+	projectDir := t.TempDir()
+	cfg, err := config.ReadMerged(projectDir)
+	if err != nil {
+		t.Fatalf("ReadMerged: %v", err)
+	}
+	if cfg.DefaultSDD != "plain" {
+		t.Errorf("DefaultSDD = %q, want %q", cfg.DefaultSDD, "plain")
+	}
+}
+
+func TestReadMerged_defaultSDD_projectLocalWins(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	if err := config.WriteGlobal(&config.GlobalConfig{DefaultSDD: "plain"}); err != nil {
+		t.Fatalf("WriteGlobal: %v", err)
+	}
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".agentctl.yml"), []byte("default_sdd: speckit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ReadMerged(projectDir)
+	if err != nil {
+		t.Fatalf("ReadMerged: %v", err)
+	}
+	if cfg.DefaultSDD != "speckit" {
+		t.Errorf("DefaultSDD = %q, want project-local %q", cfg.DefaultSDD, "speckit")
+	}
+}
+
+func TestReadMerged_defaultSDD_noneOverridesGlobal(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	if err := config.WriteGlobal(&config.GlobalConfig{DefaultSDD: "speckit"}); err != nil {
+		t.Fatalf("WriteGlobal: %v", err)
+	}
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, ".agentctl.yml"), []byte("default_sdd: none\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.ReadMerged(projectDir)
+	if err != nil {
+		t.Fatalf("ReadMerged: %v", err)
+	}
+	if cfg.DefaultSDD != config.SDDNone {
+		t.Errorf("DefaultSDD = %q, want %q (project-local none overrides global)", cfg.DefaultSDD, config.SDDNone)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `default_sdd` field to both `AgentctlConfig` (`.agentctl.yml`) and `GlobalConfig` (`~/.config/agentctl/config.yml`) so users can set a preferred SDD methodology once instead of passing `--sdd` on every `agentctl start` call
- Exports `config.SDDNone = "none"` as a sentinel value — setting `default_sdd: none` in a project config explicitly disables SDD even when the global config has a default (distinguishes "disabled" from "not set")
- `startOne` and `startTask` both read the merged config and resolve the effective SDD when `--sdd` is not passed on the command line

## Closes

Partial implementation toward #264 (setup wizard); prerequisite config layer for the `agentctl config` command in #287.

## Test plan

- [x] `go test ./internal/config/ ./internal/cmd/` passes — includes 5 new config-layer tests and 3 new command-layer tests
- [x] `TestGlobalConfig_defaultSDD_roundTrip` — write/read `GlobalConfig.DefaultSDD`
- [x] `TestGlobalConfig_defaultSDD_noneConstant` — `SDDNone == "none"`
- [x] `TestReadMerged_defaultSDD_globalFillsIn` — global fills empty project-local
- [x] `TestReadMerged_defaultSDD_projectLocalWins` — project-local overrides global
- [x] `TestReadMerged_defaultSDD_noneOverridesGlobal` — `"none"` in project-local beats global `"speckit"`
- [x] `TestStartTask_defaultSDD_speckit_fromConfig` — `startTask` with `default_sdd: speckit` fails with speckit-not-found (proving resolution from config)
- [x] `TestStartTask_defaultSDD_none_skips_sdd` — `default_sdd: none` leaves `af.SDD` empty
- [x] `TestStartOne_defaultSDD_speckit_fromConfig` — same resolution verified for `startOne` path
- [x] Manual: add `default_sdd: plain` to `.agentctl.yml`, run `agentctl start <issue>` without `--sdd`, confirm plain SDD is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)