### PR TITLE
test: add e2e smoke test for agentctl setup cobra wiring

### DIFF
--- a/cmd/agentctl/main_test.go
+++ b/cmd/agentctl/main_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 // TestRootCmdSilenceErrors verifies that the root command suppresses cobra's
 // built-in error printing so errors are not echoed twice (once by cobra, once
@@ -22,5 +27,35 @@ func TestRootCmd_registersInfoCommandOnce(t *testing.T) {
 	}
 	if infoCount != 1 {
 		t.Fatalf("expected exactly one info command registration, got %d", infoCount)
+	}
+}
+
+// TestSetupCmd_e2e verifies that "agentctl setup" is wired correctly end-to-end:
+// the command is reachable via the root, accepts stdin, writes the global config
+// file to the real path under XDG_CONFIG_HOME, and exits without error.
+func TestSetupCmd_e2e(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	root := newRootCmd()
+	// Pipe empty input so all prompts fall through to defaults.
+	root.SetIn(strings.NewReader("\n\n\n"))
+
+	root.SetArgs([]string{"setup"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("agentctl setup: %v", err)
+	}
+
+	cfgPath := filepath.Join(tmp, "agentctl", "config.yml")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("global config not written at %s: %v", cfgPath, err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "default_agent") {
+		t.Errorf("config missing default_agent field:\n%s", content)
+	}
+	if !strings.Contains(content, "notify") {
+		t.Errorf("config missing notify field:\n%s", content)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `TestSetupCmd_e2e` in `cmd/agentctl/main_test.go` — exercises the full cobra path via `newRootCmd()` rather than calling `runSetup` directly
- Pipes empty stdin so all prompts fall through to defaults
- Asserts the global config file is written at `$XDG_CONFIG_HOME/agentctl/config.yml` with `default_agent` and `notify` fields
- Complements the 24 unit tests in `setup_test.go` which stub `writeGlobalFn` and don't exercise the cobra wiring or real write path

## Test plan

- [x] `go test ./...` passes
- [x] `TestSetupCmd_e2e` writes config file and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)