### PR TITLE
feat: global status across all repos and worktrees (#192)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -255,6 +255,7 @@ Side effects:
 ```bash
 agentctl agent status
 agentctl agent status --verbose
+agentctl agent status --global
 agentctl agent list
 ```
 
@@ -272,7 +273,21 @@ Verbose columns:
 ISSUE  BRANCH  AGENT  PATH  PORT  DEV-PID  AGENT-PID  SPEC  PR  SESSION
 ```
 
-Spec states:
+**Global mode** (`--global` / `-g`): shows worktrees across all repositories from the cross-repo registry at `~/.config/agentctl/worktrees.json`. Each entry's state is re-verified at display time.
+
+Global columns:
+
+```text
+REPO  ISSUE  BRANCH  AGENT  STATE
+```
+
+Global states:
+
+- `running`: agent process is still alive.
+- `done`: worktree exists but no live agent process.
+- `stale`: worktree directory no longer exists on disk.
+
+Spec states (default/verbose mode):
 
 - `no-spec`: no spec found for the issue.
 - `paused`: `spec.md` exists, but no `plan.md` or `tasks.md`.
@@ -433,6 +448,7 @@ Error cases:
 ```bash
 agentctl worktree cleanup [issue-number-or-url]
 agentctl worktree cleanup --all
+agentctl worktree cleanup --global --stale
 ```
 
 Cleans up a worktree after its PR is merged.
@@ -448,6 +464,8 @@ Behavior:
 - Deletes local and remote branches.
 
 Use `--all` to scan all linked worktrees and run the cleanup flow for every branch whose PR state is `MERGED`. Also prunes orphaned remote branches (branches with no local worktree whose PR is MERGED or CLOSED). Branches without PRs, unmerged PRs, detached worktrees, or branches without a numeric issue prefix are skipped.
+
+Use `--global --stale` to prune entries from the cross-repo registry (`~/.config/agentctl/worktrees.json`) whose worktree directories no longer exist on disk. This does not affect local branches or PRs — it only tidies the registry used by `agentctl status --global`.
 
 If the PR is not merged, use `agentctl worktree discard` for abandoned work.
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -31,6 +31,7 @@ import (
 	"github.com/arun-gupta/agentctl/internal/git"
 	"github.com/arun-gupta/agentctl/internal/notify"
 	"github.com/arun-gupta/agentctl/internal/process"
+	"github.com/arun-gupta/agentctl/internal/registry"
 	"github.com/arun-gupta/agentctl/internal/sdd"
 	"github.com/arun-gupta/agentctl/internal/state"
 	"github.com/arun-gupta/agentctl/internal/vcs"
@@ -432,6 +433,11 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 		return err
 	}
 
+	// Register in the cross-repo registry so `agentctl status --global` can find it.
+	if regErr := registry.AddWithWorktree(repoRoot, wtPath, issueNum, branch, agentName); regErr != nil {
+		fmt.Fprintf(out, "warning: could not register worktree in global registry: %v\n", regErr)
+	}
+
 	cleanupOnError = false
 	return nil
 }
@@ -561,6 +567,11 @@ func startTask(task, branch, agentName, sddName string, headless, quiet, sendNot
 			return fmt.Errorf("%w\ncleanup warning: %v", err, cleanupErr)
 		}
 		return err
+	}
+
+	// Register in the cross-repo registry so `agentctl status --global` can find it.
+	if regErr := registry.AddWithWorktree(repoRoot, wtPath, "", branch, agentName); regErr != nil {
+		fmt.Fprintf(out, "warning: could not register worktree in global registry: %v\n", regErr)
 	}
 
 	cleanupOnError = false
@@ -974,6 +985,12 @@ func runDiscardStale() error {
 			}
 		}
 
+		if branch != "" {
+			if regErr := registry.Remove(repoRoot, branch); regErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not remove worktree from global registry: %v\n", regErr)
+			}
+		}
+
 		return nil
 	}
 
@@ -1064,6 +1081,12 @@ func runRemoveWorktree(issue, agentSuffix string) error {
 		if err := removeBranchRefs(repoRoot, branch); err != nil {
 			fmt.Fprintf(os.Stderr, "WARNING: could not delete remote branch %s\n", branch)
 			fmt.Fprintf(os.Stderr, "Delete the remote manually with:\n  git push origin --delete %s\n", branch)
+		}
+	}
+
+	if branch != "" {
+		if regErr := registry.Remove(repoRoot, branch); regErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not remove worktree from global registry: %v\n", regErr)
 		}
 	}
 
@@ -1229,6 +1252,8 @@ func runMerge(issue, strategy, agentSuffix string, noDelete, dryRun bool) error 
 // With --all it sweeps all merged worktrees; otherwise it cleans up one or more issues.
 func NewCleanupCmd() *cobra.Command {
 	var all bool
+	var global bool
+	var stale bool
 	var agentSuffix string
 	c := &cobra.Command{
 		Use:   "cleanup [issue[,issue...]]...",
@@ -1243,9 +1268,21 @@ Multiple issues may be given as a comma-separated list or as separate
 arguments (e.g. "agentctl cleanup 240,277" or "agentctl cleanup 240 277").
 Each issue is cleaned up in sequence; all failures are reported at the end.
 
-Use --all to sweep every linked worktree whose PR is MERGED in one pass.`,
+Use --all to sweep every linked worktree whose PR is MERGED in one pass.
+
+Use --global --stale to prune entries from the cross-repo registry whose
+worktree directories no longer exist on disk.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if global {
+				if !stale {
+					return fmt.Errorf("--global requires --stale; use: agentctl cleanup --global --stale")
+				}
+				if len(args) > 0 {
+					return fmt.Errorf("--global and issue arguments are mutually exclusive")
+				}
+				return runCleanupGlobalStale()
+			}
 			if all {
 				if len(args) > 0 {
 					return fmt.Errorf("--all and issue arguments are mutually exclusive")
@@ -1281,8 +1318,28 @@ Use --all to sweep every linked worktree whose PR is MERGED in one pass.`,
 		},
 	}
 	c.Flags().BoolVar(&all, "all", false, "Clean up all worktrees whose PR is MERGED")
+	c.Flags().BoolVar(&global, "global", false, "Operate on the cross-repo registry (requires --stale)")
+	c.Flags().BoolVar(&stale, "stale", false, "With --global: prune registry entries whose worktree no longer exists")
 	c.Flags().StringVar(&agentSuffix, "agent", "", "Agent name to target a specific worktree when multiple agents ran on the same issue")
 	return c
+}
+
+// runCleanupGlobalStale removes registry entries whose worktree path no longer
+// exists on disk and reports what was pruned.
+func runCleanupGlobalStale() error {
+	removed, err := registry.RemoveStale()
+	if err != nil {
+		return fmt.Errorf("pruning global registry: %w", err)
+	}
+	if len(removed) == 0 {
+		fmt.Println("No stale entries found in the global registry.")
+		return nil
+	}
+	fmt.Printf("Pruned %d stale entry(ies) from the global registry:\n", len(removed))
+	for _, e := range removed {
+		fmt.Printf("  %s  %s  %s\n", e.RepoPath, e.Branch, e.Agent)
+	}
+	return nil
 }
 
 // parseCleanupIssues expands a mix of space-separated args and comma-separated
@@ -1413,6 +1470,10 @@ func cleanupMerged(repoRoot, issue, agentSuffix string) error {
 	if err := removeBranchRefs(repoRoot, branch); err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: could not delete remote branch %s\n", branch)
 		fmt.Fprintf(os.Stderr, "Delete the remote manually with:\n  git push origin --delete %s\n", branch)
+	}
+
+	if regErr := registry.Remove(repoRoot, branch); regErr != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not remove worktree from global registry: %v\n", regErr)
 	}
 
 	return nil
@@ -1601,6 +1662,7 @@ func runCleanupAllMerged() error {
 func NewStatusCmd() *cobra.Command {
 	var verbose bool
 	var asJSON bool
+	var global bool
 	c := &cobra.Command{
 		Use:     "status",
 		Aliases: []string{"list"},
@@ -1610,6 +1672,9 @@ func NewStatusCmd() *cobra.Command {
 Compact (default):  ISSUE  BRANCH  AGENT  PORT  SPEC  PR
 Verbose:            ISSUE  BRANCH  AGENT  PATH  PORT  DEV-PID  AGENT-PID  SPEC  PR  SESSION
 
+Use --global (-g) to show worktrees across all repositories tracked in the
+cross-repo registry (~/.config/agentctl/worktrees.json).
+
 Use --json to emit a JSON array of run records from .agentctl/runs/.
 Each entry includes issue, branch, agent, status,
 started_at, elapsed_seconds, pr_url, files_changed, and tokens_used.
@@ -1618,6 +1683,9 @@ Spec states:  no-spec | paused | in-progress | done
 PR states:    none | OPEN | MERGED | CLOSED`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if global {
+				return runGlobalStatus(os.Stdout)
+			}
 			if asJSON {
 				return runStatusJSON()
 			}
@@ -1626,6 +1694,7 @@ PR states:    none | OPEN | MERGED | CLOSED`,
 	}
 	c.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show full table including PATH, PIDs, and SESSION")
 	c.Flags().BoolVar(&asJSON, "json", false, "Emit JSON array of run records from .agentctl/runs/")
+	c.Flags().BoolVarP(&global, "global", "g", false, "Show worktrees across all repos from the cross-repo registry")
 	return c
 }
 
@@ -1789,6 +1858,62 @@ func runStatusJSON() error {
 	}
 	fmt.Println(string(data))
 	return nil
+}
+
+// runGlobalStatus prints a table of all worktrees tracked in the cross-repo
+// registry, re-verifying each entry's state at display time.
+func runGlobalStatus(out io.Writer) error {
+	entries, err := registry.List()
+	if err != nil {
+		return fmt.Errorf("reading global registry: %w", err)
+	}
+
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "REPO\tISSUE\tBRANCH\tAGENT\tSTATE")
+
+	home, _ := os.UserHomeDir()
+	for _, e := range entries {
+		repoDisplay := e.RepoPath
+		if home != "" && strings.HasPrefix(repoDisplay, home) {
+			repoDisplay = "~" + repoDisplay[len(home):]
+		}
+
+		issue := e.Issue
+		if issue == "" {
+			issue = "—"
+		}
+
+		agentName := e.Agent
+		if agentName == "" {
+			agentName = "-"
+		}
+
+		wtState := globalWorktreeState(e)
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			repoDisplay, issue, e.Branch, agentName, wtState)
+	}
+	return w.Flush()
+}
+
+// globalWorktreeState returns the display state for a registry entry by
+// re-verifying its on-disk condition at call time.
+//
+//   - "stale"   — worktree path no longer exists on disk
+//   - "running" — agent process is still alive
+//   - "done"    — worktree exists but no live agent process
+func globalWorktreeState(e registry.Entry) string {
+	if e.WorktreePath == "" {
+		return "stale"
+	}
+	if _, err := os.Stat(e.WorktreePath); os.IsNotExist(err) {
+		return "stale"
+	}
+	af, _ := state.Read(e.WorktreePath)
+	if process.IsAlive(af.AgentPID) || process.IsAlive(af.DevPID) {
+		return "running"
+	}
+	return "done"
 }
 
 // ─── logs ─────────────────────────────────────────────────────────────────────
@@ -2696,6 +2821,11 @@ func cleanupFailedStart(repoRoot, wtPath, branch, devPID string) error {
 		if err := git.DeleteLocalBranch(repoRoot, branch); err != nil {
 			errs = append(errs, err.Error())
 		}
+	}
+
+	// Best-effort: remove from global registry even on failed start.
+	if branch != "" {
+		_ = registry.Remove(repoRoot, branch)
 	}
 
 	if len(errs) > 0 {

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -1679,11 +1679,18 @@ Use --json to emit a JSON array of run records from .agentctl/runs/.
 Each entry includes issue, branch, agent, status,
 started_at, elapsed_seconds, pr_url, files_changed, and tokens_used.
 
+Use --global --json together to emit a JSON array of registry entries from the
+cross-repo registry. Each entry includes repo, worktree_path, issue, branch,
+agent, state (running/done/stale), and added_at.
+
 Spec states:  no-spec | paused | in-progress | done
 PR states:    none | OPEN | MERGED | CLOSED`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if global {
+				if asJSON {
+					return runGlobalStatusJSON(os.Stdout)
+				}
 				return runGlobalStatus(os.Stdout)
 			}
 			if asJSON {
@@ -1874,7 +1881,7 @@ func runGlobalStatus(out io.Writer) error {
 	home, _ := os.UserHomeDir()
 	for _, e := range entries {
 		repoDisplay := e.RepoPath
-		if home != "" && strings.HasPrefix(repoDisplay, home) {
+		if home != "" && (repoDisplay == home || strings.HasPrefix(repoDisplay, home+"/")) {
 			repoDisplay = "~" + repoDisplay[len(home):]
 		}
 
@@ -1914,6 +1921,46 @@ func globalWorktreeState(e registry.Entry) string {
 		return "running"
 	}
 	return "done"
+}
+
+// runGlobalStatusJSON emits a JSON array of registry entries, each annotated
+// with a "state" field (running/done/stale), when both --global and --json are
+// given.
+func runGlobalStatusJSON(out io.Writer) error {
+	entries, err := registry.List()
+	if err != nil {
+		return fmt.Errorf("reading global registry: %w", err)
+	}
+
+	type globalStatusJSON struct {
+		Repo         string    `json:"repo"`
+		WorktreePath string    `json:"worktree_path,omitempty"`
+		Issue        string    `json:"issue,omitempty"`
+		Branch       string    `json:"branch"`
+		Agent        string    `json:"agent,omitempty"`
+		State        string    `json:"state"`
+		AddedAt      time.Time `json:"added_at"`
+	}
+
+	result := make([]globalStatusJSON, 0, len(entries))
+	for _, e := range entries {
+		result = append(result, globalStatusJSON{
+			Repo:         e.RepoPath,
+			WorktreePath: e.WorktreePath,
+			Issue:        e.Issue,
+			Branch:       e.Branch,
+			Agent:        e.Agent,
+			State:        globalWorktreeState(e),
+			AddedAt:      e.AddedAt,
+		})
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	out.Write(data) //nolint:errcheck
+	out.Write([]byte("\n"))
+	return nil
 }
 
 // ─── logs ─────────────────────────────────────────────────────────────────────

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/arun-gupta/agentctl/internal/git"
 	"github.com/arun-gupta/agentctl/internal/notify"
 	"github.com/arun-gupta/agentctl/internal/process"
+	"github.com/arun-gupta/agentctl/internal/registry"
 	"github.com/arun-gupta/agentctl/internal/sdd"
 	"github.com/arun-gupta/agentctl/internal/state"
 	"github.com/arun-gupta/agentctl/internal/vcs"
@@ -6372,5 +6373,126 @@ func TestStartOne_defaultSDD_speckit_fromConfig(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "SpecKit skills not found") {
 		t.Fatalf("expected speckit-not-found error, got: %v", err)
+	}
+}
+
+// ─── runGlobalStatus ──────────────────────────────────────────────────────────
+
+func setRegistryDirForCmd(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+}
+
+func TestRunGlobalStatus_emptyRegistry(t *testing.T) {
+	setRegistryDirForCmd(t)
+
+	var buf bytes.Buffer
+	if err := runGlobalStatus(&buf); err != nil {
+		t.Fatalf("runGlobalStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "REPO") {
+		t.Errorf("expected header row; got:\n%s", out)
+	}
+	// No entries — only the header line should be present.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line (header only) for empty registry; got %d:\n%s", len(lines), out)
+	}
+}
+
+func TestRunGlobalStatus_showsEntries(t *testing.T) {
+	setRegistryDirForCmd(t)
+
+	// Create a real worktree directory with a .agent file.
+	wtDir := t.TempDir()
+	if err := state.Write(wtDir, state.AgentFile{Agent: "claude", SessionID: "abc123"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := registry.AddWithWorktree("/repos/api", wtDir, "42", "42-feat-auth", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runGlobalStatus(&buf); err != nil {
+		t.Fatalf("runGlobalStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "42-feat-auth") {
+		t.Errorf("expected branch in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "claude") {
+		t.Errorf("expected agent name in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "42") {
+		t.Errorf("expected issue number in output; got:\n%s", out)
+	}
+}
+
+func TestRunGlobalStatus_staleEntry(t *testing.T) {
+	setRegistryDirForCmd(t)
+
+	if err := registry.AddWithWorktree("/repos/api", "/no/such/worktree", "42", "42-feat-auth", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runGlobalStatus(&buf); err != nil {
+		t.Fatalf("runGlobalStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "stale") {
+		t.Errorf("expected 'stale' state for missing worktree; got:\n%s", out)
+	}
+}
+
+func TestRunGlobalStatus_doneEntry(t *testing.T) {
+	setRegistryDirForCmd(t)
+
+	// Worktree exists but agent PID is empty (not running).
+	wtDir := t.TempDir()
+	if err := state.Write(wtDir, state.AgentFile{Agent: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := registry.AddWithWorktree("/repos/api", wtDir, "17", "17-fix-login", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runGlobalStatus(&buf); err != nil {
+		t.Fatalf("runGlobalStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "done") {
+		t.Errorf("expected 'done' state; got:\n%s", out)
+	}
+}
+
+func TestRunCleanupGlobalStale_prunesStaleEntries(t *testing.T) {
+	setRegistryDirForCmd(t)
+
+	liveDir := t.TempDir()
+	if err := registry.AddWithWorktree("/repos/api", liveDir, "1", "1-live", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.AddWithWorktree("/repos/frontend", "/no/such/dir", "2", "2-gone", "codex"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runCleanupGlobalStale(); err != nil {
+		t.Fatalf("runCleanupGlobalStale: %v", err)
+	}
+
+	remaining, err := registry.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 1 {
+		t.Fatalf("expected 1 remaining entry, got %d", len(remaining))
+	}
+	if remaining[0].Branch != "1-live" {
+		t.Errorf("expected live branch to remain, got %q", remaining[0].Branch)
 	}
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,150 @@
+// Package registry maintains the cross-repo worktree registry at
+// $XDG_CONFIG_HOME/agentctl/worktrees.json.
+//
+// Each entry records one agentctl-managed worktree. The registry is updated
+// on start, cleanup, and discard so that `agentctl status --global` can show
+// active worktrees across all repositories.
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/arun-gupta/agentctl/internal/xdg"
+)
+
+// Entry records one agentctl-managed worktree in the cross-repo registry.
+type Entry struct {
+	RepoPath     string    `json:"repo"`
+	WorktreePath string    `json:"worktree_path"`
+	Issue        string    `json:"issue"`
+	Branch       string    `json:"branch"`
+	Agent        string    `json:"agent"`
+	AddedAt      time.Time `json:"added_at"`
+}
+
+// filePath returns the absolute path to the registry JSON file:
+// $XDG_CONFIG_HOME/agentctl/worktrees.json
+func filePath() string {
+	dir := xdg.UserConfigDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "agentctl", "worktrees.json")
+}
+
+// load reads the registry from disk. Returns an empty slice when the file
+// does not exist.
+func load() ([]Entry, error) {
+	path := filePath()
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var entries []Entry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// save writes entries to disk, creating parent directories as needed.
+func save(entries []Entry) error {
+	path := filePath()
+	if path == "" {
+		return nil // no config dir available; silently skip
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+// Add appends an entry for the given worktree if one with the same
+// repoPath+branch does not already exist. It is safe to call multiple times;
+// duplicates are silently ignored.
+func Add(repoPath, issue, branch, agent string) error {
+	return AddWithWorktree(repoPath, "", issue, branch, agent)
+}
+
+// AddWithWorktree is like Add but also records the worktree filesystem path
+// so that state can be re-verified at display time without re-deriving it.
+func AddWithWorktree(repoPath, worktreePath, issue, branch, agent string) error {
+	entries, err := load()
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.RepoPath == repoPath && e.Branch == branch {
+			return nil // already registered
+		}
+	}
+	entries = append(entries, Entry{
+		RepoPath:     repoPath,
+		WorktreePath: worktreePath,
+		Issue:        issue,
+		Branch:       branch,
+		Agent:        agent,
+		AddedAt:      time.Now().UTC(),
+	})
+	return save(entries)
+}
+
+// Remove deletes the registry entry for the given repoPath+branch combination.
+// It is a no-op when no matching entry exists.
+func Remove(repoPath, branch string) error {
+	entries, err := load()
+	if err != nil {
+		return err
+	}
+	n := 0
+	for _, e := range entries {
+		if e.RepoPath == repoPath && e.Branch == branch {
+			continue
+		}
+		entries[n] = e
+		n++
+	}
+	return save(entries[:n])
+}
+
+// List returns all registered entries in the order they were added.
+func List() ([]Entry, error) {
+	return load()
+}
+
+// RemoveStale removes entries whose WorktreePath no longer exists on disk.
+// It returns the list of removed entries so callers can report them.
+func RemoveStale() ([]Entry, error) {
+	entries, err := load()
+	if err != nil {
+		return nil, err
+	}
+	var keep, removed []Entry
+	for _, e := range entries {
+		worktreePath := e.WorktreePath
+		if worktreePath == "" {
+			// Legacy entry without worktree_path — treat as stale.
+			removed = append(removed, e)
+			continue
+		}
+		if _, statErr := os.Stat(worktreePath); os.IsNotExist(statErr) {
+			removed = append(removed, e)
+		} else {
+			keep = append(keep, e)
+		}
+	}
+	return removed, save(keep)
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/arun-gupta/agentctl/internal/xdg"
@@ -56,20 +57,68 @@ func load() ([]Entry, error) {
 	return entries, nil
 }
 
-// save writes entries to disk, creating parent directories as needed.
+// save writes entries to disk atomically: data is marshalled to a temporary
+// file in the same directory, then renamed over the target path.
+// Callers are expected to hold the registry file lock (see withFileLock).
 func save(entries []Entry) error {
 	path := filePath()
 	if path == "" {
 		return nil // no config dir available; silently skip
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o600)
+	// Write to a temp file in the same directory, then rename for atomicity.
+	tmp, err := os.CreateTemp(dir, "worktrees-*.json.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanupTmp := func() { tmp.Close(); os.Remove(tmpPath) }
+	if _, err := tmp.Write(data); err != nil {
+		cleanupTmp()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// withFileLock acquires an exclusive advisory lock on a companion lock file
+// alongside the registry JSON, runs fn, then releases the lock.  This
+// serialises concurrent agentctl invocations (e.g. two simultaneous `start`
+// commands) so that load-modify-save sequences are never interleaved.
+func withFileLock(fn func() error) error {
+	path := filePath()
+	if path == "" {
+		return fn() // no config dir; skip locking
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	lockPath := path + ".lock"
+	lf, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	defer lf.Close()
+	if err := syscall.Flock(int(lf.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer syscall.Flock(int(lf.Fd()), syscall.LOCK_UN) //nolint:errcheck
+	return fn()
 }
 
 // Add appends an entry for the given worktree if one with the same
@@ -82,42 +131,46 @@ func Add(repoPath, issue, branch, agent string) error {
 // AddWithWorktree is like Add but also records the worktree filesystem path
 // so that state can be re-verified at display time without re-deriving it.
 func AddWithWorktree(repoPath, worktreePath, issue, branch, agent string) error {
-	entries, err := load()
-	if err != nil {
-		return err
-	}
-	for _, e := range entries {
-		if e.RepoPath == repoPath && e.Branch == branch {
-			return nil // already registered
+	return withFileLock(func() error {
+		entries, err := load()
+		if err != nil {
+			return err
 		}
-	}
-	entries = append(entries, Entry{
-		RepoPath:     repoPath,
-		WorktreePath: worktreePath,
-		Issue:        issue,
-		Branch:       branch,
-		Agent:        agent,
-		AddedAt:      time.Now().UTC(),
+		for _, e := range entries {
+			if e.RepoPath == repoPath && e.Branch == branch {
+				return nil // already registered
+			}
+		}
+		entries = append(entries, Entry{
+			RepoPath:     repoPath,
+			WorktreePath: worktreePath,
+			Issue:        issue,
+			Branch:       branch,
+			Agent:        agent,
+			AddedAt:      time.Now().UTC(),
+		})
+		return save(entries)
 	})
-	return save(entries)
 }
 
 // Remove deletes the registry entry for the given repoPath+branch combination.
 // It is a no-op when no matching entry exists.
 func Remove(repoPath, branch string) error {
-	entries, err := load()
-	if err != nil {
-		return err
-	}
-	n := 0
-	for _, e := range entries {
-		if e.RepoPath == repoPath && e.Branch == branch {
-			continue
+	return withFileLock(func() error {
+		entries, err := load()
+		if err != nil {
+			return err
 		}
-		entries[n] = e
-		n++
-	}
-	return save(entries[:n])
+		n := 0
+		for _, e := range entries {
+			if e.RepoPath == repoPath && e.Branch == branch {
+				continue
+			}
+			entries[n] = e
+			n++
+		}
+		return save(entries[:n])
+	})
 }
 
 // List returns all registered entries in the order they were added.
@@ -126,25 +179,30 @@ func List() ([]Entry, error) {
 }
 
 // RemoveStale removes entries whose WorktreePath no longer exists on disk.
+// Entries with an empty WorktreePath are left untouched (they were not created
+// via AddWithWorktree and cannot be verified by filesystem stat).
 // It returns the list of removed entries so callers can report them.
 func RemoveStale() ([]Entry, error) {
-	entries, err := load()
-	if err != nil {
-		return nil, err
-	}
-	var keep, removed []Entry
-	for _, e := range entries {
-		worktreePath := e.WorktreePath
-		if worktreePath == "" {
-			// Legacy entry without worktree_path — treat as stale.
-			removed = append(removed, e)
-			continue
+	var removed []Entry
+	err := withFileLock(func() error {
+		entries, err := load()
+		if err != nil {
+			return err
 		}
-		if _, statErr := os.Stat(worktreePath); os.IsNotExist(statErr) {
-			removed = append(removed, e)
-		} else {
-			keep = append(keep, e)
+		var keep []Entry
+		for _, e := range entries {
+			if e.WorktreePath == "" {
+				// No path recorded — cannot verify; preserve the entry.
+				keep = append(keep, e)
+				continue
+			}
+			if _, statErr := os.Stat(e.WorktreePath); os.IsNotExist(statErr) {
+				removed = append(removed, e)
+			} else {
+				keep = append(keep, e)
+			}
 		}
-	}
-	return removed, save(keep)
+		return save(keep)
+	})
+	return removed, err
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,188 @@
+package registry_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/arun-gupta/agentctl/internal/registry"
+)
+
+// setRegistryDir overrides XDG_CONFIG_HOME to a temp directory for isolation.
+func setRegistryDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+func TestAdd_addsNewEntry(t *testing.T) {
+	setRegistryDir(t)
+
+	if err := registry.Add("/repos/api", "42", "42-feat-auth", "claude"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	entries, err := registry.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.RepoPath != "/repos/api" {
+		t.Errorf("RepoPath = %q, want %q", e.RepoPath, "/repos/api")
+	}
+	if e.Issue != "42" {
+		t.Errorf("Issue = %q, want %q", e.Issue, "42")
+	}
+	if e.Branch != "42-feat-auth" {
+		t.Errorf("Branch = %q, want %q", e.Branch, "42-feat-auth")
+	}
+	if e.Agent != "claude" {
+		t.Errorf("Agent = %q, want %q", e.Agent, "claude")
+	}
+	if e.AddedAt.IsZero() {
+		t.Errorf("AddedAt should be set")
+	}
+}
+
+func TestAdd_deduplicates(t *testing.T) {
+	setRegistryDir(t)
+
+	if err := registry.Add("/repos/api", "42", "42-feat-auth", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	// Adding the same repo+branch again is a no-op.
+	if err := registry.Add("/repos/api", "42", "42-feat-auth", "codex"); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := registry.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry after dedup, got %d", len(entries))
+	}
+	// First write wins (agent stays "claude", not "codex").
+	if entries[0].Agent != "claude" {
+		t.Errorf("expected agent %q, got %q", "claude", entries[0].Agent)
+	}
+}
+
+func TestAdd_multipleRepos(t *testing.T) {
+	setRegistryDir(t)
+
+	if err := registry.Add("/repos/api", "42", "42-feat-auth", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Add("/repos/frontend", "17", "17-fix-login", "codex"); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := registry.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(entries))
+	}
+}
+
+func TestRemove_removesMatchingEntry(t *testing.T) {
+	setRegistryDir(t)
+
+	if err := registry.Add("/repos/api", "42", "42-feat-auth", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Add("/repos/frontend", "17", "17-fix-login", "codex"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := registry.Remove("/repos/api", "42-feat-auth"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	entries, err := registry.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry after remove, got %d", len(entries))
+	}
+	if entries[0].Branch != "17-fix-login" {
+		t.Errorf("remaining entry should be 17-fix-login, got %q", entries[0].Branch)
+	}
+}
+
+func TestRemove_noopOnMissingEntry(t *testing.T) {
+	setRegistryDir(t)
+
+	// Remove on an empty registry should not error.
+	if err := registry.Remove("/repos/api", "42-feat-auth"); err != nil {
+		t.Fatalf("Remove on empty registry: %v", err)
+	}
+}
+
+func TestList_emptyWhenNoFile(t *testing.T) {
+	setRegistryDir(t)
+
+	entries, err := registry.List()
+	if err != nil {
+		t.Fatalf("List on empty registry: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+func TestRemoveStale_removesEntriesWhereWorktreeGone(t *testing.T) {
+	setRegistryDir(t)
+
+	// Create a real worktree directory so one entry is "live".
+	liveDir := t.TempDir()
+
+	if err := registry.AddWithWorktree("/repos/api", liveDir, "1", "1-live-branch", "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.AddWithWorktree("/repos/frontend", "/no/such/worktree", "2", "2-gone-branch", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := registry.RemoveStale()
+	if err != nil {
+		t.Fatalf("RemoveStale: %v", err)
+	}
+	if len(removed) != 1 {
+		t.Fatalf("expected 1 stale entry removed, got %d", len(removed))
+	}
+	if removed[0].Branch != "2-gone-branch" {
+		t.Errorf("expected removed branch %q, got %q", "2-gone-branch", removed[0].Branch)
+	}
+
+	remaining, err := registry.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 1 {
+		t.Fatalf("expected 1 remaining entry, got %d", len(remaining))
+	}
+	if remaining[0].Branch != "1-live-branch" {
+		t.Errorf("expected remaining branch %q, got %q", "1-live-branch", remaining[0].Branch)
+	}
+}
+
+func TestFilePath_usesXDGConfigHome(t *testing.T) {
+	dir := setRegistryDir(t)
+
+	if err := registry.Add("/repos/api", "42", "42-feat", "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPath := filepath.Join(dir, "agentctl", "worktrees.json")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("expected registry file at %s: %v", expectedPath, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/registry` package that maintains a cross-repo worktree registry at `$XDG_CONFIG_HOME/agentctl/worktrees.json`
- Adds `agentctl status --global` / `-g` flag showing all tracked worktrees across repos with live state verification (`running`, `done`, `stale`)
- Registry is updated on `start`, `cleanup`, and `discard` so no manual maintenance is required
- Adds `agentctl cleanup --global --stale` to prune stale registry entries

Closes #192

## Test plan

### Automated

Command: `go test ./...`

Result: **PASS** — all packages pass, including 9 new tests across `internal/registry` and `internal/cmd`.

```
ok  github.com/arun-gupta/agentctl/cmd/agentctl
ok  github.com/arun-gupta/agentctl/internal/adapters
ok  github.com/arun-gupta/agentctl/internal/cmd
ok  github.com/arun-gupta/agentctl/internal/config
ok  github.com/arun-gupta/agentctl/internal/diagnostics
ok  github.com/arun-gupta/agentctl/internal/git
ok  github.com/arun-gupta/agentctl/internal/notify
ok  github.com/arun-gupta/agentctl/internal/process
ok  github.com/arun-gupta/agentctl/internal/registry
ok  github.com/arun-gupta/agentctl/internal/sdd
ok  github.com/arun-gupta/agentctl/internal/state
ok  github.com/arun-gupta/agentctl/internal/vcs
```

`go vet ./...` — **PASS** (no issues)

### Manual

- **Cross-repo global status**: Start agents in two separate repos, then run `agentctl status --global` from a third directory — verify both appear with correct REPO, ISSUE, BRANCH, AGENT, STATE columns. Cannot be automated because it requires multiple real git repos on disk with live agents.
- **`running` state detection**: Confirm an entry shows `running` while the agent process is alive and switches to `done` after the agent exits. Requires a live background process; not automatable in unit tests.
- **`stale` state after manual deletion**: Delete a worktree directory by hand without running cleanup, then run `agentctl status --global` — verify the entry shows `stale`. Automating this in CI would require file-system manipulation tightly coupled to the registry file path.
- **`cleanup --global --stale` output**: After several worktrees are removed manually, run `agentctl cleanup --global --stale` and verify the correct entries are reported as pruned and the registry file shrinks accordingly.
- **Registry persistence across repos**: Verify that entries added in one repo survive a `cd` to another repo and still appear under `agentctl status --global`. Requires manual multi-repo setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)