### PR TITLE
fix(test): isolate XDG_CONFIG_HOME and stub SendFn in headless notify tests

### DIFF
--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1345,6 +1345,11 @@ func TestLaunchAgent_headless_withSDD_showsResumeHint(t *testing.T) {
 // sent from the detached __finalise-diagnostics subprocess, so we intercept it
 // via a temp file rather than stubbing notify.SendFn in-process.
 func TestLaunchAgent_headless_notify(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // isolate sentinel so real ~/.config is not written
+	origFn := notify.SendFn
+	t.Cleanup(func() { notify.SendFn = origFn })
+	notify.SendFn = func(_, _ string) {} // suppress real OS notification from maybeFireTestNotification
+
 	dir := t.TempDir()
 	writeLocalAdapter(t, dir, "echoagent",
 		"binary: echo\nsession: --session\n")
@@ -2440,6 +2445,11 @@ func TestAgentResume_headless_hints(t *testing.T) {
 // notification is sent from the detached __finalise-diagnostics subprocess,
 // so we intercept it via a temp file rather than stubbing notify.SendFn.
 func TestAgentResume_headless_notify(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // isolate sentinel so real ~/.config is not written
+	origFn := notify.SendFn
+	t.Cleanup(func() { notify.SendFn = origFn })
+	notify.SendFn = func(_, _ string) {} // suppress real OS notification from maybeFireTestNotification
+
 	t.Setenv("GITHUB_TOKEN", "test-token")
 	dir := t.TempDir()
 	writeLocalAdapter(t, dir, "echoagent",

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1341,9 +1341,13 @@ func TestLaunchAgent_headless_withSDD_showsResumeHint(t *testing.T) {
 }
 
 // TestLaunchAgent_headless_notify verifies that a desktop notification is
-// fired after the headless agent exits when notify=true. The notification is
-// sent from the detached __finalise-diagnostics subprocess, so we intercept it
-// via a temp file rather than stubbing notify.SendFn in-process.
+// fired after the headless agent exits when notify=true. Two notification paths
+// are exercised: (1) the parent-process first-run test notification fired by
+// maybeFireTestNotification — suppressed here by stubbing notify.SendFn so no
+// real OS notification appears; (2) the detached completion notification sent
+// from the __finalise-diagnostics subprocess — captured via
+// AGENTCTL_TEST_NOTIFY_FILE rather than the stub, since the subprocess runs in
+// a separate process where the in-process stub has no effect.
 func TestLaunchAgent_headless_notify(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // isolate sentinel so real ~/.config is not written
 	origFn := notify.SendFn
@@ -2441,9 +2445,13 @@ func TestAgentResume_headless_hints(t *testing.T) {
 }
 
 // TestAgentResume_headless_notify verifies that a desktop notification is
-// fired after the headless resume agent exits when sendNotify=true. The
-// notification is sent from the detached __finalise-diagnostics subprocess,
-// so we intercept it via a temp file rather than stubbing notify.SendFn.
+// fired after the headless resume agent exits when sendNotify=true. Two
+// notification paths are exercised: (1) the parent-process first-run test
+// notification fired by maybeFireTestNotification — suppressed here by stubbing
+// notify.SendFn so no real OS notification appears; (2) the detached completion
+// notification sent from the __finalise-diagnostics subprocess — captured via
+// AGENTCTL_TEST_NOTIFY_FILE rather than the stub, since the subprocess runs in
+// a separate process where the in-process stub has no effect.
 func TestAgentResume_headless_notify(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // isolate sentinel so real ~/.config is not written
 	origFn := notify.SendFn


### PR DESCRIPTION
## Bug

`TestLaunchAgent_headless_notify` and `TestAgentResume_headless_notify` both call `maybeFireTestNotification` in-process without isolating `XDG_CONFIG_HOME`. Every test run:

1. Fired a **real macOS notification** saying "Notifications enabled — you'll be notified when issue #99 finishes." (the hardcoded test issue number)
2. Wrote the one-time sentinel to the **real** `~/.config/agentctl/notify-tested`

The user saw `#99` in the notification even though they were working on a completely different issue — and the sentinel being written meant the legitimate first-run notification would never fire for real work.

## Fix

For both tests, before calling `launchAgent`/`agentResume`:

- `t.Setenv("XDG_CONFIG_HOME", t.TempDir())` — sentinel goes to isolated temp dir, never touches `~/.config`
- Stub `notify.SendFn` to a no-op — suppresses the real OS notification from `maybeFireTestNotification` in the parent process

The subprocess path (`__finalise-diagnostics`) was already correctly handled via `AGENTCTL_TEST_NOTIFY_FILE`; this fix closes the gap in the parent process.

## Test plan

- [x] `go test ./... ` — all pass
- [x] `ls ~/.config/agentctl/notify-tested` — not found after running tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)