### PR TITLE
feat: add validate-adapter automation script

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -90,6 +90,29 @@ agentctl **best-effort** injects `GITHUB_TOKEN` from `gh auth token` into the ag
 
 These adapters have not been verified end-to-end. See the warning in [Available adapters → Untested](#untested) above.
 
+## Running the validator
+
+Use the validation harness to exercise an untested adapter against the pre-existing issues in `arun-gupta/agentctl-test`.
+
+```bash
+./scripts/validate-adapter.sh <adapter-name> [--issue <number>] [--repo-path <path>]
+```
+
+Examples:
+
+```bash
+./scripts/validate-adapter.sh gemini
+./scripts/validate-adapter.sh cursor --issue 42
+./scripts/validate-adapter.sh opencode --repo-path ~/src/agentctl-test
+```
+
+Notes:
+
+- The script defaults to `../agentctl-test` relative to this repository.
+- If `--issue` is omitted, it reuses the first open issue returned by `gh issue list --repo arun-gupta/agentctl-test --limit 1`.
+- Exit code `0` means every automated check passed. Any non-zero exit code means at least one automated check failed.
+- Resume, notification, and PR/merge lifecycle checks are still reported as manual follow-ups.
+
 ### gemini
 
 [Gemini CLI](https://github.com/google-gemini/gemini-cli) — Google's coding agent. Uses directory-based session continuity.

--- a/internal/cmd/validate_adapter_script_test.go
+++ b/internal/cmd/validate_adapter_script_test.go
@@ -10,7 +10,19 @@ import (
 	"testing"
 )
 
+func requireBash(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available on this system")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("validate-adapter.sh requires bash; skipping on Windows")
+	}
+}
+
 func TestValidateAdapterScriptUsage(t *testing.T) {
+	requireBash(t)
+
 	script := validateAdapterScriptPath(t)
 	info, err := os.Stat(script)
 	if err != nil {
@@ -45,6 +57,8 @@ func TestValidateAdapterScriptUsage(t *testing.T) {
 }
 
 func TestValidateAdapterScriptDefaultIssueAndOverrides(t *testing.T) {
+	requireBash(t)
+
 	script := validateAdapterScriptPath(t)
 	stubBin := t.TempDir()
 	repoPath := initValidateAdapterRepo(t)
@@ -95,6 +109,8 @@ func TestValidateAdapterScriptDefaultIssueAndOverrides(t *testing.T) {
 }
 
 func TestValidateAdapterScriptCleanupOnFailure(t *testing.T) {
+	requireBash(t)
+
 	script := validateAdapterScriptPath(t)
 	stubBin := t.TempDir()
 	repoPath := initValidateAdapterRepo(t)
@@ -163,7 +179,7 @@ func makeValidateAdapterStubs(t *testing.T, dir string) {
 
 	writeValidateAdapterStub(t, filepath.Join(dir, "gh"), `#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$*" >>"`+filepath.Join(dir, "gh.log")+`"
+printf '%s\n' "$*" >>`+`"`+filepath.Join(dir, "gh.log")+`"`+`
 if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
   echo 77
   exit 0
@@ -172,22 +188,21 @@ echo "unexpected gh invocation: $*" >&2
 exit 1
 `)
 
-	writeValidateAdapterStub(t, filepath.Join(dir, "fake-adapter-bin"), `#!/usr/bin/env bash
-exit 0
-`)
-
+	// agentctl stub mirrors real output formats:
+	//   info     — "Coding Agents:" block with ✗/✓ markers and install hints
+	//   status   — tab-separated table with ISSUE as first column (NR>1)
+	//   start    — creates a real git worktree so resolve_worktree and cleanup work
+	//   logs     — emits a log line
+	//   attach   — exits 0 immediately
 	writeValidateAdapterStub(t, filepath.Join(dir, "agentctl"), `#!/usr/bin/env bash
 set -euo pipefail
 
 if [[ "${1:-}" == "info" ]]; then
   cat <<'EOF'
-Available adapters:
-  gemini
-    binary: fake-adapter-bin
-  cursor
-    binary: fake-adapter-bin
-  opencode
-    binary: fake-adapter-bin
+Coding Agents:
+  ✗ gemini       (not installed) — install with: npm install -g @google/gemini-cli
+  ✗ cursor       (not installed) — install with: brew install --cask cursor-cli
+  ✗ opencode     (not installed) — install with: npm install -g opencode@latest
 EOF
   exit 0
 fi
@@ -197,27 +212,12 @@ if [[ "${1:-}" == "agent" && "${2:-}" == "start" ]]; then
   issue=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --agent)
-        adapter="$2"
-        shift 2
-        ;;
-      --headless)
-        shift
-        ;;
-      agent|start)
-        shift
-        ;;
-      *)
-        issue="$1"
-        shift
-        ;;
+      --agent)   adapter="$2"; shift 2 ;;
+      --headless) shift ;;
+      agent|start) shift ;;
+      *) issue="$1"; shift ;;
     esac
   done
-
-  if ! command -v fake-adapter-bin >/dev/null 2>&1; then
-    echo "install: npm install -g fake-adapter-bin"
-    exit 1
-  fi
 
   repo_path="$(pwd)"
   worktree_path="${repo_path}/${issue}-${adapter}"
@@ -233,8 +233,9 @@ if [[ "${1:-}" == "agent" && "${2:-}" == "start" ]]; then
 fi
 
 if [[ "${1:-}" == "agent" && "${2:-}" == "status" ]]; then
-  echo "issue #77 running"
-  echo "issue #42 running"
+  printf 'ISSUE\tBRANCH\tAGENT\tPORT\tSPEC\tPR\n'
+  printf '77\t77-gemini\tgemini\t3010\tno-spec\tnone\n'
+  printf '42\t42-cursor\tcursor\t3011\tno-spec\tnone\n'
   exit 0
 fi
 

--- a/internal/cmd/validate_adapter_script_test.go
+++ b/internal/cmd/validate_adapter_script_test.go
@@ -1,0 +1,273 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestValidateAdapterScriptUsage(t *testing.T) {
+	script := validateAdapterScriptPath(t)
+	info, err := os.Stat(script)
+	if err != nil {
+		t.Fatalf("stat script: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("script is not executable: mode=%#o", info.Mode().Perm())
+	}
+
+	cmd := exec.Command("bash", script)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	if err == nil {
+		t.Fatal("expected missing-adapter invocation to fail")
+	}
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError, got %T", err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("exit code = %d, want 1", exitErr.ExitCode())
+	}
+
+	output := stdout.String() + stderr.String()
+	if !strings.Contains(output, "Usage: validate-adapter.sh <adapter-name> [--issue N] [--repo-path PATH]") {
+		t.Fatalf("usage output missing, got:\n%s", output)
+	}
+}
+
+func TestValidateAdapterScriptDefaultIssueAndOverrides(t *testing.T) {
+	script := validateAdapterScriptPath(t)
+	stubBin := t.TempDir()
+	repoPath := initValidateAdapterRepo(t)
+	makeValidateAdapterStubs(t, stubBin)
+
+	cmd := exec.Command("bash", script, "gemini", "--repo-path", repoPath)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, out)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, "[validate-adapter] adapter: gemini  repo: arun-gupta/agentctl-test  issue: #77") {
+		t.Fatalf("summary line missing discovered issue, got:\n%s", output)
+	}
+	if !strings.Contains(output, "[PASS] install hint shown when binary is missing") {
+		t.Fatalf("install-hint check did not pass, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Result: 7 automated checks passed, 0 failed, 3 manual checks pending") {
+		t.Fatalf("result summary mismatch, got:\n%s", output)
+	}
+
+	ghLog, err := os.ReadFile(filepath.Join(stubBin, "gh.log"))
+	if err != nil {
+		t.Fatalf("read gh log: %v", err)
+	}
+	if !strings.Contains(string(ghLog), "issue list --repo arun-gupta/agentctl-test --limit 1 --json number -q .[0].number") {
+		t.Fatalf("gh issue list call missing, got:\n%s", ghLog)
+	}
+	if strings.Contains(string(ghLog), "issue create") || strings.Contains(string(ghLog), "issue delete") {
+		t.Fatalf("script must not create/delete issues, got:\n%s", ghLog)
+	}
+
+	cmd = exec.Command("bash", script, "cursor", "--issue", "42", "--repo-path", repoPath)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script with explicit issue failed: %v\n%s", err, out)
+	}
+	if strings.Contains(string(out), "issue: #77") || !strings.Contains(string(out), "issue: #42") {
+		t.Fatalf("explicit issue override not respected, got:\n%s", out)
+	}
+}
+
+func TestValidateAdapterScriptCleanupOnFailure(t *testing.T) {
+	script := validateAdapterScriptPath(t)
+	stubBin := t.TempDir()
+	repoPath := initValidateAdapterRepo(t)
+	makeValidateAdapterStubs(t, stubBin)
+
+	cmd := exec.Command("bash", script, "opencode", "--repo-path", repoPath)
+	cmd.Env = append(os.Environ(),
+		"PATH="+stubBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AGENTCTL_FAKE_NO_CHANGES=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected script to fail when no worktree changes are present\n%s", out)
+	}
+
+	output := string(out)
+	if !strings.Contains(output, "[FAIL] no file changes detected in worktree") {
+		t.Fatalf("expected no-file-changes failure, got:\n%s", output)
+	}
+
+	worktreeList := runValidateAdapterCommand(t, repoPath, "git", "-C", repoPath, "worktree", "list", "--porcelain")
+	if strings.Contains(worktreeList, "/77-opencode") {
+		t.Fatalf("worktree cleanup failed, remaining worktrees:\n%s", worktreeList)
+	}
+
+	branches := runValidateAdapterCommand(t, repoPath, "git", "-C", repoPath, "branch", "--list")
+	if strings.Contains(branches, "77-opencode") {
+		t.Fatalf("branch cleanup failed, remaining branches:\n%s", branches)
+	}
+}
+
+func validateAdapterScriptPath(t *testing.T) string {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+	return filepath.Join(root, "scripts", "validate-adapter.sh")
+}
+
+func initValidateAdapterRepo(t *testing.T) string {
+	t.Helper()
+
+	repoPath := filepath.Join(t.TempDir(), "agentctl-test")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+
+	runValidateAdapterCommand(t, repoPath, "git", "init", "-b", "main", repoPath)
+	runValidateAdapterCommand(t, repoPath, "git", "-C", repoPath, "config", "user.name", "Test User")
+	runValidateAdapterCommand(t, repoPath, "git", "-C", repoPath, "config", "user.email", "test@example.com")
+	runValidateAdapterCommand(t, repoPath, "git", "-C", repoPath, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	runValidateAdapterCommand(t, repoPath, "git", "-C", repoPath, "add", "README.md")
+	runValidateAdapterCommand(t, repoPath, "git", "-C", repoPath, "commit", "-m", "seed")
+
+	return repoPath
+}
+
+func makeValidateAdapterStubs(t *testing.T, dir string) {
+	t.Helper()
+
+	writeValidateAdapterStub(t, filepath.Join(dir, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"`+filepath.Join(dir, "gh.log")+`"
+if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
+  echo 77
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`)
+
+	writeValidateAdapterStub(t, filepath.Join(dir, "fake-adapter-bin"), `#!/usr/bin/env bash
+exit 0
+`)
+
+	writeValidateAdapterStub(t, filepath.Join(dir, "agentctl"), `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "info" ]]; then
+  cat <<'EOF'
+Available adapters:
+  gemini
+    binary: fake-adapter-bin
+  cursor
+    binary: fake-adapter-bin
+  opencode
+    binary: fake-adapter-bin
+EOF
+  exit 0
+fi
+
+if [[ "${1:-}" == "agent" && "${2:-}" == "start" ]]; then
+  adapter=""
+  issue=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent)
+        adapter="$2"
+        shift 2
+        ;;
+      --headless)
+        shift
+        ;;
+      agent|start)
+        shift
+        ;;
+      *)
+        issue="$1"
+        shift
+        ;;
+    esac
+  done
+
+  if ! command -v fake-adapter-bin >/dev/null 2>&1; then
+    echo "install: npm install -g fake-adapter-bin"
+    exit 1
+  fi
+
+  repo_path="$(pwd)"
+  worktree_path="${repo_path}/${issue}-${adapter}"
+  branch_name="${issue}-${adapter}"
+  git -C "$repo_path" worktree add -b "$branch_name" "$worktree_path" HEAD >/dev/null
+
+  if [[ "${AGENTCTL_FAKE_NO_CHANGES:-0}" != "1" ]]; then
+    printf 'adapter=%s issue=%s\n' "$adapter" "$issue" >"$worktree_path/result.txt"
+    git -C "$worktree_path" add result.txt >/dev/null
+    git -C "$worktree_path" commit -m "agent output" >/dev/null
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "agent" && "${2:-}" == "status" ]]; then
+  echo "issue #77 running"
+  echo "issue #42 running"
+  exit 0
+fi
+
+if [[ "${1:-}" == "agent" && "${2:-}" == "logs" ]]; then
+  echo "log line"
+  exit 0
+fi
+
+if [[ "${1:-}" == "agent" && "${2:-}" == "attach" ]]; then
+  exit 0
+fi
+
+echo "unexpected agentctl invocation: $*" >&2
+exit 1
+`)
+}
+
+func writeValidateAdapterStub(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write stub %s: %v", path, err)
+	}
+}
+
+func runValidateAdapterCommand(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}

--- a/scripts/validate-adapter.sh
+++ b/scripts/validate-adapter.sh
@@ -15,6 +15,7 @@ REPO_PATH="../agentctl-test"
 ISSUE=""
 WORKTREE=""
 BRANCH=""
+WORKTREES_BEFORE=""
 PASS=0
 FAIL=0
 MANUAL=3
@@ -40,19 +41,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-pass() {
-  echo "[PASS] $*"
-  PASS=$((PASS + 1))
-}
-
-fail() {
-  echo "[FAIL] $*"
-  FAIL=$((FAIL + 1))
-}
-
-skip() {
-  echo "[SKIP] $* - manual check required"
-}
+pass() { echo "[PASS] $*"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $*"; FAIL=$((FAIL + 1)); }
+skip() { echo "[SKIP] $* — manual check required"; }
 
 cleanup() {
   if [[ -n "$WORKTREE" && -d "$WORKTREE" ]]; then
@@ -76,18 +67,17 @@ resolve_issue() {
   fi
 }
 
-adapter_binary() {
-  agentctl info 2>&1 | awk -v adapter="$ADAPTER" '
-    $0 == "  " adapter { found=1; next }
-    found && $0 ~ /^  [^ ]/ { found=0 }
-    found && $0 ~ /^[[:space:]]+binary:/ {
-      sub(/^[[:space:]]+binary:[[:space:]]*/, "", $0)
-      print $0
-      exit
-    }
-  '
+# Extract only the "Coding Agents:" block from agentctl info output.
+# Stops at the first non-indented line after the block starts, preventing
+# false positives from config lines like "default_agent: gemini".
+coding_agents_section() {
+  agentctl info 2>&1 | awk '/^Coding Agents:/{found=1;next} found && /^[^[:space:]]/{exit} found{print}'
 }
 
+# Resolve the worktree created by agent start for ISSUE by diffing
+# git worktree list before and after the start call. This prevents
+# accidentally selecting a pre-existing worktree whose branch already
+# matches ${ISSUE}-*.
 resolve_worktree() {
   local record path branch
   while IFS= read -r record; do
@@ -97,7 +87,7 @@ resolve_worktree() {
         ;;
       branch\ refs/heads/*)
         branch="${record#branch refs/heads/}"
-        if [[ "$branch" == "${ISSUE}-"* ]]; then
+        if [[ "$branch" == "${ISSUE}-"* ]] && ! grep -qxF "worktree $path" <<<"$WORKTREES_BEFORE"; then
           WORKTREE="$path"
           BRANCH="$branch"
           return 0
@@ -121,29 +111,36 @@ resolve_issue
 
 echo "[validate-adapter] adapter: $ADAPTER  repo: arun-gupta/agentctl-test  issue: #$ISSUE"
 
-if agentctl info 2>&1 | grep -q "$ADAPTER"; then
+# ── Level 1: Binary & wiring ─────────────────────────────────────────────
+
+AGENTS_SECTION="$(coding_agents_section)"
+
+# 1a: adapter appears in Coding Agents section — anchored to the adapter name
+# token to avoid matching config lines elsewhere in agentctl info output.
+if echo "$AGENTS_SECTION" | grep -qE "[[:space:]]${ADAPTER}([[:space:]]|$)"; then
   pass "agentctl info lists adapter \"$ADAPTER\""
 else
   fail "agentctl info does not list adapter \"$ADAPTER\""
 fi
 
-BINARY="$(adapter_binary || true)"
-BINARY_CMD="${BINARY%% *}"
-if [[ -n "$BINARY_CMD" ]] && BINARY_PATH="$(command -v "$BINARY_CMD" 2>/dev/null)"; then
-  BINARY_BAK="${BINARY_PATH}.validate-bak"
-  mv "$BINARY_PATH" "$BINARY_BAK"
-  OUTPUT="$(cd "$REPO_PATH" && agentctl agent start --agent "$ADAPTER" "$ISSUE" 2>&1 || true)"
-  mv "$BINARY_BAK" "$BINARY_PATH"
-  if grep -qi "install" <<<"$OUTPUT"; then
-    pass "install hint shown when binary is missing"
-  else
-    fail "no install hint shown when binary is missing"
-  fi
+# 1b: install hint present when adapter binary is not installed.
+# Reads directly from agentctl info output — no binary rename or PATH mutation needed.
+ADAPTER_LINE="$(echo "$AGENTS_SECTION" | grep -E "[[:space:]]${ADAPTER}([[:space:]]|$)" | head -1)"
+if echo "$ADAPTER_LINE" | grep -q "not installed" && echo "$ADAPTER_LINE" | grep -q "install with:"; then
+  pass "install hint shown when binary is missing"
+elif echo "$ADAPTER_LINE" | grep -q "not installed"; then
+  fail "adapter binary not installed but no install hint provided in agentctl info"
 else
-  skip "install hint check - binary not on PATH, skipping hide-and-restore"
+  skip "install hint check — binary is installed; test manually by temporarily removing it from PATH"
 fi
 
+# ── Level 2: Launch smoke test ───────────────────────────────────────────
+
 START="$(date +%s)"
+
+# Snapshot existing worktrees before agent start so resolve_worktree can
+# identify the newly-created one without clobbering a pre-existing worktree.
+WORKTREES_BEFORE="$(git -C "$REPO_PATH" worktree list --porcelain)"
 
 if (cd "$REPO_PATH" && agentctl agent start --agent "$ADAPTER" --headless "$ISSUE"); then
   pass "agentctl agent start launched agent"
@@ -158,7 +155,9 @@ else
   fail "could not resolve worktree path for issue #$ISSUE"
 fi
 
-if (cd "$REPO_PATH" && agentctl agent status 2>&1 | grep -q "$ISSUE"); then
+# Match exact first column in agent status table to avoid false positives
+# where issue number "42" would match row "142".
+if (cd "$REPO_PATH" && agentctl agent status 2>&1 | awk -v issue="$ISSUE" 'NR>1 && $1==issue{found=1} END{exit !found}'); then
   pass "agentctl agent status shows issue #$ISSUE"
 else
   fail "agentctl agent status does not show issue #$ISSUE"

--- a/scripts/validate-adapter.sh
+++ b/scripts/validate-adapter.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: validate-adapter.sh <adapter-name> [--issue N] [--repo-path PATH]" >&2
+}
+
+if [[ $# -lt 1 || "${1:-}" == --* ]]; then
+  usage
+  exit 1
+fi
+
+ADAPTER="$1"
+REPO_PATH="../agentctl-test"
+ISSUE=""
+WORKTREE=""
+BRANCH=""
+PASS=0
+FAIL=0
+MANUAL=3
+
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)
+      [[ $# -ge 2 ]] || { echo "missing value for --issue" >&2; exit 1; }
+      ISSUE="$2"
+      shift 2
+      ;;
+    --repo-path)
+      [[ $# -ge 2 ]] || { echo "missing value for --repo-path" >&2; exit 1; }
+      REPO_PATH="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown flag: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+pass() {
+  echo "[PASS] $*"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "[FAIL] $*"
+  FAIL=$((FAIL + 1))
+}
+
+skip() {
+  echo "[SKIP] $* - manual check required"
+}
+
+cleanup() {
+  if [[ -n "$WORKTREE" && -d "$WORKTREE" ]]; then
+    git -C "$REPO_PATH" worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$BRANCH" ]]; then
+    git -C "$REPO_PATH" branch -D "$BRANCH" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+resolve_issue() {
+  if [[ -n "$ISSUE" ]]; then
+    return
+  fi
+
+  ISSUE="$(gh issue list --repo arun-gupta/agentctl-test --limit 1 --json number -q '.[0].number')"
+  if [[ -z "$ISSUE" || "$ISSUE" == "null" ]]; then
+    echo "failed to resolve an open issue from arun-gupta/agentctl-test" >&2
+    exit 1
+  fi
+}
+
+adapter_binary() {
+  agentctl info 2>&1 | awk -v adapter="$ADAPTER" '
+    $0 == "  " adapter { found=1; next }
+    found && $0 ~ /^  [^ ]/ { found=0 }
+    found && $0 ~ /^[[:space:]]+binary:/ {
+      sub(/^[[:space:]]+binary:[[:space:]]*/, "", $0)
+      print $0
+      exit
+    }
+  '
+}
+
+resolve_worktree() {
+  local record path branch
+  while IFS= read -r record; do
+    case "$record" in
+      worktree\ *)
+        path="${record#worktree }"
+        ;;
+      branch\ refs/heads/*)
+        branch="${record#branch refs/heads/}"
+        if [[ "$branch" == "${ISSUE}-"* ]]; then
+          WORKTREE="$path"
+          BRANCH="$branch"
+          return 0
+        fi
+        ;;
+    esac
+  done < <(git -C "$REPO_PATH" worktree list --porcelain)
+  return 1
+}
+
+changed_files_stat() {
+  if git -C "$WORKTREE" rev-parse HEAD~1 >/dev/null 2>&1; then
+    git -C "$WORKTREE" diff --stat HEAD~1 2>/dev/null
+    return
+  fi
+
+  git -C "$WORKTREE" status --short 2>/dev/null
+}
+
+resolve_issue
+
+echo "[validate-adapter] adapter: $ADAPTER  repo: arun-gupta/agentctl-test  issue: #$ISSUE"
+
+if agentctl info 2>&1 | grep -q "$ADAPTER"; then
+  pass "agentctl info lists adapter \"$ADAPTER\""
+else
+  fail "agentctl info does not list adapter \"$ADAPTER\""
+fi
+
+BINARY="$(adapter_binary || true)"
+BINARY_CMD="${BINARY%% *}"
+if [[ -n "$BINARY_CMD" ]] && BINARY_PATH="$(command -v "$BINARY_CMD" 2>/dev/null)"; then
+  BINARY_BAK="${BINARY_PATH}.validate-bak"
+  mv "$BINARY_PATH" "$BINARY_BAK"
+  OUTPUT="$(cd "$REPO_PATH" && agentctl agent start --agent "$ADAPTER" "$ISSUE" 2>&1 || true)"
+  mv "$BINARY_BAK" "$BINARY_PATH"
+  if grep -qi "install" <<<"$OUTPUT"; then
+    pass "install hint shown when binary is missing"
+  else
+    fail "no install hint shown when binary is missing"
+  fi
+else
+  skip "install hint check - binary not on PATH, skipping hide-and-restore"
+fi
+
+START="$(date +%s)"
+
+if (cd "$REPO_PATH" && agentctl agent start --agent "$ADAPTER" --headless "$ISSUE"); then
+  pass "agentctl agent start launched agent"
+else
+  fail "agentctl agent start failed - aborting smoke test"
+  exit 1
+fi
+
+if resolve_worktree; then
+  :
+else
+  fail "could not resolve worktree path for issue #$ISSUE"
+fi
+
+if (cd "$REPO_PATH" && agentctl agent status 2>&1 | grep -q "$ISSUE"); then
+  pass "agentctl agent status shows issue #$ISSUE"
+else
+  fail "agentctl agent status does not show issue #$ISSUE"
+fi
+
+sleep 2
+if (cd "$REPO_PATH" && agentctl agent logs "$ISSUE" --no-follow --lines 5 2>&1 | grep -q .); then
+  pass "agentctl agent logs produces output"
+else
+  fail "agentctl agent logs produced no output"
+fi
+
+if (cd "$REPO_PATH" && agentctl agent attach "$ISSUE"); then
+  ELAPSED="$(( $(date +%s) - START ))"
+  pass "agent exited cleanly in ${ELAPSED}s"
+else
+  fail "agent exited with non-zero status"
+fi
+
+if [[ -n "$WORKTREE" ]] && CHANGED="$(changed_files_stat)" && grep -q . <<<"$CHANGED"; then
+  pass "files changed in worktree (${CHANGED##*$'\n'})"
+else
+  fail "no file changes detected in worktree at $WORKTREE"
+fi
+
+skip "resume: cd $REPO_PATH && agentctl agent resume $ISSUE 'revise the implementation'"
+skip "notify: agentctl agent start --agent $ADAPTER --headless --notify $ISSUE"
+skip "full lifecycle: verify PR opened, agentctl worktree merge, agentctl report"
+
+echo
+echo "Result: $PASS automated checks passed, $FAIL failed, $MANUAL manual checks pending"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Closes #326.

Adds `scripts/validate-adapter.sh` as a non-interactive validation harness for adapter smoke checks against `arun-gupta/agentctl-test`, including issue auto-discovery, install-hint verification, worktree cleanup, and pass/fail/manual reporting.

Also documents the validator in `docs/adapters.md` and adds a Go test that exercises the script through stubbed `gh` and `agentctl` binaries so the script contract is covered by `go test ./...`.

## Test plan

### Automated

Command run:

```bash
go test ./...
```

Summary: Pass. The full Go test suite completed successfully, including the new script-focused tests for usage handling, issue discovery/flag overrides, and cleanup on failure.

### Manual

- Run `./scripts/validate-adapter.sh gemini` against a real `../agentctl-test` clone. This requires the vendor CLI to be installed and authenticated, which the unit tests intentionally stub out.
- Run `./scripts/validate-adapter.sh opencode`, `./scripts/validate-adapter.sh kilocode`, and `./scripts/validate-adapter.sh cursor` with their real CLIs available. Adapter-specific launch and resume behavior depends on external binaries that are not present in CI.
- Verify the resume reminder flow against a live agent session. The script can print the exact `agentctl agent resume` command, but only a real session can confirm end-to-end resume behavior.
- Verify `--notify` on a machine with desktop notifications enabled. Notification delivery depends on the host OS integration rather than repo-local code alone.
- Verify the full lifecycle after a successful adapter run, including PR creation, `agentctl worktree merge`, and `agentctl report`. Those steps require live VCS/auth state and an actual agent-produced change set.
