### PR TITLE
fix(adapters): validate gemini adapter end-to-end

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -19,7 +19,7 @@ The following adapters have not been verified end-to-end. The YAML is provided a
 
 | Adapter | Type | Install |
 |---------|------|---------|
-| [gemini](#gemini) | Built-in | `npm install -g @google/gemini-cli` |
+| [gemini](#gemini) | Built-in | `brew install gemini-cli` |
 | [opencode](#opencode) | Built-in | `npm install -g opencode@latest` |
 | [kilocode](#kilocode) | Pluggable | `npm install -g @kilocode/cli` |
 | [cursor](#cursor) | Pluggable | `brew install --cask cursor-cli` |
@@ -119,8 +119,10 @@ Notes:
 
 ```yaml
 binary: gemini
+launch: gemini --skip-trust -p {kickoff}
+resume_cmd: gemini --skip-trust -p {prompt}
 session_type: directory
-install: npm install -g @google/gemini-cli
+install: brew install gemini-cli
 ```
 
 ### opencode

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -12,6 +12,7 @@ agentctl uses a **YAML adapter system** to launch and resume coding agents. Any 
 | [codex](#codex) | Built-in | `npm install -g @openai/codex` |
 | [copilot](#copilot) | Built-in | `npm install -g @github/copilot` |
 | [openhands](#openhands) | Pluggable | `uv tool install openhands --python 3.12` |
+| [gemini](#gemini) | Built-in | `brew install gemini-cli` |
 
 ### Untested
 
@@ -19,7 +20,6 @@ The following adapters have not been verified end-to-end. The YAML is provided a
 
 | Adapter | Type | Install |
 |---------|------|---------|
-| [gemini](#gemini) | Built-in | `brew install gemini-cli` |
 | [opencode](#opencode) | Built-in | `npm install -g opencode@latest` |
 | [kilocode](#kilocode) | Pluggable | `npm install -g @kilocode/cli` |
 | [cursor](#cursor) | Pluggable | `brew install --cask cursor-cli` |
@@ -30,6 +30,18 @@ The following adapters have not been verified end-to-end. The YAML is provided a
 ---
 
 ## Tested adapters
+
+### gemini
+
+[Gemini CLI](https://github.com/google-gemini/gemini-cli) — Google's coding agent. Uses directory-based session continuity. The `--skip-trust` flag is required when running inside git worktrees (untrusted directories).
+
+```yaml
+binary: gemini
+launch: gemini --skip-trust -p {kickoff}
+resume_cmd: gemini --skip-trust -p {prompt}
+session_type: directory
+install: brew install gemini-cli
+```
 
 ### claude
 
@@ -112,18 +124,6 @@ Notes:
 - If `--issue` is omitted, it reuses the first open issue returned by `gh issue list --repo arun-gupta/agentctl-test --limit 1`.
 - Exit code `0` means every automated check passed. Any non-zero exit code means at least one automated check failed.
 - Resume, notification, and PR/merge lifecycle checks are still reported as manual follow-ups.
-
-### gemini
-
-[Gemini CLI](https://github.com/google-gemini/gemini-cli) — Google's coding agent. Uses directory-based session continuity.
-
-```yaml
-binary: gemini
-launch: gemini --skip-trust -p {kickoff}
-resume_cmd: gemini --skip-trust -p {prompt}
-session_type: directory
-install: brew install gemini-cli
-```
 
 ### opencode
 

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -93,6 +93,7 @@ func TestLaunchCmd_gemini_noSessionFlag(t *testing.T) {
 	cmd := a.LaunchCmd("do gemini stuff", "sess-abc", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "gemini")
+	assertContains(t, args, "--skip-trust")
 	assertContains(t, args, "do gemini stuff")
 	// session_type: directory — no session ID flag expected
 	for _, arg := range args {
@@ -110,6 +111,7 @@ func TestResumeCmd_gemini_noSessionFlag(t *testing.T) {
 	cmd := a.ResumeCmd("revise this", "sess-abc", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "gemini")
+	assertContains(t, args, "--skip-trust")
 	for _, arg := range args {
 		if arg == "sess-abc" {
 			t.Errorf("gemini ResumeCmd should not pass session ID, got args: %v", args)
@@ -496,7 +498,7 @@ func TestBuiltins_installHints(t *testing.T) {
 		install string
 	}{
 		{"claude", "claude", "npm install -g @anthropic-ai/claude-code"},
-		{"gemini", "gemini", "npm install -g @google/gemini-cli"},
+		{"gemini", "gemini", "brew install gemini-cli"},
 		{"opencode", "opencode", "npm install -g opencode@latest"},
 		{"codex", "codex", "npm install -g @openai/codex"},
 		{"copilot", "copilot", "npm install -g @github/copilot"},

--- a/internal/adapters/builtin/gemini.yml
+++ b/internal/adapters/builtin/gemini.yml
@@ -1,3 +1,5 @@
 binary: gemini
+launch: gemini --skip-trust -p {kickoff}
+resume_cmd: gemini --skip-trust -p {prompt}
 session_type: directory
-install: npm install -g @google/gemini-cli
+install: brew install gemini-cli


### PR DESCRIPTION
Closes #325

## Summary

- Adds `--skip-trust` to gemini adapter `launch` and `resume_cmd` so the agent runs headlessly in agentctl-provisioned worktrees without the "not running in a trusted directory" error
- Corrects the install hint from `npm install -g @google/gemini-cli` to `brew install gemini-cli`

## Validation

Validated end-to-end using `./scripts/validate-adapter.sh gemini --repo-path ../agentctl-test` against issue arun-gupta/agentctl-test#67 ("add-structured-logging-to-api"):

```
[validate-adapter] adapter: gemini  repo: arun-gupta/agentctl-test  issue: #67
[PASS] agentctl info lists adapter "gemini"
[INFO] install hint not checked — binary is installed; test manually by temporarily removing it from PATH
[PASS] agent exited cleanly in 365s
[PASS] agentctl agent status shows issue #67
[INFO] agentctl agent logs not checked (headless only)
[PASS] files changed in worktree ( 2 files changed, 106 insertions(+), 1 deletion(-))
[PASS] PR opened: https://github.com/arun-gupta/agentctl-test/pull/75

Result: 5 automated checks passed, 0 failed
```

**Environment:** gemini-cli v0.42.0, macOS, Gemini billing credits enabled.

Also validated install hint with restricted PATH (binary removed from PATH):

```
✗ gemini      (not installed) — install with: brew install gemini-cli
```

Interactive mode (`agentctl agent status` after gemini run):

```
ISSUE  BRANCH                                      AGENT      PORT  SPEC     PR
-      issue-14-title-length-limit                 openhands  -     no-spec  #23 MERGED
35     35-add-get-tasks-export-endpoint-csv        claude     -     no-spec  #48 MERGED
46     46-add-response-time-header-to-api          claude     -     paused   #50 MERGED
56     56-add-task-urgency-flag-boolean-field      claude     -     no-spec  #73 MERGED
6      6-add-tags-categories-to-tasks-with-filter  gemini     -     no-spec  none
66     66-add-health-check-endpoint                claude     -     no-spec  #72 MERGED
```

`agentctl report` showing gemini runs on issue #67 with `pr_opened` outcomes:

```
PERIOD        RUNS  SUCCESS  FAILED  AVG TIME  TOTAL TOKENS
Last 7 days   23    9        9       2m 03s    -
Last 30 days  23    9        9       2m 03s    -

SLOWEST RUNS
ISSUE  BRANCH                                       ELAPSED  OUTCOME
43     43-add-get-tasks-recent-endpoint             17m 59s  discarded
6      6-add-tags-categories-to-tasks-with-filter   6m 43s   failed
67     67-add-structured-logging-to-api             6m 01s   pr_opened
67     67-add-structured-logging-to-api             4m 33s   discarded
67     67-add-structured-logging-to-api             4m 27s   pr_opened
27     27-validate-title-max-length-on-create-and   3m 50s   discarded
58     58-add-task-color-label-field-for-visual-gr  2m 04s   failed
58     58-add-task-color-label-field-for-visual-gr  39s      failed
32     32-add-patch-tasks-id-for-partial-update     28s      discarded
29     29-return-404-with-json-body-for-unknown-ro  16s      discarded
```

## Test plan

- [x] `go test ./...` passes
- [x] `./scripts/validate-adapter.sh gemini --repo-path ../agentctl-test` passes all automated checks
- [x] Install hint verified with restricted PATH
- [x] `agentctl agent status` shows gemini agent correctly
- [x] `agentctl report` shows gemini runs with `pr_opened` outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)