### PR TITLE
docs: replace %20 with underscores in agent badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | Coding agents | SDD methodologies |
 |---|---|
-| [![Claude Code](https://img.shields.io/badge/Claude%20Code-1F1F1F?logo=anthropic&logoColor=white)](https://www.anthropic.com/claude-code) (default)<br>[![OpenAI Codex](https://img.shields.io/badge/OpenAI%20Codex-412991?logo=openai&logoColor=white)](https://github.com/openai/codex)<br>[![GitHub Copilot](https://img.shields.io/badge/GitHub%20Copilot-1F222E?logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)<br>[![OpenHands](https://img.shields.io/badge/OpenHands-0D1117?logoColor=white)](https://openhands.dev/)<br>…and [any agent](docs/adapters.md) via a one-line YAML file | [**Spec Kit**](https://github.com/github/spec-kit) (`--sdd speckit`)<br>[**Plain**](docs/sdd.md) (`--sdd plain`)<br>…and [any methodology](docs/sdd.md) via a one-line YAML file |
+| [![Claude Code](https://img.shields.io/badge/Claude_Code-1F1F1F?logo=anthropic&logoColor=white)](https://www.anthropic.com/claude-code) (default)<br>[![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-412991?logo=openai&logoColor=white)](https://github.com/openai/codex)<br>[![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-1F222E?logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)<br>[![OpenHands](https://img.shields.io/badge/OpenHands-0D1117?logoColor=white)](https://openhands.dev/)<br>…and [any agent](docs/adapters.md) via a one-line YAML file | [**Spec Kit**](https://github.com/github/spec-kit) (`--sdd speckit`)<br>[**Plain**](docs/sdd.md) (`--sdd plain`)<br>…and [any methodology](docs/sdd.md) via a one-line YAML file |
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Replace URL-encoded spaces (%20) with underscores in Shields.io badge text for coding agents
- Improves badge rendering consistency across GitHub light/dark themes

## Changes

Updated the README.md table to use underscores instead of `%20` in badge text:
- `Claude%20Code` → `Claude_Code`
- `OpenAI%20Codex` → `OpenAI_Codex`
- `GitHub%20Copilot` → `GitHub_Copilot`

This follows Shields.io best practices for badge text formatting and ensures better visual consistency.

## Test plan

### Automated

**Command:** `go test ./...`

**Result:** ✅ PASS

All test packages passed:
```
ok  	github.com/arun-gupta/agentctl/cmd/agentctl	0.761s
ok  	github.com/arun-gupta/agentctl/internal/adapters	(cached)
ok  	github.com/arun-gupta/agentctl/internal/cmd	55.759s
ok  	github.com/arun-gupta/agentctl/internal/config	(cached)
ok  	github.com/arun-gupta/agentctl/internal/diagnostics	(cached)
ok  	github.com/arun-gupta/agentctl/internal/git	(cached)
ok  	github.com/arun-gupta/agentctl/internal/notify	(cached)
ok  	github.com/arun-gupta/agentctl/internal/process	(cached)
ok  	github.com/arun-gupta/agentctl/internal/registry	(cached)
ok  	github.com/arun-gupta/agentctl/internal/sdd	(cached)
ok  	github.com/arun-gupta/agentctl/internal/state	(cached)
ok  	github.com/arun-gupta/agentctl/internal/vcs	(cached)
?   	github.com/arun-gupta/agentctl/internal/xdg	[no test files]
```

### Manual

- **Badge rendering verification**: View README.md on GitHub in both light and dark themes to verify badges display correctly with proper spacing and logos
  - _Manual verification needed because automated tests cannot validate visual rendering in different GitHub themes_
- **Badge URL accessibility**: Click each badge link to verify they resolve to the correct documentation pages
  - _Manual verification needed because automated tests cannot simulate browser navigation and verify external links_

Fixes #42