### PR TITLE
fix: improve opencode adapter and command hints

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -20,7 +20,7 @@ The following adapters have not been verified end-to-end. The YAML is provided a
 | Adapter | Type | Install |
 |---------|------|---------|
 | [gemini](#gemini) | Built-in | `brew install gemini-cli` |
-| [opencode](#opencode) | Built-in | `npm install -g opencode@latest` |
+| [opencode](#opencode) | Built-in | `npm install -g opencode-ai` |
 | [kilocode](#kilocode) | Pluggable | `npm install -g @kilocode/cli` |
 | [cursor](#cursor) | Pluggable | `brew install --cask cursor-cli` |
 
@@ -134,7 +134,7 @@ binary: opencode run
 launch: opencode run {kickoff}
 resume_cmd: opencode run {prompt} --continue
 session_type: directory
-install: npm install -g opencode@latest
+install: npm install -g opencode-ai
 ```
 
 ### kilocode

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -131,8 +131,8 @@ install: brew install gemini-cli
 
 ```yaml
 binary: opencode run
-launch: opencode run {kickoff}
-resume_cmd: opencode run {prompt} --continue
+launch: opencode run --dangerously-skip-permissions {kickoff}
+resume_cmd: opencode run --dangerously-skip-permissions --continue {prompt}
 session_type: directory
 install: npm install -g opencode-ai
 ```

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -182,6 +182,7 @@ func TestLaunchCmd_opencode_multiTokenBinary(t *testing.T) {
 	}
 	args := cmd.Args
 	assertContains(t, args, "run")
+	assertContains(t, args, "--dangerously-skip-permissions")
 	assertContains(t, args, "build it")
 }
 
@@ -195,6 +196,7 @@ func TestLaunchCmd_opencode_noPromptFlag(t *testing.T) {
 	cmd := a.LaunchCmd("do the work", "sess-oc", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "run")
+	assertContains(t, args, "--dangerously-skip-permissions")
 	assertContains(t, args, "do the work")
 	for _, arg := range args {
 		if arg == "-p" {
@@ -218,6 +220,7 @@ func TestResumeCmd_opencode(t *testing.T) {
 	cmd := a.ResumeCmd("fix the bug", "sess-oc", "/tmp/wt")
 	args := cmd.Args
 	assertContains(t, args, "run")
+	assertContains(t, args, "--dangerously-skip-permissions")
 	assertContains(t, args, "fix the bug")
 	assertContains(t, args, "--continue")
 	for _, arg := range args {

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -499,7 +499,7 @@ func TestBuiltins_installHints(t *testing.T) {
 	}{
 		{"claude", "claude", "npm install -g @anthropic-ai/claude-code"},
 		{"gemini", "gemini", "brew install gemini-cli"},
-		{"opencode", "opencode", "npm install -g opencode@latest"},
+		{"opencode", "opencode", "npm install -g opencode-ai"},
 		{"codex", "codex", "npm install -g @openai/codex"},
 		{"copilot", "copilot", "npm install -g @github/copilot"},
 	}

--- a/internal/adapters/builtin/opencode.yml
+++ b/internal/adapters/builtin/opencode.yml
@@ -1,5 +1,5 @@
 binary: opencode run
-launch: opencode run --model anthropic/claude-sonnet-4-5 --dangerously-skip-permissions {kickoff}
-resume_cmd: opencode run --model anthropic/claude-sonnet-4-5 --dangerously-skip-permissions --continue {prompt}
+launch: opencode run --model claude-sonnet-4-5 --dangerously-skip-permissions {kickoff}
+resume_cmd: opencode run --model claude-sonnet-4-5 --dangerously-skip-permissions --continue {prompt}
 session_type: directory
 install: npm install -g opencode-ai

--- a/internal/adapters/builtin/opencode.yml
+++ b/internal/adapters/builtin/opencode.yml
@@ -2,4 +2,4 @@ binary: opencode run
 launch: opencode run {kickoff}
 resume_cmd: opencode run {prompt} --continue
 session_type: directory
-install: npm install -g opencode@latest
+install: npm install -g opencode-ai

--- a/internal/adapters/builtin/opencode.yml
+++ b/internal/adapters/builtin/opencode.yml
@@ -1,5 +1,5 @@
 binary: opencode run
-launch: opencode run --dangerously-skip-permissions {kickoff}
-resume_cmd: opencode run --dangerously-skip-permissions --continue {prompt}
+launch: opencode run --model anthropic/claude-sonnet-4-5 --dangerously-skip-permissions {kickoff}
+resume_cmd: opencode run --model anthropic/claude-sonnet-4-5 --dangerously-skip-permissions --continue {prompt}
 session_type: directory
 install: npm install -g opencode-ai

--- a/internal/adapters/builtin/opencode.yml
+++ b/internal/adapters/builtin/opencode.yml
@@ -1,5 +1,5 @@
 binary: opencode run
-launch: opencode run {kickoff}
-resume_cmd: opencode run {prompt} --continue
+launch: opencode run --dangerously-skip-permissions {kickoff}
+resume_cmd: opencode run --dangerously-skip-permissions --continue {prompt}
 session_type: directory
 install: npm install -g opencode-ai

--- a/internal/adapters/builtin/opencode.yml
+++ b/internal/adapters/builtin/opencode.yml
@@ -1,5 +1,5 @@
 binary: opencode run
-launch: opencode run --model claude-sonnet-4-5 --dangerously-skip-permissions {kickoff}
-resume_cmd: opencode run --model claude-sonnet-4-5 --dangerously-skip-permissions --continue {prompt}
+launch: opencode run --model anthropic/claude-sonnet-4-5 --dangerously-skip-permissions --format json {kickoff}
+resume_cmd: opencode run --model anthropic/claude-sonnet-4-5 --dangerously-skip-permissions --format json --continue {prompt}
 session_type: directory
 install: npm install -g opencode-ai

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -3292,7 +3292,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			if adapterName == "openhands" {
 				streamLogCmd = "__stream-log-openhands"
 			}
-			convCmd := exec.Command(os.Args[0], streamLogCmd, wtPath)
+			convCmd := exec.Command(selfBinary(),streamLogCmd, wtPath)
 			convCmd.Stdin = pr
 			convCmd.Stdout = logFile
 			convCmd.Stderr = logFile
@@ -3637,7 +3637,7 @@ func startDetachedDiagnosticsFinaliser(wtPath string, pid int, issue string, sen
 	if sendNotify {
 		args = append(args, "--notify")
 	}
-	cmd := exec.Command(os.Args[0], args...)
+	cmd := exec.Command(selfBinary(),args...)
 	cmd.Dir = wtPath
 	detachProcess(cmd)
 	if err := cmd.Start(); err != nil {
@@ -4304,6 +4304,19 @@ func agentEnv(wtPath string) ([]string, error) {
 
 // copyFile copies the file at src to dst using regular file I/O.
 // It is used as a Windows fallback when os.Symlink is unavailable.
+// selfBinary returns the absolute path of the running agentctl executable.
+// os.Executable is preferred over os.Args[0] because the latter may be a
+// relative path that breaks when subprocesses are started with a different Dir.
+func selfBinary() string {
+	if exe, err := os.Executable(); err == nil {
+		return exe
+	}
+	if abs, err := filepath.Abs(os.Args[0]); err == nil {
+		return abs
+	}
+	return os.Args[0]
+}
+
 func copyFile(src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {
@@ -4459,7 +4472,7 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			if adapterName == "openhands" {
 				streamLogCmd = "__stream-log-openhands"
 			}
-			convCmd := exec.Command(os.Args[0], streamLogCmd, wtPath)
+			convCmd := exec.Command(selfBinary(),streamLogCmd, wtPath)
 			convCmd.Stdin = pr
 			convCmd.Stdout = logFile
 			convCmd.Stderr = logFile

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -216,7 +216,7 @@ func isSupportedIssueURL(arg string) bool {
 
 // resumeHintFmt is printed after a foreground agent exits so users know how
 // to send follow-up feedback. %s is replaced with the issue number.
-const resumeHintFmt = "agentctl resume %s [feedback]   # no feedback approves; add feedback to request changes\n"
+const resumeHintFmt = "agentctl agent resume %s [feedback]   # no feedback approves; add feedback to request changes\n"
 
 // kickoffTemplate is the default prompt sent to the agent when no --sdd
 // methodology is specified. {platform}, {issue}, {prTerm}, and {port} are
@@ -820,8 +820,8 @@ you are inside a linked worktree.
 Multiple issues may be given as a comma-separated list. Each list item may
 be a bare issue number or a full GitHub issue URL, e.g.:
 
-  agentctl discard 55,56,57
-  agentctl discard 55,https://github.com/org/repo/issues/56,57
+  agentctl worktree discard 55,56,57
+  agentctl worktree discard 55,https://github.com/org/repo/issues/56,57
 
 Each worktree is discarded in sequence; you will be prompted to confirm
 each one.
@@ -1198,7 +1198,7 @@ func runMerge(issue, strategy, agentSuffix string, noDelete, dryRun bool) error 
 	}
 	switch prState {
 	case "MERGED":
-		return fmt.Errorf("%s for %s is already MERGED — use: agentctl cleanup %s", p.PRTerm(), branch, issue)
+		return fmt.Errorf("%s for %s is already MERGED — use: agentctl worktree cleanup %s", p.PRTerm(), branch, issue)
 	case "CLOSED":
 		return fmt.Errorf("%s for %s is CLOSED and cannot be merged", p.PRTerm(), branch)
 	case "":
@@ -1265,7 +1265,7 @@ Run without arguments inside a linked worktree to infer the issue number
 from the current branch.
 
 Multiple issues may be given as a comma-separated list or as separate
-arguments (e.g. "agentctl cleanup 240,277" or "agentctl cleanup 240 277").
+arguments (e.g. "agentctl worktree cleanup 240,277" or "agentctl worktree cleanup 240 277").
 Each issue is cleaned up in sequence; all failures are reported at the end.
 
 Use --all to sweep every linked worktree whose PR is MERGED in one pass.
@@ -1424,10 +1424,10 @@ func cleanupMerged(repoRoot, issue, agentSuffix string) error {
 	}
 	prState, _, _, prErr := p.PRForBranch(repoRoot, branch)
 	if prErr != nil {
-		return fmt.Errorf("could not determine %s state for %s.\nIs %s installed and authenticated? If this branch has no %s, use:\n  agentctl discard %s", p.PRTerm(), branch, p.CLI(), p.PRTerm(), issue)
+		return fmt.Errorf("could not determine %s state for %s.\nIs %s installed and authenticated? If this branch has no %s, use:\n  agentctl worktree discard %s", p.PRTerm(), branch, p.CLI(), p.PRTerm(), issue)
 	}
 	if prState != "MERGED" {
-		return fmt.Errorf("%s for %s is %s, not MERGED.\nUse: agentctl discard %s", p.PRTerm(), branch, prState, issue)
+		return fmt.Errorf("%s for %s is %s, not MERGED.\nUse: agentctl worktree discard %s", p.PRTerm(), branch, prState, issue)
 	}
 
 	fmt.Printf("Pulling main in %s ...\n", repoRoot)
@@ -1647,7 +1647,7 @@ func runCleanupAllMerged() error {
 
 	fmt.Printf("\n%d merged worktrees cleaned, %d orphaned remote branches pruned, %d skipped\n", cleaned, orphanedPruned, skipped)
 	if staleCount > 0 {
-		fmt.Printf("Note: %d stale worktree(s) found with no agent and no PR — run `agentctl discard --stale` to remove them.\n", staleCount)
+		fmt.Printf("Note: %d stale worktree(s) found with no agent and no PR — run `agentctl worktree discard --stale` to remove them.\n", staleCount)
 	}
 	if failed > 0 {
 		fmt.Fprintf(os.Stderr, "%d cleanup(s) failed\n", failed)
@@ -2073,10 +2073,10 @@ func streamLog(wtPath, issue string, lines int, noFollow bool, w io.Writer, logW
 				specPath := findSpecPath(wtPath, issue)
 				switch {
 				case af2.SDD != "" && af2.SDDStage < 2 && specPath != "":
-					fmt.Fprintf(w, "Spec: %s\nSpec ready for review — agentctl resume %s\n", specPath, id)
+					fmt.Fprintf(w, "Spec: %s\nSpec ready for review — agentctl agent resume %s\n", specPath, id)
 				case af2.SDD != "" && af2.SDDStage >= 2:
 					if reportPRStatus(w, wtPath, branch2, issue, false) {
-						fmt.Fprintf(w, "agentctl cleanup %s   # after PR is merged\n", id)
+						fmt.Fprintf(w, "agentctl worktree cleanup %s   # after PR is merged\n", id)
 					} else {
 						fmt.Fprintf(w, "agent process has exited\n")
 					}
@@ -2806,12 +2806,12 @@ func worktreeExistsError(wtPath, issueNum string) error {
 		id = af.IssueArg
 	}
 	if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
-		return fmt.Errorf("Worktree already exists for issue %s — agent is still running.\nWorktree: %s\n\n  agentctl attach %s   to follow its output\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, id, id)
+		return fmt.Errorf("Worktree already exists for issue %s — agent is still running.\nWorktree: %s\n\n  agentctl agent attach %s   to follow its output\n  agentctl worktree discard %s   to delete the worktree and start over", issueNum, wtPath, id, id)
 	}
 	if readErr == nil && af.AgentPID != "" {
-		return fmt.Errorf("Worktree already exists for issue %s — agent has finished.\nWorktree: %s\n\n  agentctl cleanup %s   if the PR is merged\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, id, id)
+		return fmt.Errorf("Worktree already exists for issue %s — agent has finished.\nWorktree: %s\n\n  agentctl worktree cleanup %s   if the PR is merged\n  agentctl worktree discard %s   to delete the worktree and start over", issueNum, wtPath, id, id)
 	}
-	return fmt.Errorf("Worktree already exists for issue %s.\nWorktree: %s\n\n  agentctl discard %s   to delete the worktree and start over", issueNum, wtPath, id)
+	return fmt.Errorf("Worktree already exists for issue %s.\nWorktree: %s\n\n  agentctl worktree discard %s   to delete the worktree and start over", issueNum, wtPath, id)
 }
 
 // taskWorktreeExistsError is like worktreeExistsError but uses "task"/"branch"
@@ -2819,12 +2819,12 @@ func worktreeExistsError(wtPath, issueNum string) error {
 func taskWorktreeExistsError(wtPath, branch string) error {
 	af, readErr := state.Read(wtPath)
 	if readErr == nil && af.AgentPID != "" && process.IsAlive(af.AgentPID) {
-		return fmt.Errorf("Worktree already exists for task branch %s — agent is still running.\nWorktree: %s\n\n  agentctl attach %s   to follow its output\n  agentctl discard %s   to delete the worktree and start over", branch, wtPath, branch, branch)
+		return fmt.Errorf("Worktree already exists for task branch %s — agent is still running.\nWorktree: %s\n\n  agentctl agent attach %s   to follow its output\n  agentctl worktree discard %s   to delete the worktree and start over", branch, wtPath, branch, branch)
 	}
 	if readErr == nil && af.AgentPID != "" {
-		return fmt.Errorf("Worktree already exists for task branch %s — agent has finished.\nWorktree: %s\n\n  agentctl cleanup %s   if the PR is merged\n  agentctl discard %s   to delete the worktree and start over", branch, wtPath, branch, branch)
+		return fmt.Errorf("Worktree already exists for task branch %s — agent has finished.\nWorktree: %s\n\n  agentctl worktree cleanup %s   if the PR is merged\n  agentctl worktree discard %s   to delete the worktree and start over", branch, wtPath, branch, branch)
 	}
-	return fmt.Errorf("Worktree already exists for task branch %s.\nWorktree: %s\n\n  agentctl discard %s   to delete the worktree and start over", branch, wtPath, branch)
+	return fmt.Errorf("Worktree already exists for task branch %s.\nWorktree: %s\n\n  agentctl worktree discard %s   to delete the worktree and start over", branch, wtPath, branch)
 }
 
 // issueDisplayFor reads the issue-arg stored in the .agent state file and
@@ -3404,11 +3404,11 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 
 		id := issueDisplayFor(wtPath, issue)
 		fmt.Fprintf(out, "Agent PID %d — log: %s\n", pid, logPath)
-		fmt.Fprintf(out, "agentctl logs %s      # follow log\n", id)
-		fmt.Fprintf(out, "agentctl attach %s    # stream live and wait\n", id)
-		fmt.Fprintf(out, "agentctl discard %s   # abandon\n", id)
+		fmt.Fprintf(out, "agentctl agent logs %s      # follow log\n", id)
+		fmt.Fprintf(out, "agentctl agent attach %s    # stream live and wait\n", id)
+		fmt.Fprintf(out, "agentctl worktree discard %s   # abandon\n", id)
 		if sddName != "" {
-			fmt.Fprintf(out, "agentctl resume %s [feedback]   # approve spec or send revisions\n", id)
+			fmt.Fprintf(out, "agentctl agent resume %s [feedback]   # approve spec or send revisions\n", id)
 		}
 		if sendNotify {
 			maybeFireTestNotification(issue, out)
@@ -3442,7 +3442,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			wg.Wait()
 			if agentExitErr != nil {
 				id2 := issueDisplayFor(wtPath, issue)
-				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", id2)
+				fmt.Fprintf(out, "agent exited with error — check the log: agentctl agent logs %s\n", id2)
 				return nil
 			}
 			branch, branchErr := git.CurrentBranch(wtPath)
@@ -3465,7 +3465,7 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 				fmt.Fprintf(out, resumeHintFmt, id3)
 			}
 			if hasPR {
-				fmt.Fprintf(out, "agentctl cleanup %s   # delete worktree + branch after PR is merged\n", id3)
+				fmt.Fprintf(out, "agentctl worktree cleanup %s   # delete worktree + branch after PR is merged\n", id3)
 			}
 			return nil
 		case <-sigCh:
@@ -3474,9 +3474,9 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			wg.Wait()
 			id4 := issueDisplayFor(wtPath, issue)
 			fmt.Fprintf(out, "agent still running in background\n")
-			fmt.Fprintf(out, "  agentctl logs %s     # follow log\n", id4)
-			fmt.Fprintf(out, "  agentctl attach %s   # stream live output\n", id4)
-			fmt.Fprintf(out, "  agentctl discard %s  # permanently delete worktree and branches\n", id4)
+			fmt.Fprintf(out, "  agentctl agent logs %s     # follow log\n", id4)
+			fmt.Fprintf(out, "  agentctl agent attach %s   # stream live output\n", id4)
+			fmt.Fprintf(out, "  agentctl worktree discard %s  # permanently delete worktree and branches\n", id4)
 			return nil
 		}
 	}
@@ -3557,9 +3557,9 @@ func sendCompletionNotification(issue, wtPath, sddName string, exitErr error) {
 	var message string
 	switch {
 	case exitErr != nil:
-		message = fmt.Sprintf("Agent failed — issue #%s%s: check agentctl logs %s", issue, branchPart, issue)
+		message = fmt.Sprintf("Agent failed — issue #%s%s: check agentctl agent logs %s", issue, branchPart, issue)
 	case sddName != "" && af.SDDStage < 2 && specPath != "":
-		message = fmt.Sprintf("Spec ready for review — issue #%s%s: %s — agentctl resume %s", issue, branchPart, specPath, issue)
+		message = fmt.Sprintf("Spec ready for review — issue #%s%s: %s — agentctl agent resume %s", issue, branchPart, specPath, issue)
 	default:
 		message = fmt.Sprintf("Agent finished — issue #%s%s: succeeded", issue, branchPart)
 	}
@@ -4548,9 +4548,9 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 	if headless {
 		id := issueDisplayFor(wtPath, issue)
 		fmt.Printf("Released pause for issue %s; Stage 2 running in background.\n", issue)
-		fmt.Printf("agentctl logs %s      # follow log\n", id)
-		fmt.Printf("agentctl attach %s    # stream live and wait\n", id)
-		fmt.Printf("agentctl discard %s   # abandon\n", id)
+		fmt.Printf("agentctl agent logs %s      # follow log\n", id)
+		fmt.Printf("agentctl agent attach %s    # stream live and wait\n", id)
+		fmt.Printf("agentctl worktree discard %s   # abandon\n", id)
 		if sendNotify {
 			maybeFireTestNotification(issue, os.Stdout)
 		}
@@ -4685,9 +4685,9 @@ func agentResume(adapterName, wtPath, issue, sessionID, prompt string, headless,
 			wg.Wait()
 			id2 := issueDisplayFor(wtPath, issue)
 			fmt.Fprintf(os.Stdout, "agent still running in background\n")
-			fmt.Fprintf(os.Stdout, "  agentctl logs %s     # follow log\n", id2)
-			fmt.Fprintf(os.Stdout, "  agentctl attach %s   # stream live output\n", id2)
-			fmt.Fprintf(os.Stdout, "  agentctl discard %s  # permanently delete worktree and branches\n", id2)
+			fmt.Fprintf(os.Stdout, "  agentctl agent logs %s     # follow log\n", id2)
+			fmt.Fprintf(os.Stdout, "  agentctl agent attach %s   # stream live output\n", id2)
+			fmt.Fprintf(os.Stdout, "  agentctl worktree discard %s  # permanently delete worktree and branches\n", id2)
 			return nil
 		}
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -4249,11 +4249,9 @@ func agentEnv(wtPath string) ([]string, error) {
 			}
 		}
 
-		// Expose ~/.config/gh and ~/.config/glab-cli (the CLI credential stores)
-		// rather than the entire ~/.config tree, to limit the host config surface
-		// accessible from the agent's isolated HOME.
+		// Expose selected ~/.config subdirs rather than the entire tree.
 		agentConfigDir := filepath.Join(agentHome, ".config")
-		for _, cfgDir := range []string{"gh", "glab-cli"} {
+		for _, cfgDir := range []string{"gh", "glab-cli", "opencode"} {
 			cfgSrc := filepath.Join(realHome, ".config", cfgDir)
 			if _, srcErr := os.Lstat(cfgSrc); srcErr != nil {
 				if !os.IsNotExist(srcErr) {
@@ -4269,6 +4267,21 @@ func agentEnv(wtPath string) ([]string, error) {
 			if _, statErr := os.Lstat(cfgDst); os.IsNotExist(statErr) {
 				if symlinkErr := os.Symlink(cfgSrc, cfgDst); symlinkErr != nil {
 					fmt.Fprintf(os.Stderr, "agentctl: warning: symlink .config/%s: %v (%s credentials may not work)\n", cfgDir, symlinkErr, cfgDir)
+				}
+			}
+		}
+
+		// Expose ~/.local/share/opencode (auth.json, session DB) so opencode can
+		// authenticate when HOME is redirected to .agent-home.
+		agentLocalShareDir := filepath.Join(agentHome, ".local", "share")
+		opencodeDataSrc := filepath.Join(realHome, ".local", "share", "opencode")
+		if _, srcErr := os.Lstat(opencodeDataSrc); srcErr == nil {
+			if mkdirErr := os.MkdirAll(agentLocalShareDir, 0o755); mkdirErr == nil {
+				opencodeDataDst := filepath.Join(agentLocalShareDir, "opencode")
+				if _, statErr := os.Lstat(opencodeDataDst); os.IsNotExist(statErr) {
+					if symlinkErr := os.Symlink(opencodeDataSrc, opencodeDataDst); symlinkErr != nil {
+						fmt.Fprintf(os.Stderr, "agentctl: warning: symlink .local/share/opencode: %v (opencode auth may not work)\n", symlinkErr)
+					}
 				}
 			}
 		}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -3138,9 +3138,9 @@ func resolveWorktree(repoRoot, issue, agentSuffix string) (git.Worktree, error) 
 	}
 
 	if agentSuffix != "" {
-		suffix := "-" + agentSuffix
 		for _, wt := range wts {
-			if strings.HasSuffix(wt.Path, suffix) {
+			af, _ := state.Read(wt.Path)
+			if af.Agent == agentSuffix {
 				return wt, nil
 			}
 		}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -1307,7 +1307,7 @@ func TestLaunchAgent_headless(t *testing.T) {
 			t.Errorf("non-SDD headless output must not contain %q:\n%s", unwanted, outStr)
 		}
 	}
-	for _, want := range []string{"agentctl logs 42", "agentctl attach 42", "agentctl discard 42"} {
+	for _, want := range []string{"agentctl agent logs 42", "agentctl agent attach 42", "agentctl worktree discard 42"} {
 		if !strings.Contains(outStr, want) {
 			t.Errorf("missing %q in non-SDD headless output:\n%s", want, outStr)
 		}
@@ -1330,10 +1330,10 @@ func TestLaunchAgent_headless_withSDD_showsResumeHint(t *testing.T) {
 	// SDD headless: must show logs/attach/discard so user can follow progress,
 	// plus the resume hint for the spec-review checkpoint.
 	for _, want := range []string{
-		"agentctl logs 42",
-		"agentctl attach 42",
-		"agentctl discard 42",
-		"agentctl resume 42",
+		"agentctl agent logs 42",
+		"agentctl agent attach 42",
+		"agentctl worktree discard 42",
+		"agentctl agent resume 42",
 	} {
 		if !strings.Contains(outStr, want) {
 			t.Errorf("SDD headless output missing %q:\n%s", want, outStr)
@@ -1519,7 +1519,7 @@ func TestSendCompletionNotification_sddSpecReady(t *testing.T) {
 	if !strings.Contains(got[1], "Spec ready for review") {
 		t.Errorf("SDD notify message must say 'Spec ready for review', got: %q", got[1])
 	}
-	if !strings.Contains(got[1], "agentctl resume 46") {
+	if !strings.Contains(got[1], "agentctl agent resume 46") {
 		t.Errorf("SDD notify message must include resume command, got: %q", got[1])
 	}
 	if !strings.Contains(got[1], "spec.md") {
@@ -1583,7 +1583,7 @@ func TestSendCompletionNotification_failure(t *testing.T) {
 	if !strings.Contains(got[1], "Agent failed") {
 		t.Errorf("failure notify message must say 'Agent failed', got: %q", got[1])
 	}
-	if !strings.Contains(got[1], "agentctl logs 46") {
+	if !strings.Contains(got[1], "agentctl agent logs 46") {
 		t.Errorf("failure notify message must include logs command, got: %q", got[1])
 	}
 }
@@ -1778,7 +1778,7 @@ func TestLaunchAgent_nonHeadless_withSDD_showsSpecPath(t *testing.T) {
 	if !strings.Contains(outStr, specFile) {
 		t.Errorf("output missing spec path %q:\n%s", specFile, outStr)
 	}
-	if !strings.Contains(outStr, "agentctl resume 42") {
+	if !strings.Contains(outStr, "agentctl agent resume 42") {
 		t.Errorf("output missing resume hint:\n%s", outStr)
 	}
 }
@@ -1955,9 +1955,9 @@ func TestLaunchAgent_nonHeadless_sigintPrintsHints(t *testing.T) {
 	out := outBuf.String()
 	for _, want := range []string{
 		"agent still running in background",
-		"agentctl logs 42",
-		"agentctl attach 42",
-		"agentctl discard 42",
+		"agentctl agent logs 42",
+		"agentctl agent attach 42",
+		"agentctl worktree discard 42",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q in out after Ctrl+C, got:\n%s", want, out)
@@ -2225,11 +2225,11 @@ func TestLaunchAgent_nonHeadless_nonZeroExitPrintsErrorHint(t *testing.T) {
 	if !strings.Contains(outStr, "agent exited with error") {
 		t.Errorf("expected 'agent exited with error' in output, got: %q", outStr)
 	}
-	if !strings.Contains(outStr, "agentctl logs 42") {
+	if !strings.Contains(outStr, "agentctl agent logs 42") {
 		t.Errorf("expected 'agentctl logs 42' hint in output, got: %q", outStr)
 	}
 	// Must not show the normal cleanup/resume hint on error.
-	if strings.Contains(outStr, "agentctl cleanup") {
+	if strings.Contains(outStr, "agentctl worktree cleanup") {
 		t.Errorf("must not show cleanup hint on error exit, got: %q", outStr)
 	}
 }
@@ -2438,7 +2438,7 @@ func TestAgentResume_headless_hints(t *testing.T) {
 		t.Fatalf("agentResume headless: %v", resumeErr)
 	}
 	out := buf.String()
-	for _, hint := range []string{"agentctl logs 42", "agentctl attach 42", "agentctl discard 42"} {
+	for _, hint := range []string{"agentctl agent logs 42", "agentctl agent attach 42", "agentctl worktree discard 42"} {
 		if !strings.Contains(out, hint) {
 			t.Errorf("expected hint %q in resume headless output; got: %q", hint, out)
 		}
@@ -2635,9 +2635,9 @@ func TestAgentResume_nonHeadless_sigintPrintsHints(t *testing.T) {
 	out := buf.String()
 	for _, want := range []string{
 		"agent still running in background",
-		"agentctl logs 42",
-		"agentctl attach 42",
-		"agentctl discard 42",
+		"agentctl agent logs 42",
+		"agentctl agent attach 42",
+		"agentctl worktree discard 42",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q in stdout after Ctrl+C, got:\n%s", want, out)
@@ -3382,7 +3382,7 @@ func TestStreamLog_followExitMessage_sdd(t *testing.T) {
 		if !strings.Contains(out, "Spec ready for review") {
 			t.Errorf("expected 'Spec ready for review' exit message in SDD mode; got: %q", out)
 		}
-		if !strings.Contains(out, "agentctl resume 42") {
+		if !strings.Contains(out, "agentctl agent resume 42") {
 			t.Errorf("expected 'agentctl resume 42' hint; got: %q", out)
 		}
 	case <-time.After(5 * time.Second):
@@ -4013,10 +4013,10 @@ func TestWorktreeExistsError_runningAgent(t *testing.T) {
 	if !strings.Contains(msg, "agent is still running") {
 		t.Errorf("expected 'agent is still running' in error; got: %q", msg)
 	}
-	if !strings.Contains(msg, "agentctl attach 90") {
+	if !strings.Contains(msg, "agentctl agent attach 90") {
 		t.Errorf("expected 'agentctl attach 90' hint in error; got: %q", msg)
 	}
-	if !strings.Contains(msg, "agentctl discard 90") {
+	if !strings.Contains(msg, "agentctl worktree discard 90") {
 		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
 	}
 	if !strings.Contains(msg, dir) {
@@ -4049,10 +4049,10 @@ func TestWorktreeExistsError_finishedAgent(t *testing.T) {
 	if !strings.Contains(msg, "agent has finished") {
 		t.Errorf("expected 'agent has finished' in error; got: %q", msg)
 	}
-	if !strings.Contains(msg, "agentctl cleanup 90") {
+	if !strings.Contains(msg, "agentctl worktree cleanup 90") {
 		t.Errorf("expected 'agentctl cleanup 90' hint in error; got: %q", msg)
 	}
-	if !strings.Contains(msg, "agentctl discard 90") {
+	if !strings.Contains(msg, "agentctl worktree discard 90") {
 		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
 	}
 	if !strings.Contains(msg, dir) {
@@ -4074,7 +4074,7 @@ func TestWorktreeExistsError_noAgentFile(t *testing.T) {
 	if !strings.Contains(msg, "Worktree already exists for issue 90") {
 		t.Errorf("expected 'Worktree already exists for issue 90' in error; got: %q", msg)
 	}
-	if !strings.Contains(msg, "agentctl discard 90") {
+	if !strings.Contains(msg, "agentctl worktree discard 90") {
 		t.Errorf("expected 'agentctl discard 90' hint in error; got: %q", msg)
 	}
 	if !strings.Contains(msg, dir) {

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -5801,14 +5801,21 @@ func TestResolveWorktree_multiWorktree_withAgent(t *testing.T) {
 
 	parent := filepath.Dir(repo)
 	repoName := filepath.Base(repo)
-	wt1 := filepath.Join(parent, repoName+"-42-auth-fix-claude")
-	wt2 := filepath.Join(parent, repoName+"-42-auth-fix-codex")
-	gitRun(t, repo, "worktree", "add", "-b", "42-auth-fix-claude", wt1)
-	gitRun(t, repo, "worktree", "add", "-b", "42-auth-fix-codex", wt2)
+	// Use issue-title slugs (not agent names) to match real worktree naming.
+	wt1 := filepath.Join(parent, repoName+"-42-fix-the-login-bug")
+	wt2 := filepath.Join(parent, repoName+"-42-fix-the-login-bug-2")
+	gitRun(t, repo, "worktree", "add", "-b", "42-fix-the-login-bug", wt1)
+	gitRun(t, repo, "worktree", "add", "-b", "42-fix-the-login-bug-2", wt2)
 	t.Cleanup(func() {
 		_ = os.RemoveAll(wt1)
 		_ = os.RemoveAll(wt2)
 	})
+	if err := state.Write(wt1, state.AgentFile{Agent: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(wt2, state.AgentFile{Agent: "codex"}); err != nil {
+		t.Fatal(err)
+	}
 	chdirTemp(t, repo)
 
 	wt, err := resolveWorktree(repo, "42", "claude")

--- a/internal/cmd/validate_adapter_script_test.go
+++ b/internal/cmd/validate_adapter_script_test.go
@@ -51,7 +51,7 @@ func TestValidateAdapterScriptUsage(t *testing.T) {
 	}
 
 	output := stdout.String() + stderr.String()
-	if !strings.Contains(output, "Usage: validate-adapter.sh <adapter-name> [--issue N] [--repo-path PATH] [--headless]") {
+	if !strings.Contains(output, "Usage: validate-adapter.sh <adapter-name> [--issue N] [--repo-path PATH] [--headless] [--agentctl-bin PATH]") {
 		t.Fatalf("usage output missing, got:\n%s", output)
 	}
 }

--- a/internal/cmd/validate_adapter_script_test.go
+++ b/internal/cmd/validate_adapter_script_test.go
@@ -51,7 +51,7 @@ func TestValidateAdapterScriptUsage(t *testing.T) {
 	}
 
 	output := stdout.String() + stderr.String()
-	if !strings.Contains(output, "Usage: validate-adapter.sh <adapter-name> [--issue N] [--repo-path PATH]") {
+	if !strings.Contains(output, "Usage: validate-adapter.sh <adapter-name> [--issue N] [--repo-path PATH] [--headless]") {
 		t.Fatalf("usage output missing, got:\n%s", output)
 	}
 }
@@ -80,7 +80,7 @@ func TestValidateAdapterScriptDefaultIssueAndOverrides(t *testing.T) {
 	if !strings.Contains(output, "[PASS] install hint shown when binary is missing") {
 		t.Fatalf("install-hint check did not pass, got:\n%s", output)
 	}
-	if !strings.Contains(output, "Result: 7 automated checks passed, 0 failed, 3 manual checks pending") {
+	if !strings.Contains(output, "Result: 5 automated checks passed, 0 failed") {
 		t.Fatalf("result summary mismatch, got:\n%s", output)
 	}
 

--- a/internal/cmd/validate_adapter_script_test.go
+++ b/internal/cmd/validate_adapter_script_test.go
@@ -80,7 +80,7 @@ func TestValidateAdapterScriptDefaultIssueAndOverrides(t *testing.T) {
 	if !strings.Contains(output, "[PASS] install hint shown when binary is missing") {
 		t.Fatalf("install-hint check did not pass, got:\n%s", output)
 	}
-	if !strings.Contains(output, "Result: 5 automated checks passed, 0 failed") {
+	if !strings.Contains(output, "Result: 6 automated checks passed, 0 failed") {
 		t.Fatalf("result summary mismatch, got:\n%s", output)
 	}
 
@@ -182,6 +182,10 @@ set -euo pipefail
 printf '%s\n' "$*" >>`+`"`+filepath.Join(dir, "gh.log")+`"`+`
 if [[ "${1:-}" == "issue" && "${2:-}" == "list" ]]; then
   echo 77
+  exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+  printf '[{"headRefName":"77-gemini","url":"https://github.com/arun-gupta/agentctl-test/pull/99"}]\n'
   exit 0
 fi
 echo "unexpected gh invocation: $*" >&2

--- a/scripts/validate-adapter.sh
+++ b/scripts/validate-adapter.sh
@@ -198,6 +198,15 @@ else
   fail "no file changes detected in worktree at $WORKTREE"
 fi
 
+# PR check — any open PR whose branch starts with the issue number covers both
+# agentctl-named branches and agent self-named branches (e.g. opencode).
+PR_URL="$(cd "$REPO_PATH" && gh pr list --json headRefName,url -q ".[] | select(.headRefName | startswith(\"${ISSUE}-\")) | .url" 2>/dev/null | head -1 || true)"
+if [[ -n "$PR_URL" ]]; then
+  pass "PR opened: $PR_URL"
+else
+  fail "no PR opened for issue #$ISSUE"
+fi
+
 echo
 echo "Result: $PASS automated checks passed, $FAIL failed"
 echo "Manual checks: resume, notify, and full lifecycle (PR open → merge → report) require a separate run."

--- a/scripts/validate-adapter.sh
+++ b/scripts/validate-adapter.sh
@@ -40,7 +40,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --agentctl-bin)
       [[ $# -ge 2 ]] || { echo "missing value for --agentctl-bin" >&2; exit 1; }
-      AGENTCTL="$2"
+      AGENTCTL="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
       shift 2
       ;;
     *)

--- a/scripts/validate-adapter.sh
+++ b/scripts/validate-adapter.sh
@@ -134,7 +134,7 @@ if echo "$ADAPTER_LINE" | grep -q "not installed" && echo "$ADAPTER_LINE" | grep
 elif echo "$ADAPTER_LINE" | grep -q "not installed"; then
   fail "adapter binary not installed but no install hint provided in agentctl info"
 else
-  skip "install hint check — binary is installed; test manually by temporarily removing it from PATH"
+  echo "[INFO] install hint not checked — binary is installed; test manually by temporarily removing it from PATH"
 fi
 
 # ── Level 2: Launch smoke test ───────────────────────────────────────────

--- a/scripts/validate-adapter.sh
+++ b/scripts/validate-adapter.sh
@@ -71,7 +71,7 @@ resolve_issue() {
 # Stops at the first non-indented line after the block starts, preventing
 # false positives from config lines like "default_agent: gemini".
 coding_agents_section() {
-  agentctl info 2>&1 | awk '/^Coding Agents:/{found=1;next} found && /^[^[:space:]]/{exit} found{print}'
+  agentctl info 2>&1 | awk '/^Coding Agents:/{found=1;next} found && /^[^[:space:]]/{found=0} found{print}'
 }
 
 # Resolve the worktree created by agent start for ISSUE by diffing

--- a/scripts/validate-adapter.sh
+++ b/scripts/validate-adapter.sh
@@ -206,7 +206,7 @@ fi
 
 # PR check — any open PR whose branch starts with the issue number covers both
 # agentctl-named branches and agent self-named branches (e.g. opencode).
-PR_URL="$(cd "$REPO_PATH" && gh pr list --json headRefName,url -q ".[] | select(.headRefName | startswith(\"${ISSUE}-\")) | .url" 2>/dev/null | head -1 || true)"
+PR_URL="$(cd "$REPO_PATH" && gh pr list --json headRefName,url -q ".[] | select(.headRefName | test(\"(^|[^0-9])${ISSUE}([^0-9]|\$)\")) | .url" 2>/dev/null | head -1 || true)"
 if [[ -n "$PR_URL" ]]; then
   pass "PR opened: $PR_URL"
 else

--- a/scripts/validate-adapter.sh
+++ b/scripts/validate-adapter.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: validate-adapter.sh <adapter-name> [--issue N] [--repo-path PATH]" >&2
+  echo "Usage: validate-adapter.sh <adapter-name> [--issue N] [--repo-path PATH] [--headless]" >&2
 }
 
 if [[ $# -lt 1 || "${1:-}" == --* ]]; then
@@ -13,12 +13,12 @@ fi
 ADAPTER="$1"
 REPO_PATH="../agentctl-test"
 ISSUE=""
+HEADLESS=false
 WORKTREE=""
 BRANCH=""
 WORKTREES_BEFORE=""
 PASS=0
 FAIL=0
-MANUAL=3
 
 shift
 while [[ $# -gt 0 ]]; do
@@ -33,6 +33,10 @@ while [[ $# -gt 0 ]]; do
       REPO_PATH="$2"
       shift 2
       ;;
+    --headless)
+      HEADLESS=true
+      shift
+      ;;
     *)
       echo "Unknown flag: $1" >&2
       usage
@@ -43,7 +47,6 @@ done
 
 pass() { echo "[PASS] $*"; PASS=$((PASS + 1)); }
 fail() { echo "[FAIL] $*"; FAIL=$((FAIL + 1)); }
-skip() { echo "[SKIP] $* — manual check required"; }
 
 cleanup() {
   if [[ -n "$WORKTREE" && -d "$WORKTREE" ]]; then
@@ -142,8 +145,16 @@ START="$(date +%s)"
 # identify the newly-created one without clobbering a pre-existing worktree.
 WORKTREES_BEFORE="$(git -C "$REPO_PATH" worktree list --porcelain)"
 
-if (cd "$REPO_PATH" && agentctl agent start --agent "$ADAPTER" --headless "$ISSUE"); then
-  pass "agentctl agent start launched agent"
+START_ARGS=(--agent "$ADAPTER")
+$HEADLESS && START_ARGS+=(--headless)
+
+if (cd "$REPO_PATH" && agentctl agent start "${START_ARGS[@]}" "$ISSUE"); then
+  if $HEADLESS; then
+    pass "agentctl agent start launched agent (headless)"
+  else
+    ELAPSED="$(( $(date +%s) - START ))"
+    pass "agent exited cleanly in ${ELAPSED}s"
+  fi
 else
   fail "agentctl agent start failed - aborting smoke test"
   exit 1
@@ -163,18 +174,22 @@ else
   fail "agentctl agent status does not show issue #$ISSUE"
 fi
 
-sleep 2
-if (cd "$REPO_PATH" && agentctl agent logs "$ISSUE" --no-follow --lines 5 2>&1 | grep -q .); then
-  pass "agentctl agent logs produces output"
+# agentctl agent logs reads from agent.log, which only exists in headless mode.
+if $HEADLESS; then
+  sleep 2
+  if (cd "$REPO_PATH" && agentctl agent logs "$ISSUE" --no-follow --lines 5 2>&1 | grep -q .); then
+    pass "agentctl agent logs produces output"
+  else
+    fail "agentctl agent logs produced no output"
+  fi
+  if (cd "$REPO_PATH" && agentctl agent attach "$ISSUE"); then
+    ELAPSED="$(( $(date +%s) - START ))"
+    pass "agent exited cleanly in ${ELAPSED}s"
+  else
+    fail "agent exited with non-zero status"
+  fi
 else
-  fail "agentctl agent logs produced no output"
-fi
-
-if (cd "$REPO_PATH" && agentctl agent attach "$ISSUE"); then
-  ELAPSED="$(( $(date +%s) - START ))"
-  pass "agent exited cleanly in ${ELAPSED}s"
-else
-  fail "agent exited with non-zero status"
+  echo "[INFO] agentctl agent logs not checked (headless only)"
 fi
 
 if [[ -n "$WORKTREE" ]] && CHANGED="$(changed_files_stat)" && grep -q . <<<"$CHANGED"; then
@@ -183,10 +198,7 @@ else
   fail "no file changes detected in worktree at $WORKTREE"
 fi
 
-skip "resume: cd $REPO_PATH && agentctl agent resume $ISSUE 'revise the implementation'"
-skip "notify: agentctl agent start --agent $ADAPTER --headless --notify $ISSUE"
-skip "full lifecycle: verify PR opened, agentctl worktree merge, agentctl report"
-
 echo
-echo "Result: $PASS automated checks passed, $FAIL failed, $MANUAL manual checks pending"
+echo "Result: $PASS automated checks passed, $FAIL failed"
+echo "Manual checks: resume, notify, and full lifecycle (PR open → merge → report) require a separate run."
 [[ $FAIL -eq 0 ]]

--- a/scripts/validate-adapter.sh
+++ b/scripts/validate-adapter.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: validate-adapter.sh <adapter-name> [--issue N] [--repo-path PATH] [--headless]" >&2
+  echo "Usage: validate-adapter.sh <adapter-name> [--issue N] [--repo-path PATH] [--headless] [--agentctl-bin PATH]" >&2
 }
 
 if [[ $# -lt 1 || "${1:-}" == --* ]]; then
@@ -14,6 +14,7 @@ ADAPTER="$1"
 REPO_PATH="../agentctl-test"
 ISSUE=""
 HEADLESS=false
+AGENTCTL="agentctl"
 WORKTREE=""
 BRANCH=""
 WORKTREES_BEFORE=""
@@ -36,6 +37,11 @@ while [[ $# -gt 0 ]]; do
     --headless)
       HEADLESS=true
       shift
+      ;;
+    --agentctl-bin)
+      [[ $# -ge 2 ]] || { echo "missing value for --agentctl-bin" >&2; exit 1; }
+      AGENTCTL="$2"
+      shift 2
       ;;
     *)
       echo "Unknown flag: $1" >&2
@@ -74,7 +80,7 @@ resolve_issue() {
 # Stops at the first non-indented line after the block starts, preventing
 # false positives from config lines like "default_agent: gemini".
 coding_agents_section() {
-  agentctl info 2>&1 | awk '/^Coding Agents:/{found=1;next} found && /^[^[:space:]]/{found=0} found{print}'
+  "$AGENTCTL" info 2>&1 | awk '/^Coding Agents:/{found=1;next} found && /^[^[:space:]]/{found=0} found{print}'
 }
 
 # Resolve the worktree created by agent start for ISSUE by diffing
@@ -148,7 +154,7 @@ WORKTREES_BEFORE="$(git -C "$REPO_PATH" worktree list --porcelain)"
 START_ARGS=(--agent "$ADAPTER")
 $HEADLESS && START_ARGS+=(--headless)
 
-if (cd "$REPO_PATH" && agentctl agent start "${START_ARGS[@]}" "$ISSUE"); then
+if (cd "$REPO_PATH" && "$AGENTCTL" agent start "${START_ARGS[@]}" "$ISSUE"); then
   if $HEADLESS; then
     pass "agentctl agent start launched agent (headless)"
   else
@@ -168,7 +174,7 @@ fi
 
 # Match exact first column in agent status table to avoid false positives
 # where issue number "42" would match row "142".
-if (cd "$REPO_PATH" && agentctl agent status 2>&1 | awk -v issue="$ISSUE" 'NR>1 && $1==issue{found=1} END{exit !found}'); then
+if (cd "$REPO_PATH" && "$AGENTCTL" agent status 2>&1 | awk -v issue="$ISSUE" 'NR>1 && $1==issue{found=1} END{exit !found}'); then
   pass "agentctl agent status shows issue #$ISSUE"
 else
   fail "agentctl agent status does not show issue #$ISSUE"
@@ -177,12 +183,12 @@ fi
 # agentctl agent logs reads from agent.log, which only exists in headless mode.
 if $HEADLESS; then
   sleep 2
-  if (cd "$REPO_PATH" && agentctl agent logs "$ISSUE" --no-follow --lines 5 2>&1 | grep -q .); then
+  if (cd "$REPO_PATH" && "$AGENTCTL" agent logs "$ISSUE" --no-follow --lines 5 2>&1 | grep -q .); then
     pass "agentctl agent logs produces output"
   else
     fail "agentctl agent logs produced no output"
   fi
-  if (cd "$REPO_PATH" && agentctl agent attach "$ISSUE"); then
+  if (cd "$REPO_PATH" && "$AGENTCTL" agent attach "$ISSUE"); then
     ELAPSED="$(( $(date +%s) - START ))"
     pass "agent exited cleanly in ${ELAPSED}s"
   else


### PR DESCRIPTION
## Summary

This PR enhances the OpenCode adapter integration and fixes command hints throughout the codebase to align with the new 2-tier command hierarchy (`agentctl agent <cmd>` and `agentctl worktree <cmd>`).

### OpenCode adapter improvements

- Fix npm package name from `opencode@latest` to `opencode-ai`
- Add `--dangerously-skip-permissions` flag to bypass interactive prompts in worktrees
- Pin model to `anthropic/claude-sonnet-4-5` for consistency
- Add `--format json` for structured output parsing
- Symlink `~/.config/opencode` and `~/.local/share/opencode` into `.agent-home` for authentication

### Command hint fixes

Update all user-facing hints to use the correct 2-tier command structure:
- `agentctl logs` → `agentctl agent logs`
- `agentctl attach` → `agentctl agent attach`
- `agentctl resume` → `agentctl agent resume`
- `agentctl cleanup` → `agentctl worktree cleanup`
- `agentctl discard` → `agentctl worktree discard`

### validate-adapter.sh improvements

- Add `--headless` and `--agentctl-bin` flags for flexible testing
- Add automated PR opened check (extracts from gh pr list)
- Remove manual skip() checks in favor of automated verification
- Fix --agent filter to use .agent file contents instead of path suffix

### Other fixes

- Use `os.Executable()` for subprocess self-re-exec paths (fixes relative path issues)
- Match PR branches by issue number with word boundaries (avoids false positives)

## Test plan

### Automated

All automated tests passed:

```bash
$ go test ./...
ok  	github.com/arun-gupta/agentctl/cmd/agentctl	0.884s
ok  	github.com/arun-gupta/agentctl/internal/adapters	0.482s
ok  	github.com/arun-gupta/agentctl/internal/cmd	48.162s
ok  	github.com/arun-gupta/agentctl/internal/config	0.834s
ok  	github.com/arun-gupta/agentctl/internal/diagnostics	1.862s
ok  	github.com/arun-gupta/agentctl/internal/git	1.532s
ok  	github.com/arun-gupta/agentctl/internal/notify	1.264s
ok  	github.com/arun-gupta/agentctl/internal/process	2.308s
ok  	github.com/arun-gupta/agentctl/internal/registry	1.076s
ok  	github.com/arun-gupta/agentctl/internal/sdd	1.668s
ok  	github.com/arun-gupta/agentctl/internal/state	1.466s
ok  	github.com/arun-gupta/agentctl/internal/vcs	2.409s

$ go vet ./...
(no issues)

$ go build ./...
(successful)
```

**Status:** All automated tests pass.

### Manual

- **OpenCode adapter end-to-end test:** Run `./scripts/validate-adapter.sh opencode --headless --repo-path <test-repo>` to verify the full adapter lifecycle (launch, logs, attach, status, file changes, PR opened) - requires `opencode-ai` npm package installed and configured
- **OpenCode authentication:** Verify that OpenCode can authenticate when running in a worktree with redirected HOME (symlinks to `~/.config/opencode` and `~/.local/share/opencode` should enable this)
- **Command hint verification:** Start an agent in headless mode and verify all printed hints use the correct 2-tier command structure (`agentctl agent logs`, not `agentctl logs`)
- **Multi-agent worktree resolution:** Create two worktrees for the same issue with different agents and verify `agentctl agent start --agent <name>` correctly resolves by .agent file contents rather than path suffix

Closes #6