### PR TITLE
fix(ux): improve error UX when agent fails due to auth or immediate exit

### DIFF
--- a/internal/adapters/adapter.go
+++ b/internal/adapters/adapter.go
@@ -55,6 +55,12 @@ type Adapter struct {
 	// Example: "npm install -g @anthropic-ai/claude-code"
 	Install string `yaml:"install"`
 
+	// AuthCheck is an optional command run before launching the agent to verify
+	// authentication is available. Example: "claude --status". When the command
+	// exits non-zero, the launch is aborted with an actionable error before any
+	// worktree is created.
+	AuthCheck string `yaml:"auth_check"`
+
 	// source is the file path this adapter was loaded from (not in YAML).
 	source string
 }
@@ -125,6 +131,28 @@ func (a *Adapter) CheckBinary() error {
 			return fmt.Errorf("agent binary %q not found on PATH\ninstall it with: %s", binary, a.Install)
 		}
 		return fmt.Errorf("agent binary %q not found on PATH", binary)
+	}
+	return nil
+}
+
+// PreflightCheck runs the auth_check command if configured. Returns nil when
+// no auth_check is set or the command exits 0. Returns an actionable error
+// when the command exits non-zero so the caller can abort before any worktree
+// side-effects are created.
+func (a *Adapter) PreflightCheck() error {
+	if a.AuthCheck == "" {
+		return nil
+	}
+	parts := strings.Fields(a.AuthCheck)
+	cmd := exec.Command(parts[0], parts[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		binary := strings.Fields(a.Binary)[0]
+		if msg != "" {
+			return fmt.Errorf("%q is not authenticated: %s\nRun:  %s\nThen: agentctl agent start <issue>", binary, msg, a.AuthCheck)
+		}
+		return fmt.Errorf("%q is not authenticated\nRun:  %s\nThen: agentctl agent start <issue>", binary, a.AuthCheck)
 	}
 	return nil
 }

--- a/internal/adapters/adapters_test.go
+++ b/internal/adapters/adapters_test.go
@@ -560,6 +560,58 @@ func TestCheckBinary_notFound_noHint(t *testing.T) {
 	}
 }
 
+// ─── PreflightCheck ───────────────────────────────────────────────────────────
+
+func TestPreflightCheck_noAuthCheck(t *testing.T) {
+	a, err := adapters.LoadBytes([]byte("binary: echo\n"), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.PreflightCheck(); err != nil {
+		t.Errorf("expected nil when no auth_check configured, got: %v", err)
+	}
+}
+
+func TestPreflightCheck_commandPasses(t *testing.T) {
+	a, err := adapters.LoadBytes([]byte("binary: echo\nauth_check: true\n"), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.PreflightCheck(); err != nil {
+		t.Errorf("expected nil when auth_check exits 0, got: %v", err)
+	}
+}
+
+func TestPreflightCheck_commandFails(t *testing.T) {
+	a, err := adapters.LoadBytes([]byte("binary: echo\nauth_check: false\n"), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = a.PreflightCheck()
+	if err == nil {
+		t.Fatal("expected error when auth_check exits non-zero, got nil")
+	}
+	if !strings.Contains(err.Error(), "not authenticated") {
+		t.Errorf("error should mention authentication, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "agentctl agent start") {
+		t.Errorf("error should mention retry command, got: %v", err)
+	}
+}
+
+func TestPreflightCheck_loadedFromYAML(t *testing.T) {
+	a, err := adapters.LoadBytes(
+		[]byte("binary: echo\nauth_check: true\n"),
+		"test-fixture",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.PreflightCheck() != nil {
+		t.Error("expected PreflightCheck to pass for auth_check: true")
+	}
+}
+
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 // writeAdapter creates an adapter file at dir/filename with the given YAML content.

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -352,6 +352,15 @@ func startOne(issue, slug, agentName, sddName, agentSuffix string, headless, qui
 
 	branch, wtPath := worktreeNames(repoName, issueNum, slug, agentSuffix, parentDir)
 
+	// Pre-flight auth check before any worktree side-effects. Run after all
+	// cheap validations but before git worktree add so a failed auth does not
+	// leave dirty state behind.
+	if ad, getErr := adapters.Get(agentName); getErr == nil {
+		if preflightErr := ad.PreflightCheck(); preflightErr != nil {
+			return preflightErr
+		}
+	}
+
 	// Create the worktree.
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		return worktreeExistsError(wtPath, issueNum)
@@ -3442,6 +3451,13 @@ func launchAgent(adapterName, wtPath, issue, port, sessionID, kickoff, sddName s
 			wg.Wait()
 			if agentExitErr != nil {
 				id2 := issueDisplayFor(wtPath, issue)
+				// Show a recovery hint when the log contains a known auth-failure
+				// pattern so the user gets an actionable next step inline.
+				if tail := readLogTail(logPath, 20); tail != "" {
+					if hint := agentRecoveryHint(tail, id2); hint != "" {
+						fmt.Fprintln(out, hint)
+					}
+				}
 				fmt.Fprintf(out, "agent exited with error — check the log: agentctl logs %s\n", id2)
 				return nil
 			}
@@ -3492,6 +3508,36 @@ func waitForFile(path string, timeout time.Duration) error {
 		time.Sleep(100 * time.Millisecond)
 	}
 	return fmt.Errorf("%s did not appear within %s", path, timeout)
+}
+
+// readLogTail reads the last n lines from path. Returns "" if the file cannot
+// be read or has no content.
+func readLogTail(path string, n int) string {
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// agentRecoveryHint scans logContent for known failure patterns and returns a
+// targeted recovery message. Returns "" when no known pattern is found.
+// issue is the display identifier used in the suggested retry command.
+func agentRecoveryHint(logContent, issue string) string {
+	lower := strings.ToLower(logContent)
+	if strings.Contains(lower, "not logged in") || strings.Contains(lower, "please run /login") {
+		return "Hint: agent is not authenticated — log in and retry:\n" +
+			"  agentctl agent start " + issue
+	}
+	if strings.Contains(lower, "authentication required") || strings.Contains(lower, "unauthorized") {
+		return "Hint: authentication failed — check your credentials and retry:\n" +
+			"  agentctl agent start " + issue
+	}
+	return ""
 }
 
 // notifyTestSentinelPath returns the path of the one-time sentinel file that

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -2234,6 +2234,43 @@ func TestLaunchAgent_nonHeadless_nonZeroExitPrintsErrorHint(t *testing.T) {
 	}
 }
 
+// TestLaunchAgent_nonHeadless_knownAuthErrorShowsRecovery verifies that when
+// an agent exits non-zero and its log contains a known auth-failure pattern,
+// agentctl emits its own actionable recovery hint (not just the passthrough log).
+func TestLaunchAgent_nonHeadless_knownAuthErrorShowsRecovery(t *testing.T) {
+	dir := t.TempDir()
+
+	scriptPath := filepath.Join(dir, "authfail.sh")
+	// Outputs the exact string claude emits when unauthenticated, then exits 1.
+	script := "#!/bin/sh\necho 'Not logged in'\nexit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeLocalAdapter(t, dir, "authfail", "binary: "+scriptPath+"\n")
+	chdirTemp(t, dir)
+
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- launchAgent("authfail", dir, "42", "3010", "sess-abc", "do the thing", "", false, false, false, &out)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("launchAgent: unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("launchAgent did not return")
+	}
+
+	outStr := out.String()
+	// agentctl must add its own recovery hint (not just the agent's raw output).
+	if !strings.Contains(outStr, "agentctl agent start") {
+		t.Errorf("expected agentctl recovery hint (agentctl agent start) in output, got:\n%s", outStr)
+	}
+}
+
 func TestAgentResume_unknownAdapter(t *testing.T) {
 	dir := t.TempDir()
 	err := agentResume("nonexistent-xyz-abc", dir, "42", "sess-123", "my feedback", true, false, false)
@@ -2275,6 +2312,36 @@ func TestStartOne_headlessImmediateExitCleansUpWorktree(t *testing.T) {
 		if wt.Path == wtPath {
 			t.Fatalf("worktree %s should not remain registered after failed start", wtPath)
 		}
+	}
+}
+
+// TestStartOne_preflightAuthCheckBlocksBeforeWorktree verifies that when an
+// adapter has auth_check configured and it fails, startOne returns an error
+// before creating any worktree.
+func TestStartOne_preflightAuthCheckBlocksBeforeWorktree(t *testing.T) {
+	repo := initGitRepoForStale(t)
+	chdirTemp(t, repo)
+
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	writeLocalAdapter(t, repo, "authcheckfail",
+		"binary: echo\nauth_check: false\n")
+
+	var out bytes.Buffer
+	err := startOne("42", "auth-test", "authcheckfail", "", "", true, false, false, &out)
+	if err == nil {
+		t.Fatal("expected startOne to fail when auth_check exits non-zero")
+	}
+	if !strings.Contains(err.Error(), "not authenticated") {
+		t.Fatalf("expected auth error, got: %v", err)
+	}
+
+	// No worktree should have been created.
+	wtPath := filepath.Join(filepath.Dir(repo), filepath.Base(repo)+"-42-auth-test")
+	if _, statErr := os.Stat(wtPath); !os.IsNotExist(statErr) {
+		// Clean up so the test directory can be removed.
+		_ = git.RemoveWorktree(repo, wtPath)
+		t.Fatalf("worktree should not be created when auth_check fails, stat err=%v", statErr)
 	}
 }
 


### PR DESCRIPTION
Closes #361

## Summary

- **Pre-flight auth check** (`auth_check` adapter field): before creating the git worktree or starting the dev server, agentctl runs the adapter's optional `auth_check` command (e.g. `auth_check: claude --status`). If it exits non-zero the launch is aborted immediately with an actionable error — no dirty state left behind.
- **Recovery hints on known auth errors**: when an agent exits non-zero in foreground mode and its log contains a known pattern like `"not logged in"` or `"authentication required"`, agentctl now emits a targeted retry command so the user knows what to do without running a second command.
- **`Adapter.PreflightCheck()`**: new method on `Adapter`, fully covered by tests. `startOne` integrates it before `git worktree add`.

## What's not included (out of scope for this PR)

- Interactive "clean up worktree?" prompt on immediate non-headless failure — this requires stdin interaction and is better handled separately.
- Populating `auth_check` in the built-in `claude.yml` — `claude --status` exit-code semantics need verification before committing to the built-in. Users can add it to their project-local or user-level adapter YAML today.

## Test plan

- [ ] `go test ./...` — all tests pass
- [ ] `go vet ./...` — no issues
- [ ] Create a project-local adapter with `auth_check: false` and run `agentctl agent start <issue>` — should fail before worktree creation with "not authenticated" error
- [ ] Remove `auth_check` field — launch proceeds normally (no regression)
- [ ] Run agent that outputs "Not logged in" and exits 1 in foreground mode — output should include "agentctl agent start" retry hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)